### PR TITLE
chore(ci): guard version bumps against main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Fetch main for version audit
+        run: git fetch --no-tags --depth=1 origin main:main
+
+      - name: Version bump guard
+        run: uv run python scripts/audit/check_version_bump.py
+
       - name: Markdown format
         run: uv run mdformat --check AGENTS.md README.md docs reference CHANGELOG.md
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@ repos:
 
 - repo: local
   hooks:
+  - id: version-bump-guard
+    name: version bump guard
+    entry: ./.venv/bin/python scripts/audit/check_version_bump.py
+    language: system
+    always_run: true
+    pass_filenames: false
   - id: ruff-check
     name: ruff check
     entry: ./.venv/bin/ruff check src tests scripts

--- a/scripts/audit/check_version_bump.py
+++ b/scripts/audit/check_version_bump.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Validate that pyproject.toml only bumps one semantic-version step beyond main."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+VersionTuple = tuple[int, int, int]
+
+
+def parse_version(version: str) -> VersionTuple:
+    match = SEMVER_RE.fullmatch(version.strip())
+    if match is None:
+        raise ValueError(f"Expected MAJOR.MINOR.PATCH version, got {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def format_version(version: VersionTuple) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def load_version_from_pyproject_text(pyproject_text: str) -> str:
+    payload = tomllib.loads(pyproject_text)
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        raise ValueError("pyproject.toml is missing a [project] table")
+    version = project.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("pyproject.toml is missing project.version")
+    return version.strip()
+
+
+def read_version_from_pyproject_path(pyproject_path: Path) -> str:
+    return load_version_from_pyproject_text(pyproject_path.read_text(encoding="utf-8"))
+
+
+def read_version_from_git_ref(
+    repo_root: Path,
+    *,
+    ref: str,
+    pyproject_path: str = "pyproject.toml",
+) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{pyproject_path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git show failed"
+        raise RuntimeError(f"Unable to read {pyproject_path} from git ref {ref!r}: {detail}")
+    return load_version_from_pyproject_text(result.stdout)
+
+
+def allowed_version_bumps(version: str) -> tuple[VersionTuple, VersionTuple, VersionTuple]:
+    major, minor, patch = parse_version(version)
+    return (
+        (major, minor, patch + 1),
+        (major, minor + 1, 0),
+        (major + 1, 0, 0),
+    )
+
+
+def validate_version_bump(base_version: str, candidate_version: str) -> str | None:
+    parsed_base = parse_version(base_version)
+    parsed_candidate = parse_version(candidate_version)
+    if parsed_candidate == parsed_base:
+        return None
+
+    allowed = allowed_version_bumps(base_version)
+    if parsed_candidate in allowed:
+        return None
+
+    allowed_versions = ", ".join([base_version, *(format_version(version) for version in allowed)])
+    if parsed_candidate < parsed_base:
+        return (
+            f"project.version {candidate_version} must not be lower than {base_version}; "
+            f"allowed versions: {allowed_versions}"
+        )
+    return (
+        f"project.version {candidate_version} must be unchanged or exactly one patch, minor, "
+        f"or major step ahead of {base_version}; allowed versions: {allowed_versions}"
+    )
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default="main",
+        help="Git ref used as the version baseline.",
+    )
+    parser.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Repo-relative pyproject file to validate.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    pyproject_path = (REPO_ROOT / args.pyproject).resolve()
+
+    try:
+        base_version = read_version_from_git_ref(REPO_ROOT, ref=args.base_ref, pyproject_path=args.pyproject)
+        current_version = read_version_from_pyproject_path(pyproject_path)
+        error = validate_version_bump(base_version, current_version)
+    except (RuntimeError, ValueError, OSError) as exc:
+        print(f"Version bump check failed: {exc}")
+        return 1
+
+    if error is not None:
+        print(f"Version bump check failed against {args.base_ref}: {error}")
+        return 1
+
+    print(
+        "Version bump check passed: "
+        f"current={current_version}, base_ref={args.base_ref}, base_version={base_version}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_audit_scripts.py
+++ b/tests/audit/test_audit_scripts.py
@@ -4,6 +4,8 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -29,6 +31,10 @@ check_markdown_links = _load_script_module(
 module_graph = _load_script_module(
     REPO_ROOT / "scripts" / "audit" / "module_graph.py",
     "module_graph_script",
+)
+check_version_bump = _load_script_module(
+    REPO_ROOT / "scripts" / "audit" / "check_version_bump.py",
+    "check_version_bump_script",
 )
 
 
@@ -123,3 +129,94 @@ def test_module_dependency_doc_matches_observed_graph() -> None:
 
     assert report.undocumented_edges == []
     assert report.stale_documented_edges == []
+
+
+@pytest.mark.parametrize(
+    ("base_version", "candidate_version"),
+    [
+        ("0.6.0", "0.6.0"),
+        ("0.6.0", "0.6.1"),
+        ("0.6.0", "0.7.0"),
+        ("0.6.0", "1.0.0"),
+        ("1.2.3", "1.2.4"),
+        ("1.2.3", "1.3.0"),
+        ("1.2.3", "2.0.0"),
+    ],
+)
+def test_version_bump_check_allows_same_or_single_semver_step(
+    base_version: str,
+    candidate_version: str,
+) -> None:
+    assert check_version_bump.validate_version_bump(base_version, candidate_version) is None
+
+
+@pytest.mark.parametrize(
+    ("base_version", "candidate_version"),
+    [
+        ("0.6.0", "0.6.2"),
+        ("0.6.0", "0.7.1"),
+        ("0.6.0", "0.8.0"),
+        ("1.2.3", "1.2.2"),
+        ("1.2.3", "2.0.1"),
+        ("1.2.3", "2.1.0"),
+    ],
+)
+def test_version_bump_check_rejects_skipped_or_lower_versions(
+    base_version: str,
+    candidate_version: str,
+) -> None:
+    message = check_version_bump.validate_version_bump(base_version, candidate_version)
+
+    assert message is not None
+    assert base_version in message
+    assert candidate_version in message
+
+
+def test_version_bump_check_rejects_non_semver_versions() -> None:
+    with pytest.raises(ValueError, match="MAJOR.MINOR.PATCH"):
+        check_version_bump.validate_version_bump("0.6.0", "0.6")
+
+
+def test_read_version_from_git_ref_uses_requested_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return check_version_bump.subprocess.CompletedProcess(
+            args=["git", "show", "main:pyproject.toml"],
+            returncode=0,
+            stdout='[project]\nversion = "1.2.3"\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(check_version_bump.subprocess, "run", fake_run)
+
+    version = check_version_bump.read_version_from_git_ref(REPO_ROOT, ref="main")
+
+    assert version == "1.2.3"
+    assert calls == [
+        (
+            (["git", "show", "main:pyproject.toml"],),
+            {
+                "cwd": REPO_ROOT,
+                "capture_output": True,
+                "text": True,
+                "check": False,
+            },
+        )
+    ]
+
+
+def test_read_version_from_git_ref_reports_git_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_args, **_kwargs):
+        return check_version_bump.subprocess.CompletedProcess(
+            args=["git", "show", "missing:pyproject.toml"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: invalid object name 'missing'.",
+        )
+
+    monkeypatch.setattr(check_version_bump.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="invalid object name"):
+        check_version_bump.read_version_from_git_ref(REPO_ROOT, ref="missing")


### PR DESCRIPTION
## Summary
- add an audit script that compares `project.version` to `main` and only allows unchanged, +1 patch, +1 minor, or +1 major bumps
- run the guard in local pre-commit and in the GitHub Actions quality job after fetching `main`
- cover allowed/rejected transitions and git-ref loading behavior in audit tests

## Verification
- `uv run python -m pytest tests/audit/test_audit_scripts.py`
- `./.venv/bin/pre-commit run --all-files`
- `./.venv/bin/python scripts/audit/check_version_bump.py`