### PR TITLE
chore(codex): add repo guidance and skills

### DIFF
--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: commit
+description:
+  Create a well-formed git commit from current changes using session history for
+  rationale and summary; use when asked to commit, prepare a commit message, or
+  finalize staged work.
+---
+
+# Commit
+
+## Goals
+
+- Produce a commit that matches the staged changes.
+- Use a conventional, concise subject line.
+- Include rationale and validation in the body.
+
+## Steps
+
+1. Inspect `git status`, `git diff`, and `git diff --staged`.
+2. Stage only the intended files.
+3. Choose a conventional commit type and optional scope.
+4. Write a subject line in imperative mood, <= 72 characters.
+5. Write a body that covers:
+   - what changed
+   - why it changed
+   - validation run, or why validation was not run
+6. Append `Co-authored-by: Codex <codex@openai.com>` unless the user asked otherwise.
+7. Create the commit with `git commit -F <file>` so newlines are preserved exactly.
+
+## Template
+
+```text
+<type>(<scope>): <short summary>
+
+Summary:
+- <what changed>
+
+Rationale:
+- <why>
+
+Tests:
+- <command or "not run (reason)">
+
+Co-authored-by: Codex <codex@openai.com>
+```

--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: land
+description:
+  Land a PR by resolving branch drift, addressing review feedback, waiting for
+  green checks, and squash-merging when approved.
+---
+
+# Land
+
+## Goals
+
+- Ensure the PR is up to date with `origin/main`.
+- Ensure review feedback is addressed or explicitly replied to.
+- Wait for green checks.
+- Squash-merge only when the PR is approved and ready.
+
+## Preconditions
+
+- `gh auth status` succeeds.
+- You are on the PR branch with a clean working tree.
+- The required validation gate has passed locally:
+  - `uv run ruff check .`
+  - `uv run mypy src`
+  - `uv run pytest -q`
+
+## Workflow
+
+1. Locate the PR for the current branch:
+   - `gh pr view --json number,title,body,mergeable,reviewDecision,url`
+2. If the tree is dirty, commit with the `commit` skill and publish with the `push` skill before continuing.
+3. If the PR is behind `origin/main` or conflicting, run the `pull` skill, rerun validation, and publish again.
+4. Sweep review feedback from all channels:
+   - `gh pr view --comments`
+   - `gh pr view --json reviews`
+   - `gh api repos/<owner>/<repo>/pulls/<pr>/comments`
+5. Treat actionable comments as blocking until code or replies resolve them.
+6. Watch checks:
+   - `gh pr checks --watch`
+7. If checks fail:
+   - inspect the failing run
+   - fix the issue
+   - rerun local validation
+   - commit and push
+   - restart the checks loop
+8. Merge only when all checks are green and review state is acceptable.
+9. Squash-merge with the PR title and body:
+   - `gh pr merge --squash --subject "$pr_title" --body "$pr_body"`
+
+## Notes
+
+- Do not enable auto-merge for this repo.
+- Do not ignore inline review comments; handle both inline and top-level feedback.
+- If `gh` access fails, stop and surface the exact command and error rather than rewriting remotes or inventing auth workarounds.
+
+## Commands
+
+```bash
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q .number)
+pr_title=$(gh pr view --json title -q .title)
+pr_body=$(gh pr view --json body -q .body)
+mergeable=$(gh pr view --json mergeable -q .mergeable)
+
+uv run ruff check .
+uv run mypy src
+uv run pytest -q
+
+if [ "$mergeable" = "CONFLICTING" ]; then
+  echo "Run the pull skill, rerun validation, and push again." >&2
+  exit 1
+fi
+
+gh pr checks --watch
+gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+```

--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: linear
+description: |
+  Use the Linear workspace tools for issue reads, comment updates, state
+  changes, and PR link attachment.
+---
+
+# Linear
+
+Use this skill when a Codex session needs to read or update Linear directly.
+Prefer the typed Linear tools that are available in the current session rather
+than raw GraphQL.
+
+## Preferred Tools
+
+- `mcp__linear__get_issue` for full issue context
+- `mcp__linear__list_comments` to inspect existing discussion/workpad comments
+- `mcp__linear__save_comment` to create or update comments
+- `mcp__linear__save_issue` to change state, assignee, labels, or attach links
+- `mcp__linear__get_issue_status` or `mcp__linear__list_issue_statuses` when a
+  target state name is ambiguous
+- `mcp__linear__list_issues` for search
+- `mcp__linear__get_project`, `mcp__linear__get_team`, and
+  `mcp__linear__get_user` for metadata lookup when needed
+
+## Usage Rules
+
+- Query or update only the fields needed for the current task.
+- Reuse an existing workpad/status comment when one exists instead of creating
+  duplicates.
+- When linking a PR or external URL back to an issue, use
+  `mcp__linear__save_issue` with the append-only `links` field.
+- Treat append-only fields such as `links`, `blocks`, `blockedBy`, and
+  `relatedTo` carefully to avoid duplicate entries.
+- Resolve the exact target issue state before changing it if state names are
+  not already known.
+
+## Common Operations
+
+### Read an issue
+
+- Call `mcp__linear__get_issue` with the issue identifier.
+- Set `includeRelations` or `includeCustomerNeeds` only when the task needs
+  them.
+
+### Find or update a workpad comment
+
+- Call `mcp__linear__list_comments` with the issue ID.
+- Reuse the existing comment ID with `mcp__linear__save_comment` when updating.
+
+### Move an issue
+
+- Resolve the target state with `mcp__linear__get_issue_status` or
+  `mcp__linear__list_issue_statuses` if needed.
+- Call `mcp__linear__save_issue` with `id` and `state`.
+
+### Attach a PR
+
+- Call `mcp__linear__save_issue` with `id` and
+  `links: [{ title: "<pr title>", url: "<pr url>" }]`.

--- a/.codex/skills/pull/SKILL.md
+++ b/.codex/skills/pull/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: pull
+description:
+  Pull latest origin/main into the current local branch and resolve merge
+  conflicts; use when Codex needs to sync a branch before or during PR work.
+---
+
+# Pull
+
+## Workflow
+
+1. Verify the working tree is clean or intentionally committed.
+2. Enable rerere locally:
+   - `git config rerere.enabled true`
+   - `git config rerere.autoupdate true`
+3. Fetch latest refs:
+   - `git fetch origin`
+4. Sync the current branch with its remote counterpart:
+   - `git pull --ff-only origin $(git branch --show-current)`
+5. Merge `origin/main` into the current branch:
+   - `git -c merge.conflictstyle=zdiff3 merge origin/main`
+6. If conflicts appear:
+   - inspect intent on both sides before editing
+   - resolve one file at a time
+   - `git add <files>`
+   - `git commit` or `git merge --continue`
+7. Run the repo validation required for the scope.
+8. Summarize the merge result and any assumptions.
+
+## Conflict Rules
+
+- Prefer minimal, intention-preserving resolutions.
+- Do not blindly choose `ours` or `theirs` unless one side should clearly win wholesale.
+- For generated outputs, resolve source files first and only regenerate when necessary.
+- Use `git diff --check` before considering the merge complete.

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: push
+description:
+  Push current branch changes to origin and create or update the corresponding
+  pull request; use when asked to publish branch updates for tab-foundry.
+---
+
+# Push
+
+## Goals
+
+- Run the required repo validation before publish.
+- Push the current branch safely.
+- Create or update an open PR for the branch.
+
+## Required Validation
+
+Run these commands before every push:
+
+```bash
+uv run ruff check .
+uv run mypy src
+uv run pytest -q
+```
+
+## Workflow
+
+1. Identify the current branch.
+2. Run the required validation.
+3. Push to `origin`, using `-u` if upstream is not set.
+4. If push is rejected because the remote moved, run the `pull` skill, rerun validation, then push again.
+5. If push fails due to auth or permissions, stop and surface the exact error.
+6. Ensure there is one open PR for the current branch:
+   - create a PR if missing
+   - update the title and body if it already exists
+   - if the current branch is tied to a closed PR, create a fresh branch before trying again
+7. Reply with the PR URL.
+
+## PR Body
+
+This repo does not require a template. Use a short, concrete body such as:
+
+```markdown
+## Summary
+- <main behavior change>
+
+## Testing
+- `uv run ruff check .`
+- `uv run mypy src`
+- `uv run pytest -q`
+
+## Notes
+- <risks, follow-ups, or "None">
+```
+
+## Commands
+
+```bash
+branch=$(git branch --show-current)
+
+uv run ruff check .
+uv run mypy src
+uv run pytest -q
+
+git push -u origin HEAD
+
+pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
+if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "Current branch is tied to a closed PR; create a new branch." >&2
+  exit 1
+fi
+
+pr_title="<clear title for the shipped change>"
+tmp_pr_body=$(mktemp)
+cat >"$tmp_pr_body" <<'EOF'
+## Summary
+- <main behavior change>
+
+## Testing
+- `uv run ruff check .`
+- `uv run mypy src`
+- `uv run pytest -q`
+
+## Notes
+- None
+EOF
+
+if [ -z "$pr_state" ]; then
+  gh pr create --title "$pr_title" --body-file "$tmp_pr_body"
+else
+  gh pr edit --title "$pr_title" --body-file "$tmp_pr_body"
+fi
+
+rm -f "$tmp_pr_body"
+gh pr view --json url -q .url
+```

--- a/.codex/worktree_init.sh
+++ b/.codex/worktree_init.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required to bootstrap tab-foundry workspaces." >&2
+  exit 1
+fi
+
+uv sync --frozen
+
+if [[ -z "${DAGZOO_DATA_ROOT:-}" ]]; then
+  echo "Note: DAGZOO_DATA_ROOT is unset. This is fine unless the ticket needs dataset-backed commands." >&2
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# tab-foundry Agent Guide
+
+## Environment
+
+- Python `3.13` from `.python-version`
+- Package and task runner: `uv`
+- Bootstrap a fresh clone with `uv sync --frozen`
+- Git remote uses SSH: `git@github.com:bensonlee5/tab-foundry.git`
+
+## Validation
+
+Run targeted checks while iterating, then run the full gate before push or review handoff:
+
+```bash
+uv run ruff check .
+uv run mypy src
+uv run pytest -q
+```
+
+## Repo Rules
+
+- Keep changes narrowly scoped to the ticket.
+- Prefer smoke experiments and targeted validation over workstation-scale training unless the task explicitly requires heavier runs.
+- `DAGZOO_DATA_ROOT` is optional. Only treat it as required when the task needs real dataset-backed commands.
+- Do not commit generated artifacts or local runtime outputs from `data/`, `outputs/`, `wandb/`, caches, or local env files.
+- If you change export/runtime contract behavior, update `docs/INFERENCE_CONTRACT.md` in the same change.
+- Training and evaluation commands may write outputs under `outputs/`; those outputs are not source files and should not be committed.
+- If Muon is unavailable and the task only needs a smoke proof, use the documented override `optimizer=adamw`.
+
+## Git and PR Expectations
+
+- Start by syncing with `origin/main` before edits on long-lived branches.
+- Keep PR descriptions concise and concrete; this repo does not require a PR template.
+- Address both top-level and inline PR feedback before moving work to review-complete states.
+
+## Secrets and External Access
+
+- Never read secrets from home-directory files from inside repo automation.
+- Assume required secrets are already present in environment variables provided by the launcher.
+- If required auth is missing, record the exact failing command and treat it as a blocker instead of inventing a workaround.


### PR DESCRIPTION
Summary:
- add the in-repo AGENTS guide and Codex helper skills for commit, pull, push, and land
- add a generic Linear skill that targets the available Linear workspace tools
- include worktree bootstrap guidance without committing the Symphony workflow layer

Rationale:
- keep Codex repo instructions close to the codebase for future sessions
- preserve Linear tracker support while removing Symphony-specific orchestration

Tests:
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`