### PR TITLE
Fold measurement-first guidance and updates into TF-RD-001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added explicit no-missing mainline guardrails for benchmark-facing manifests,
+  manifest-backed datasets, prior-dump training inputs, and benchmark bundle
+  loading. `tab-foundry build-manifest` now accepts
+  `--missing-value-policy {allow_any,forbid_any}`, manifest parquet files
+  persist missingness metadata, and the mainline benchmark helpers reject
+  bundles or inputs that allow NaN/Inf unless a future research path opts in
+  explicitly.
+
+- Restored explicit large-bundle benchmark compatibility for compare and bounce
+  diagnosis entry points by auto-opting into missing-valued inputs when the
+  explicitly selected bundle metadata allows them. User-facing note:
+  `training_surface_record.json` now emits
+  `data.manifest.characteristics.all_records_no_missing = null` for legacy
+  manifests that predate missingness annotations instead of incorrectly
+  reporting `true`.
+
+- Mainline bounce diagnosis no longer defaults to the larger
+  `nanotabpfn_openml_binary_large_v1.json` confirmation bundle because that
+  bundle permits missing-valued inputs. The default diagnosis path now stays on
+  the primary no-missing bundle unless a separate confirmation bundle is passed
+  explicitly.
+
 - Added a dedicated benchmark-bounce diagnosis runner and script that benchmark
   completed runs on both the primary and a larger confirmation bundle, writes
   task-bootstrap checkpoint traces, and classifies likely causes such as
   benchmark noise, checkpoint aliasing, optimization instability, and
   concentrated per-dataset tradeoffs.
+
+- `comparison_summary.json` now carries additive checkpoint-level benchmark
+  diagnostics for tab-foundry runs, including best-to-final drift, per-task
+  deltas, task-bootstrap confidence intervals, explicit failed-checkpoint
+  metadata, and the mainline no-missing benchmark-bundle policy used to produce
+  the summary.
 
 - Added a repo-tracked large binary confirmation benchmark bundle for diagnosis
   work under `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -73,7 +73,7 @@ for traceability.
 | Rank | Roadmap ID | Item | Status | Milestone | Tracker Links |
 | ---- | ---------- | ---- | ------ | --------- | ------------- |
 | 0 | TF-RD-002 | Repo foundation and dagzoo-style organization | implemented | Implemented | `BL-175 -> BL-177 -> BL-178 -> BL-179 -> BL-180` |
-| 1 | TF-RD-001 | Canonical control baseline and experiment trust | partial | Now | `BL-152 -> BL-155 -> BL-156 -> BL-157 -> BL-158 -> BL-159` |
+| 1 | TF-RD-001 | Canonical control baseline and experiment trust | partial | Now | `BL-152 -> BL-155 -> BL-156 -> BL-157 -> BL-158 -> BL-159 -> BL-199` |
 | 2 | TF-RD-014 | Stable dagzoo handoff and corpus provenance | planned | Now | `BL-195 -> BL-196 -> BL-197 -> BL-198` |
 | 3 | TF-RD-012 | Shared preprocessing and export-contract fidelity | planned | Now | `no active issue yet; open BL preprocessing chain after TF-RD-014` |
 | 4 | TF-RD-003 | Literature-first references and external baseline borrowing | partial | Now | `BL-154 -> BL-170 -> BL-173` |
@@ -93,8 +93,8 @@ for traceability.
 | --- | --- | --- | --- | --- |
 | Manifest-backed packed-shard training on `dagzoo` outputs | `implemented` | Manifest build flow, manifest-backed train/eval CLI, export/load contract, and packed-shard dataset handling are present in the canonical workflow | Source and prior modularity beyond the manifest path is not yet implemented | `TF-RD-004`, `TF-RD-011` |
 | Corpus provenance and split-safe dagzoo handoff | `planned` | Manifest-backed build flow and dagzoo filter metadata already exist in the canonical workflow | Handoff ingestion, path-independent corpus IDs, and request-run-aware split assignment are not complete | `TF-RD-014`, `TF-RD-001` |
-| Short-run reproducible experiment loop with smoke coverage | `partial` | GitHub Actions quality gate, Iris smoke, dagzoo smoke, persisted run artifacts, and pinned benchmark-bundle discipline are implemented | Repeated-run stability evaluation, checkpoint-selection diagnostics, and leaderboard output are incomplete | `TF-RD-001`, `TF-RD-007` |
-| Benchmark-facing comparison against `nanoTabPFN` | `partial` | Env bootstrap and comparison harnesses exist, and the benchmark remains the selection surface for shortlist validation | Canonical promoted external-baseline configs and benchmark-trust discipline are not complete | `TF-RD-001`, `TF-RD-003`, `TF-RD-007` |
+| Short-run reproducible experiment loop with smoke coverage | `partial` | GitHub Actions quality gate, Iris smoke, dagzoo smoke, persisted run artifacts, and pinned benchmark-bundle discipline are implemented | Repeated-run stability evaluation, checkpoint-selection diagnostics, durable per-task traces, and leaderboard output are incomplete | `TF-RD-001`, `TF-RD-007` |
+| Benchmark-facing comparison against `nanoTabPFN` | `partial` | Env bootstrap and comparison harnesses exist, and the benchmark remains the selection surface for shortlist validation | Canonical promoted external-baseline configs and benchmark-trust discipline are not complete, and the mainline comparison lane still needs an explicit no-missing evaluation boundary | `TF-RD-001`, `TF-RD-003`, `TF-RD-007` |
 | Scaling-oriented architecture planning | `partial` | Architecture guidance, literature references, and evidence mapping are now first-class planning artifacts | Neutral registry, modular backbones, and canonical scaling-law measurement are not complete | `TF-RD-003`, `TF-RD-004`, `TF-RD-005`, `TF-RD-006` |
 | Export-grade preprocessing fidelity | `partial` | Shared preprocessing code now exists and v3 bundles persist fitted feature fill values, label values, and model `input_normalization` | The fitted preprocessing surface is not yet promoted as the settled producer contract across every downstream workflow and tracker lane | `TF-RD-012` |
 | Separate-runtime handoff readiness | `partial` | The repo now ships a v3 reference consumer plus golden bundle conformance fixtures while keeping runtime ownership out of this package | Separate-repo adoption, broader conformance reuse, and downstream stabilization are still unfinished | `TF-RD-013` |
@@ -155,12 +155,14 @@ surface. Use the canonical docs instead:
 - Goal: make benchmark-facing experiment results reproducible, comparable, and
   reviewable enough that scaling conclusions can be trusted.
 - Linear tracking:
-  `BL-152 -> BL-155 -> BL-156 -> BL-157 -> BL-158 -> BL-159`
+  `BL-152 -> BL-155 -> BL-156 -> BL-157 -> BL-158 -> BL-159 -> BL-199`
 - Repo touchpoints:
   - `.github/workflows/test.yml`
   - `src/tab_foundry/bench/dagzoo_smoke.py`
   - `src/tab_foundry/bench/iris_smoke.py`
   - `src/tab_foundry/bench/checkpoint.py`
+  - `src/tab_foundry/bench/bounce_diagnosis.py`
+  - `src/tab_foundry/bench/nanotabpfn.py`
   - `scripts/configure_repo_protection.sh`
 - Current state:
   - The benchmark-facing control is named and documented as
@@ -169,15 +171,24 @@ surface. Use the canonical docs instead:
     artifacts.
   - The canonical benchmark bundle is now pinned in-repo, and the comparison
     flow fails fast on benchmark-input drift.
+  - Mainline benchmark interpretation now needs an explicit no-missing boundary;
+    missing-valued surfaces are a separate research track rather than the
+    current explanation for delta-queue bounce.
   - Benchmark-facing trust remains incomplete until the dagzoo training-data
     seam becomes path-independent and split-safe under `TF-RD-014`.
-  - Repeated-run trust, checkpoint-selection diagnostics, and leaderboard
-    output are not yet fully codified.
+  - Repeated-run trust, checkpoint-level benchmark diagnostics, durable
+    per-task traces, uncertainty estimates for near-anchor rows, and
+    leaderboard output are not yet fully codified.
 - Exit criteria:
   - One frozen canonical control run is documented and preserved.
   - Benchmark inputs are pinned and drift-checked.
+  - Mainline benchmark-facing interpretation is explicitly bounded to the
+    no-missing evaluation surface.
   - Repeated-run stability evaluation exists for the benchmark-facing workflow.
-  - Checkpoint-selection diagnostics appear in benchmark summaries.
+  - Checkpoint-level diagnostics, per-task traces, and uncertainty-aware
+    benchmark summaries appear in benchmark summaries.
+  - Missingness work is tracked as a separate follow-on research lane rather
+    than as the current explanation for benchmark-facing delta-queue bounce.
   - Research and confirmatory runs can land in one canonical leaderboard-style
     output.
 
@@ -592,8 +603,10 @@ surface. Use the canonical docs instead:
 
 ## Dependencies and Sequencing
 
-- `TF-RD-001` must mature before deeper benchmark-facing interpretation work can
-  be trusted.
+- `TF-RD-001` must mature before deeper benchmark-facing interpretation work or
+  control-promotion claims can be trusted, including the no-missing evaluation
+  boundary and checkpoint-level benchmark diagnostics used to read delta-queue
+  behavior.
 - `TF-RD-014` should land before stronger benchmark-facing interpretation or
   control-promotion claims rely on the current dagzoo corpora.
 - `TF-RD-002` should stay ahead of deeper architecture expansion so repo growth
@@ -608,6 +621,9 @@ surface. Use the canonical docs instead:
   surface to make scaling measurements comparable.
 - `TF-RD-007` comes before `TF-RD-008`; the current architecture should be tuned
   before architectural ablations are used to explain benchmark gaps.
+- `TF-RD-001` constrains the interpretation layer for `TF-RD-007`, so
+  control-promotion decisions rely on no-missing measurement evidence before
+  missingness or new mechanism work is used to explain benchmark variance.
 - `TF-RD-008` and the later architecture decision should complete before Goal 2
   becomes the main driver.
 - `TF-RD-013` depends on `TF-RD-012` and should stabilize the separate-runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.6.1"
+version = "0.6.2"
 description = "Tabfoundry tabular foundation model training on dagzoo packed shard outputs"
 readme = "README.md"
 license = "MIT"

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -565,8 +565,8 @@ deltas:
         - adequacy_plan_complete
         - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
-    default_initial_status: ready
-    default_initial_interpretation_status: pending
+    default_initial_status: deferred_separate_workstream
+    default_initial_interpretation_status: blocked
     default_effective_surface:
       model:
         stage_label: anchor_model
@@ -576,7 +576,7 @@ deltas:
         surface_label: runtime_no_impute
         overrides:
           impute_missing: false
-    default_next_action: Run once the matrix records the anchor manifest's missingness expectations.
+    default_next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
     applicability_guards: []
 
   delta_preproc_all_nan_fill_nonzero:
@@ -597,8 +597,8 @@ deltas:
         - adequacy_plan_complete
         - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
-    default_initial_status: ready
-    default_initial_interpretation_status: pending
+    default_initial_status: deferred_separate_workstream
+    default_initial_interpretation_status: blocked
     default_effective_surface:
       model:
         stage_label: anchor_model
@@ -608,7 +608,7 @@ deltas:
         surface_label: runtime_all_nan_fill_one
         overrides:
           all_nan_fill: 1.0
-    default_next_action: Run after the no-imputation row so missing-value sensitivity has context.
+    default_next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
     applicability_guards: []
 
   delta_preproc_label_mapping_surface:

--- a/reference/system_delta_matrix.md
+++ b/reference/system_delta_matrix.md
@@ -52,8 +52,8 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | 13 | `delta_data_filter_policy_accepted_only` | provenance | yes | blocked_on_artifacts | none | Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor. | Materialize the accepted-only manifest and attach its provenance before scheduling training. |
 | 14 | `delta_data_manifest_root_curated_dagzoo` | provenance | yes | blocked_on_artifacts | none | Point training at a curated dagzoo manifest root with explicit dagzoo command provenance. | Capture the dagzoo generation/filter lineage first. |
 | 15 | `delta_data_manifest_source_binary_iris` | source | yes | ready | none | Swap the training manifest to the small binary iris support surface while keeping the model and preprocessing anchored. | Run only after the matrix explicitly records the anchor-versus-iris manifest characteristics. |
-| 16 | `delta_preproc_impute_missing_off` | missing_values | yes | ready | none | Disable runtime mean imputation while keeping the fitted label-remap path intact. | Run once the matrix records the anchor manifest's missingness expectations. |
-| 17 | `delta_preproc_all_nan_fill_nonzero` | missing_values | yes | ready | none | Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0. | Run after the no-imputation row so missing-value sensitivity has context. |
+| 16 | `delta_preproc_impute_missing_off` | missing_values | yes | deferred_separate_workstream | none | Disable runtime mean imputation while keeping the fitted label-remap path intact. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
+| 17 | `delta_preproc_all_nan_fill_nonzero` | missing_values | yes | deferred_separate_workstream | none | Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
 | 18 | `delta_preproc_label_mapping_surface` | label_mapping | yes | blocked_on_policy_impl | none | Compare the current train-only remap/filter label policy against an alternate surfaced label-mapping policy. | Add a second supported label policy before activating this row. |
 
 ## Detailed Rows
@@ -555,7 +555,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 ### 16. `delta_preproc_impute_missing_off`
 
 - Dimension family: `preprocessing`
-- Status: `ready`
+- Status: `deferred_separate_workstream`
 - Binary applicable: `True`
 - Legacy stage alias: `none`
 - Description: Disable runtime mean imputation while keeping the fitted label-remap path intact.
@@ -570,7 +570,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - If the result is weak, note whether the benchmark tasks actually contain meaningful missingness on the support side.
 - Adequacy knobs to dimension explicitly:
   - Interpret against manifest missingness prevalence where available.
-- Interpretation status: `pending`
+- Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/binary_md_v1/delta_preproc_impute_missing_off/result_card.md`
@@ -579,7 +579,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 ### 17. `delta_preproc_all_nan_fill_nonzero`
 
 - Dimension family: `preprocessing`
-- Status: `ready`
+- Status: `deferred_separate_workstream`
 - Binary applicable: `True`
 - Legacy stage alias: `none`
 - Description: Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0.
@@ -594,7 +594,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Interpret near-zero movement as expected if the surface rarely exercises this branch.
 - Adequacy knobs to dimension explicitly:
   - Report whether all-NaN columns are actually present in the compared manifests.
-- Interpretation status: `pending`
+- Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/binary_md_v1/delta_preproc_all_nan_fill_nonzero/result_card.md`

--- a/reference/system_delta_queue.yaml
+++ b/reference/system_delta_queue.yaml
@@ -1125,7 +1125,7 @@ rows:
   notes: []
 - order: 16
   delta_id: delta_preproc_impute_missing_off
-  status: ready
+  status: deferred_separate_workstream
   dimension_family: preprocessing
   family: missing_values
   binary_applicable: true
@@ -1171,13 +1171,14 @@ rows:
   run_id: null
   followup_run_ids: []
   decision: null
-  interpretation_status: pending
+  interpretation_status: blocked
   confounders: []
-  next_action: Run once the matrix records the anchor manifest's missingness expectations.
+  next_action: Do not run on the main no-missing campaign; revisit only in a dedicated
+    missingness workstream with explicit missing-valued training and evaluation inputs.
   notes: []
 - order: 17
   delta_id: delta_preproc_all_nan_fill_nonzero
-  status: ready
+  status: deferred_separate_workstream
   dimension_family: preprocessing
   family: missing_values
   binary_applicable: true
@@ -1222,9 +1223,10 @@ rows:
   run_id: null
   followup_run_ids: []
   decision: null
-  interpretation_status: pending
+  interpretation_status: blocked
   confounders: []
-  next_action: Run after the no-imputation row so missing-value sensitivity has context.
+  next_action: Do not run on the main no-missing campaign; revisit only in a dedicated
+    missingness workstream with explicit missing-valued training and evaluation inputs.
   notes: []
 - order: 18
   delta_id: delta_preproc_label_mapping_surface

--- a/reference/system_delta_sweeps/binary_md_v1/matrix.md
+++ b/reference/system_delta_sweeps/binary_md_v1/matrix.md
@@ -52,8 +52,8 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | 13 | `delta_data_filter_policy_accepted_only` | provenance | yes | blocked_on_artifacts | none | Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor. | Materialize the accepted-only manifest and attach its provenance before scheduling training. |
 | 14 | `delta_data_manifest_root_curated_dagzoo` | provenance | yes | blocked_on_artifacts | none | Point training at a curated dagzoo manifest root with explicit dagzoo command provenance. | Capture the dagzoo generation/filter lineage first. |
 | 15 | `delta_data_manifest_source_binary_iris` | source | yes | ready | none | Swap the training manifest to the small binary iris support surface while keeping the model and preprocessing anchored. | Run only after the matrix explicitly records the anchor-versus-iris manifest characteristics. |
-| 16 | `delta_preproc_impute_missing_off` | missing_values | yes | ready | none | Disable runtime mean imputation while keeping the fitted label-remap path intact. | Run once the matrix records the anchor manifest's missingness expectations. |
-| 17 | `delta_preproc_all_nan_fill_nonzero` | missing_values | yes | ready | none | Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0. | Run after the no-imputation row so missing-value sensitivity has context. |
+| 16 | `delta_preproc_impute_missing_off` | missing_values | yes | deferred_separate_workstream | none | Disable runtime mean imputation while keeping the fitted label-remap path intact. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
+| 17 | `delta_preproc_all_nan_fill_nonzero` | missing_values | yes | deferred_separate_workstream | none | Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
 | 18 | `delta_preproc_label_mapping_surface` | label_mapping | yes | blocked_on_policy_impl | none | Compare the current train-only remap/filter label policy against an alternate surfaced label-mapping policy. | Add a second supported label policy before activating this row. |
 
 ## Detailed Rows
@@ -555,7 +555,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 ### 16. `delta_preproc_impute_missing_off`
 
 - Dimension family: `preprocessing`
-- Status: `ready`
+- Status: `deferred_separate_workstream`
 - Binary applicable: `True`
 - Legacy stage alias: `none`
 - Description: Disable runtime mean imputation while keeping the fitted label-remap path intact.
@@ -570,7 +570,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - If the result is weak, note whether the benchmark tasks actually contain meaningful missingness on the support side.
 - Adequacy knobs to dimension explicitly:
   - Interpret against manifest missingness prevalence where available.
-- Interpretation status: `pending`
+- Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/binary_md_v1/delta_preproc_impute_missing_off/result_card.md`
@@ -579,7 +579,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 ### 17. `delta_preproc_all_nan_fill_nonzero`
 
 - Dimension family: `preprocessing`
-- Status: `ready`
+- Status: `deferred_separate_workstream`
 - Binary applicable: `True`
 - Legacy stage alias: `none`
 - Description: Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0.
@@ -594,7 +594,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Interpret near-zero movement as expected if the surface rarely exercises this branch.
 - Adequacy knobs to dimension explicitly:
   - Report whether all-NaN columns are actually present in the compared manifests.
-- Interpretation status: `pending`
+- Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/binary_md_v1/delta_preproc_all_nan_fill_nonzero/result_card.md`

--- a/reference/system_delta_sweeps/binary_md_v1/queue.yaml
+++ b/reference/system_delta_sweeps/binary_md_v1/queue.yaml
@@ -487,7 +487,7 @@ rows:
 
   - order: 16
     delta_ref: delta_preproc_impute_missing_off
-    status: ready
+    status: deferred_separate_workstream
     rationale: Missing-value handling is a first-class preprocessing dimension and should be measured without mixing in data or model changes.
     hypothesis: If missingness is rare on the anchor surface this may be neutral; if not, harm may reflect simple information loss rather than a meaningful architectural weakness.
     anchor_delta: Changes only preprocessing.impute_missing from true to false.
@@ -504,14 +504,14 @@ rows:
     run_id: null
     followup_run_ids: []
     decision: null
-    interpretation_status: pending
+    interpretation_status: blocked
     confounders: []
-    next_action: Run once the matrix records the anchor manifest's missingness expectations.
+    next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
     notes: []
 
   - order: 17
     delta_ref: delta_preproc_all_nan_fill_nonzero
-    status: ready
+    status: deferred_separate_workstream
     rationale: This isolates a preprocessing policy knob that is usually hidden inside fitted-state defaults.
     hypothesis: The row is mainly interpretive; a weak result may simply mean all-NaN columns are rare on the current surface.
     anchor_delta: Changes only preprocessing.all_nan_fill from 0.0 to 1.0.
@@ -528,9 +528,9 @@ rows:
     run_id: null
     followup_run_ids: []
     decision: null
-    interpretation_status: pending
+    interpretation_status: blocked
     confounders: []
-    next_action: Run after the no-imputation row so missing-value sensitivity has context.
+    next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
     notes: []
 
   - order: 18

--- a/src/tab_foundry/bench/bounce_diagnosis.py
+++ b/src/tab_foundry/bench/bounce_diagnosis.py
@@ -22,12 +22,13 @@ from tab_foundry.bench.benchmark_run_registry import (
     resolve_registry_path_value,
 )
 from tab_foundry.bench.nanotabpfn import (
-    annotate_curve_records_with_task_statistics,
     benchmark_bundle_summary,
+    curve_summary,
     default_benchmark_bundle_path,
     evaluate_tab_foundry_run,
-    load_benchmark_bundle,
+    load_benchmark_bundle_for_execution,
     load_openml_benchmark_datasets,
+    summarize_checkpoint_curve,
 )
 from tab_foundry.bench.prior_train import train_tabfoundry_simple_prior
 from tab_foundry.training.trainer import train
@@ -52,13 +53,6 @@ class BenchmarkBounceDiagnosisConfig:
     dense_run_dir: Path | None = None
     rerun_mode: RerunMode = "none"
     run_id: str | None = None
-
-
-def default_confirmation_benchmark_bundle_path() -> Path:
-    """Return the repo-tracked large confirmation bundle path."""
-
-    return Path(__file__).resolve().with_name("nanotabpfn_openml_binary_large_v1.json")
-
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -199,63 +193,24 @@ def _run_dense_checkpoint_rerun(config: BenchmarkBounceDiagnosisConfig) -> Path:
     return dense_output_dir
 
 
-def _interval_overlap(interval_a: Mapping[str, Any], interval_b: Mapping[str, Any]) -> bool:
-    return float(interval_a["lower"]) <= float(interval_b["upper"]) and float(interval_b["lower"]) <= float(interval_a["upper"])
-
-
-def _adjacent_ci_overlap_fraction(records: list[dict[str, Any]]) -> float | None:
-    sorted_records = sorted(records, key=lambda record: int(record["step"]))
-    overlaps = 0
-    pairs = 0
-    for previous, current in zip(sorted_records, sorted_records[1:], strict=False):
-        prev_ci = previous.get("roc_auc_task_bootstrap_ci")
-        curr_ci = current.get("roc_auc_task_bootstrap_ci")
-        if not isinstance(prev_ci, Mapping) or not isinstance(curr_ci, Mapping):
-            continue
-        pairs += 1
-        if _interval_overlap(prev_ci, curr_ci):
-            overlaps += 1
-    if pairs <= 0:
-        return None
-    return float(overlaps) / float(pairs)
-
-
-def _curve_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
-    if not records:
-        return {
-            "checkpoint_count": 0,
-            "task_count": 0,
-            "best_step": 0,
-            "best_roc_auc": float("nan"),
-            "final_step": 0,
-            "final_roc_auc": float("nan"),
-            "adjacent_ci_overlap_fraction": None,
-        }
-    sorted_records = sorted(records, key=lambda record: int(record["step"]))
-    best_record = max(sorted_records, key=lambda record: float(record["roc_auc"]))
-    final_record = sorted_records[-1]
-    return {
-        "checkpoint_count": int(len(sorted_records)),
-        "task_count": int(sorted_records[0].get("dataset_count", 0)),
-        "best_step": int(best_record["step"]),
-        "best_roc_auc": float(best_record["roc_auc"]),
-        "final_step": int(final_record["step"]),
-        "final_roc_auc": float(final_record["roc_auc"]),
-        "adjacent_ci_overlap_fraction": _adjacent_ci_overlap_fraction(sorted_records),
-    }
-
-
 def _shared_bundle_analysis(
     primary_records: list[dict[str, Any]],
-    confirmation_records: list[dict[str, Any]],
+    confirmation_records: list[dict[str, Any]] | None,
 ) -> dict[str, Any]:
     primary_by_step = {int(record["step"]): record for record in primary_records}
-    confirmation_by_step = {int(record["step"]): record for record in confirmation_records}
+    confirmation_by_step = (
+        {}
+        if confirmation_records is None
+        else {int(record["step"]): record for record in confirmation_records}
+    )
     shared_steps = sorted(set(primary_by_step) & set(confirmation_by_step))
-    primary_summary = _curve_summary(primary_records)
-    confirmation_summary = _curve_summary(confirmation_records)
+    primary_summary = curve_summary(primary_records)
+    confirmation_summary = (
+        None if confirmation_records is None else curve_summary(confirmation_records)
+    )
     best_step_changed = bool(
         int(primary_summary["checkpoint_count"]) > 0
+        and confirmation_summary is not None
         and int(confirmation_summary["checkpoint_count"]) > 0
         and int(primary_summary["best_step"]) != int(confirmation_summary["best_step"])
     )
@@ -263,6 +218,7 @@ def _shared_bundle_analysis(
         best_step_changed
         and primary_summary["adjacent_ci_overlap_fraction"] is not None
         and float(primary_summary["adjacent_ci_overlap_fraction"]) >= 0.5
+        and confirmation_summary is not None
         and int(confirmation_summary["task_count"]) > int(primary_summary["task_count"])
     )
     return {
@@ -273,6 +229,12 @@ def _shared_bundle_analysis(
         "confirmation": confirmation_summary,
         "likely_benchmark_noise": likely_benchmark_noise,
     }
+
+
+def _curve_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compatibility wrapper around the shared checkpoint-curve summary helper."""
+
+    return curve_summary(records)
 
 
 def _history_variance(values: list[float]) -> float | None:
@@ -398,8 +360,8 @@ def _checkpoint_aliasing_signal(
             "available": False,
             "likely_checkpoint_aliasing": False,
         }
-    coarse_summary = _curve_summary(coarse_records)
-    dense_summary = _curve_summary(dense_records)
+    coarse_summary = curve_summary(coarse_records)
+    dense_summary = curve_summary(dense_records)
     coarse_steps = {int(record["step"]) for record in coarse_records}
     dense_best_step = int(dense_summary["best_step"])
     likely_aliasing = bool(
@@ -484,43 +446,37 @@ def _evaluate_one_bundle(
     bootstrap_samples: int,
     bootstrap_confidence: float,
 ) -> dict[str, Any]:
-    bundle = load_benchmark_bundle(bundle_path)
+    bundle, allow_missing_values = load_benchmark_bundle_for_execution(bundle_path)
     selection = cast(dict[str, Any], bundle["selection"])
     datasets, benchmark_tasks = load_openml_benchmark_datasets(
         new_instances=int(selection["new_instances"]),
         benchmark_bundle_path=bundle_path,
+        allow_missing_values=allow_missing_values,
     )
     raw_records = evaluate_tab_foundry_run(
         run_dir,
         datasets=datasets,
         device=device,
         allow_checkpoint_failures=True,
+        allow_missing_values=allow_missing_values,
     )
-    successful_records = [
-        dict(record)
-        for record in raw_records
-        if record.get("roc_auc") is not None
-    ]
-    failed_records = [
-        dict(record)
-        for record in raw_records
-        if record.get("evaluation_error") is not None
-    ]
-    records = annotate_curve_records_with_task_statistics(
-        successful_records,
+    diagnostics = summarize_checkpoint_curve(
+        raw_records,
         bootstrap_samples=int(bootstrap_samples),
         bootstrap_confidence=float(bootstrap_confidence),
     )
+    records = cast(list[dict[str, Any]], diagnostics["successful_records"])
+    failed_records = cast(list[dict[str, Any]], diagnostics["failed_records"])
     write_jsonl(
         out_path,
-        sorted(records + failed_records, key=lambda record: int(record["step"])),
+        cast(list[dict[str, Any]], diagnostics["records"]),
     )
     return {
         "bundle": benchmark_bundle_summary(bundle, source_path=bundle_path),
         "benchmark_tasks": benchmark_tasks,
         "records": records,
         "records_path": str(out_path.resolve()),
-        "summary": _curve_summary(records),
+        "summary": curve_summary(records),
         "failure_count": int(len(failed_records)),
         "failed_checkpoints": failed_records,
     }
@@ -545,11 +501,6 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
         if config.benchmark_bundle_path is None
         else config.benchmark_bundle_path.expanduser().resolve()
     )
-    confirmation_bundle_path = (
-        default_confirmation_benchmark_bundle_path()
-        if config.confirmation_benchmark_bundle_path is None
-        else config.confirmation_benchmark_bundle_path.expanduser().resolve()
-    )
 
     primary = _evaluate_one_bundle(
         run_dir=run_dir,
@@ -559,14 +510,16 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
         bootstrap_samples=bootstrap_samples,
         bootstrap_confidence=bootstrap_confidence,
     )
-    confirmation = _evaluate_one_bundle(
-        run_dir=run_dir,
-        bundle_path=confirmation_bundle_path,
-        device=config.device,
-        out_path=out_root / "confirmation_bundle_curve.jsonl",
-        bootstrap_samples=bootstrap_samples,
-        bootstrap_confidence=bootstrap_confidence,
-    )
+    confirmation: dict[str, Any] | None = None
+    if config.confirmation_benchmark_bundle_path is not None:
+        confirmation = _evaluate_one_bundle(
+            run_dir=run_dir,
+            bundle_path=config.confirmation_benchmark_bundle_path.expanduser().resolve(),
+            device=config.device,
+            out_path=out_root / "confirmation_bundle_curve.jsonl",
+            bootstrap_samples=bootstrap_samples,
+            bootstrap_confidence=bootstrap_confidence,
+        )
 
     dense_run_dir: Path | None = None
     dense_confirmation: dict[str, Any] | None = None
@@ -575,9 +528,14 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
     elif config.dense_checkpoint_every is not None:
         dense_run_dir = _run_dense_checkpoint_rerun(config)
     if dense_run_dir is not None:
+        dense_bundle_path = (
+            benchmark_bundle_path
+            if confirmation is None
+            else Path(str(cast(dict[str, Any], confirmation["bundle"])["source_path"]))
+        )
         dense_confirmation = _evaluate_one_bundle(
             run_dir=dense_run_dir,
-            bundle_path=confirmation_bundle_path,
+            bundle_path=dense_bundle_path,
             device=config.device,
             out_path=out_root / "dense_confirmation_bundle_curve.jsonl",
             bootstrap_samples=bootstrap_samples,
@@ -591,23 +549,38 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
     )
     bundle_analysis = _shared_bundle_analysis(
         cast(list[dict[str, Any]], primary["records"]),
-        cast(list[dict[str, Any]], confirmation["records"]),
+        None if confirmation is None else cast(list[dict[str, Any]], confirmation["records"]),
     )
     training_signal = _training_signal(
         history=history,
-        curve_records=cast(list[dict[str, Any]], confirmation["records"]),
+        curve_records=(
+            cast(list[dict[str, Any]], primary["records"])
+            if confirmation is None
+            else cast(list[dict[str, Any]], confirmation["records"])
+        ),
     )
     task_tradeoff_signal = _task_tradeoff_signal(
-        cast(list[dict[str, Any]], confirmation["records"]),
+        (
+            cast(list[dict[str, Any]], primary["records"])
+            if confirmation is None
+            else cast(list[dict[str, Any]], confirmation["records"])
+        ),
     )
     checkpoint_aliasing_signal = _checkpoint_aliasing_signal(
-        coarse_records=cast(list[dict[str, Any]], confirmation["records"]),
+        coarse_records=(
+            cast(list[dict[str, Any]], primary["records"])
+            if confirmation is None
+            else cast(list[dict[str, Any]], confirmation["records"])
+        ),
         dense_records=None if dense_confirmation is None else cast(list[dict[str, Any]], dense_confirmation["records"]),
     )
     evaluation_failures = {
-        "failure_count": int(primary.get("failure_count", 0)) + int(confirmation.get("failure_count", 0)),
+        "failure_count": int(primary.get("failure_count", 0))
+        + (0 if confirmation is None else int(confirmation.get("failure_count", 0))),
         "primary_bundle_failures": list(primary.get("failed_checkpoints", [])),
-        "confirmation_bundle_failures": list(confirmation.get("failed_checkpoints", [])),
+        "confirmation_bundle_failures": []
+        if confirmation is None
+        else list(confirmation.get("failed_checkpoints", [])),
     }
     classification = _classify_causes(
         bundle_analysis=bundle_analysis,
@@ -624,7 +597,9 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
         "run_dir": str(run_dir),
         "artifacts": {
             "primary_bundle_curve_jsonl": primary["records_path"],
-            "confirmation_bundle_curve_jsonl": confirmation["records_path"],
+            "confirmation_bundle_curve_jsonl": None
+            if confirmation is None
+            else confirmation["records_path"],
             "dense_confirmation_bundle_curve_jsonl": None
             if dense_confirmation is None
             else dense_confirmation["records_path"],
@@ -634,7 +609,9 @@ def run_benchmark_bounce_diagnosis(config: BenchmarkBounceDiagnosisConfig) -> di
                 "benchmark_bundle": primary["bundle"],
                 "summary": primary["summary"],
             },
-            "confirmation": {
+            "confirmation": None
+            if confirmation is None
+            else {
                 "benchmark_bundle": confirmation["bundle"],
                 "summary": confirmation["summary"],
             },
@@ -681,7 +658,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--confirmation-benchmark-bundle-path",
         default=None,
-        help="Larger confirmation benchmark bundle path",
+        help="Optional confirmation benchmark bundle path; omit to stay on the primary no-missing bundle only",
     )
     parser.add_argument(
         "--bootstrap-samples",

--- a/src/tab_foundry/bench/compare.py
+++ b/src/tab_foundry/bench/compare.py
@@ -19,11 +19,15 @@ from tab_foundry.bench.control_baseline import (
 from tab_foundry.bench.nanotabpfn import (
     default_benchmark_bundle_path,
     build_comparison_summary,
+    DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE,
+    DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SAMPLES,
+    DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SEED,
     evaluate_tab_foundry_run,
-    load_benchmark_bundle,
+    load_benchmark_bundle_for_execution,
     load_openml_benchmark_datasets,
     plot_comparison_curve,
     save_dataset_cache,
+    summarize_checkpoint_curve,
 )
 
 
@@ -152,7 +156,9 @@ def run_nanotabpfn_benchmark(config: NanoTabPFNBenchmarkConfig) -> dict[str, Any
         if config.benchmark_bundle_path is None
         else config.benchmark_bundle_path.expanduser().resolve()
     )
-    benchmark_bundle = load_benchmark_bundle(benchmark_bundle_path)
+    benchmark_bundle, allow_missing_values = load_benchmark_bundle_for_execution(
+        benchmark_bundle_path
+    )
     benchmark_selection = cast(dict[str, Any], benchmark_bundle["selection"])
     benchmark_new_instances = int(benchmark_selection["new_instances"])
     control_baseline = None
@@ -165,6 +171,7 @@ def run_nanotabpfn_benchmark(config: NanoTabPFNBenchmarkConfig) -> dict[str, Any
     datasets, benchmark_tasks = load_openml_benchmark_datasets(
         new_instances=benchmark_new_instances,
         benchmark_bundle_path=benchmark_bundle_path,
+        allow_missing_values=allow_missing_values,
     )
     write_json(benchmark_tasks_path, benchmark_bundle)
     save_dataset_cache(dataset_cache_path, datasets)
@@ -173,6 +180,17 @@ def run_nanotabpfn_benchmark(config: NanoTabPFNBenchmarkConfig) -> dict[str, Any
         tab_foundry_run_dir,
         datasets=datasets,
         device=config.device,
+        allow_checkpoint_failures=True,
+        allow_missing_values=allow_missing_values,
+    )
+    tab_foundry_records = cast(
+        list[dict[str, Any]],
+        summarize_checkpoint_curve(
+            tab_foundry_records,
+            bootstrap_samples=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SAMPLES,
+            bootstrap_confidence=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE,
+            bootstrap_seed=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SEED,
+        )["records"],
     )
     write_jsonl(tab_foundry_curve_path, tab_foundry_records)
 

--- a/src/tab_foundry/bench/nanotabpfn.py
+++ b/src/tab_foundry/bench/nanotabpfn.py
@@ -19,11 +19,15 @@ from sklearn.model_selection import StratifiedKFold, train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer, LabelEncoder, OrdinalEncoder
 
+from tab_foundry.data.validation import assert_no_non_finite_values
 from tab_foundry.bench.artifacts import checkpoint_snapshots_from_history
 
 
 BENCHMARK_BUNDLE_FILENAME = "nanotabpfn_openml_binary_medium_v1.json"
 _BUNDLE_SELECTION_TASK_TYPE = "supervised_classification"
+DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SAMPLES = 2000
+DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE = 0.95
+DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SEED = 0
 
 _SKF = StratifiedKFold(n_splits=5, shuffle=True, random_state=0)
 
@@ -38,6 +42,17 @@ class PreparedOpenMLBenchmarkTask:
     y: np.ndarray
     observed_task: dict[str, Any]
     qualities: dict[str, float]
+
+
+class BenchmarkDatasetEvaluationError(RuntimeError):
+    """One benchmark dataset failed within a checkpoint evaluation."""
+
+    def __init__(self, dataset_name: str, cause: Exception) -> None:
+        self.dataset_name = str(dataset_name)
+        self.error_type = type(cause).__name__
+        super().__init__(
+            f"benchmark evaluation failed for dataset {self.dataset_name!r}: {cause}"
+        )
 
 
 def get_feature_preprocessor(x: np.ndarray | pd.DataFrame) -> ColumnTransformer:
@@ -222,16 +237,72 @@ def normalize_benchmark_bundle(payload: Any) -> dict[str, Any]:
     return normalized_bundle
 
 
-def load_benchmark_bundle(path: Path | None = None) -> dict[str, Any]:
+def _validate_bundle_missing_value_policy(
+    bundle: Mapping[str, Any],
+    *,
+    allow_missing_values: bool,
+    source_path: Path,
+) -> None:
+    if allow_missing_values:
+        return
+    selection = cast(dict[str, Any], bundle["selection"])
+    max_missing_pct = float(selection["max_missing_pct"])
+    if max_missing_pct > 0.0:
+        raise RuntimeError(
+            "benchmark bundle permits missing-valued inputs while allow_missing_values=False: "
+            f"path={source_path}, max_missing_pct={max_missing_pct}"
+        )
+
+
+def _assert_finite_benchmark_datasets(
+    datasets: Mapping[str, tuple[np.ndarray, np.ndarray]],
+    *,
+    context: str,
+) -> None:
+    for dataset_name, (x, y) in datasets.items():
+        assert_no_non_finite_values(
+            {"x": x, "y": y},
+            context=f"{context} dataset={dataset_name!r}",
+        )
+
+
+def benchmark_bundle_allows_missing_values(bundle: Mapping[str, Any]) -> bool:
+    """Return whether the bundle contract permits missing-valued inputs."""
+
+    selection = cast(dict[str, Any], bundle["selection"])
+    raw_max_missing_pct = selection.get("max_missing_pct")
+    if not isinstance(raw_max_missing_pct, (int, float)):
+        return False
+    return bool(float(raw_max_missing_pct) > 0.0)
+
+
+def load_benchmark_bundle(
+    path: Path | None = None,
+    *,
+    allow_missing_values: bool = False,
+) -> dict[str, Any]:
     """Load and validate the canonical benchmark bundle metadata."""
 
     bundle_path = (path or default_benchmark_bundle_path()).expanduser().resolve()
     with bundle_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     try:
-        return normalize_benchmark_bundle(payload)
+        bundle = normalize_benchmark_bundle(payload)
     except RuntimeError as exc:
         raise RuntimeError(f"{exc}: {bundle_path}") from exc
+    _validate_bundle_missing_value_policy(
+        bundle,
+        allow_missing_values=bool(allow_missing_values),
+        source_path=bundle_path,
+    )
+    return bundle
+
+
+def load_benchmark_bundle_for_execution(path: Path | None = None) -> tuple[dict[str, Any], bool]:
+    """Load a bundle and resolve whether execution should allow missing values."""
+
+    bundle = load_benchmark_bundle(path, allow_missing_values=True)
+    return bundle, benchmark_bundle_allows_missing_values(bundle)
 
 
 def benchmark_bundle_summary(
@@ -242,12 +313,26 @@ def benchmark_bundle_summary(
     """Build compact bundle metadata for run summaries."""
 
     task_ids = [int(task_id) for task_id in cast(list[Any], bundle["task_ids"])]
+    selection_raw = bundle.get("selection")
+    selection = (
+        cast(dict[str, Any], json.loads(json.dumps(selection_raw, sort_keys=True)))
+        if isinstance(selection_raw, Mapping)
+        else None
+    )
+    allow_missing_values = (
+        None
+        if not isinstance(selection_raw, Mapping)
+        else benchmark_bundle_allows_missing_values(bundle)
+    )
     return {
         "name": str(bundle["name"]),
         "version": int(bundle["version"]),
         "source_path": str(source_path.expanduser().resolve()),
         "task_count": int(len(task_ids)),
         "task_ids": task_ids,
+        "selection": selection,
+        "allow_missing_values": allow_missing_values,
+        "all_tasks_no_missing": None if allow_missing_values is None else (not allow_missing_values),
     }
 
 
@@ -336,10 +421,14 @@ def load_openml_benchmark_datasets(
     *,
     new_instances: int = 200,
     benchmark_bundle_path: Path | None = None,
+    allow_missing_values: bool = False,
 ) -> tuple[dict[str, tuple[np.ndarray, np.ndarray]], list[dict[str, Any]]]:
     """Load the nanoTabPFN OpenML benchmark suite."""
 
-    bundle = load_benchmark_bundle(benchmark_bundle_path)
+    bundle = load_benchmark_bundle(
+        benchmark_bundle_path,
+        allow_missing_values=allow_missing_values,
+    )
     selection = cast(dict[str, Any], bundle["selection"])
     expected_new_instances = int(selection["new_instances"])
     if new_instances != expected_new_instances:
@@ -395,6 +484,11 @@ def load_openml_benchmark_datasets(
             "benchmark bundle drift: "
             f"task count mismatch expected={len(expected_tasks)}, actual={len(benchmark_tasks)}"
         )
+    if not allow_missing_values:
+        _assert_finite_benchmark_datasets(
+            datasets,
+            context=f"benchmark bundle {bundle['name']!r}",
+        )
     return datasets, benchmark_tasks
 
 
@@ -430,29 +524,40 @@ def load_dataset_cache(path: Path) -> dict[str, tuple[np.ndarray, np.ndarray]]:
 def evaluate_classifier(
     classifier: Any,
     datasets: Mapping[str, tuple[np.ndarray, np.ndarray]],
+    *,
+    allow_missing_values: bool = False,
 ) -> dict[str, float]:
     """Evaluate a sklearn-style classifier on the cached benchmark suite."""
 
+    if not allow_missing_values:
+        _assert_finite_benchmark_datasets(datasets, context="benchmark evaluation inputs")
     metrics: dict[str, float] = {}
     for dataset_name, (x, y) in datasets.items():
-        targets: list[np.ndarray] = []
-        probabilities: list[np.ndarray] = []
-        for train_idx, test_idx in _SKF.split(x, y):
-            x_train, x_test = x[train_idx], x[test_idx]
-            y_train, y_test = y[train_idx], y[test_idx]
-            targets.append(y_test)
-            classifier.fit(x_train, y_train)
-            y_proba = classifier.predict_proba(x_test)
-            if y_proba.shape[1] == 2:
-                probabilities.append(np.asarray(y_proba[:, 1], dtype=np.float64))
-            else:
-                probabilities.append(np.asarray(y_proba, dtype=np.float64))
+        try:
+            targets: list[np.ndarray] = []
+            probabilities: list[np.ndarray] = []
+            for train_idx, test_idx in _SKF.split(x, y):
+                x_train, x_test = x[train_idx], x[test_idx]
+                y_train, y_test = y[train_idx], y[test_idx]
+                targets.append(y_test)
+                classifier.fit(x_train, y_train)
+                y_proba = classifier.predict_proba(x_test)
+                if y_proba.shape[1] == 2:
+                    probabilities.append(np.asarray(y_proba[:, 1], dtype=np.float64))
+                else:
+                    probabilities.append(np.asarray(y_proba, dtype=np.float64))
 
-        target_array = np.concatenate(targets, axis=0)
-        probability_array = np.concatenate(probabilities, axis=0)
-        metrics[f"{dataset_name}/ROC AUC"] = float(
-            roc_auc_score(target_array, probability_array, multi_class="ovr")
-        )
+            target_array = np.concatenate(targets, axis=0)
+            probability_array = np.concatenate(probabilities, axis=0)
+            assert_no_non_finite_values(
+                {"probabilities": probability_array},
+                context=f"benchmark classifier outputs dataset={dataset_name!r}",
+            )
+            metrics[f"{dataset_name}/ROC AUC"] = float(
+                roc_auc_score(target_array, probability_array, multi_class="ovr")
+            )
+        except Exception as exc:
+            raise BenchmarkDatasetEvaluationError(str(dataset_name), exc) from exc
 
     roc_auc_values = [value for key, value in metrics.items() if key.endswith("/ROC AUC")]
     metrics["ROC AUC"] = float(np.mean(roc_auc_values))
@@ -531,6 +636,179 @@ def annotate_curve_records_with_task_statistics(
             enriched["roc_auc_task_bootstrap_ci"] = bootstrap_interval
         annotated.append(enriched)
     return annotated
+
+
+def _interval_overlap(interval_a: Mapping[str, Any], interval_b: Mapping[str, Any]) -> bool:
+    return float(interval_a["lower"]) <= float(interval_b["upper"]) and float(
+        interval_b["lower"]
+    ) <= float(interval_a["upper"])
+
+
+def _is_successful_curve_record(record: Mapping[str, Any]) -> bool:
+    raw_roc_auc = record.get("roc_auc")
+    if raw_roc_auc is None:
+        return False
+    try:
+        return math.isfinite(float(raw_roc_auc))
+    except (TypeError, ValueError):
+        return False
+
+
+def curve_adjacent_ci_overlap_fraction(records: list[dict[str, Any]]) -> float | None:
+    """Estimate how often adjacent checkpoint CIs overlap."""
+
+    sorted_records = sorted(
+        [dict(record) for record in records if _is_successful_curve_record(record)],
+        key=lambda record: int(record["step"]),
+    )
+    overlaps = 0
+    pairs = 0
+    for previous, current in zip(sorted_records, sorted_records[1:], strict=False):
+        prev_ci = previous.get("roc_auc_task_bootstrap_ci")
+        curr_ci = current.get("roc_auc_task_bootstrap_ci")
+        if not isinstance(prev_ci, Mapping) or not isinstance(curr_ci, Mapping):
+            continue
+        pairs += 1
+        if _interval_overlap(prev_ci, curr_ci):
+            overlaps += 1
+    if pairs <= 0:
+        return None
+    return float(overlaps) / float(pairs)
+
+
+def curve_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize one checkpoint curve after task statistics are attached."""
+
+    successful_records = sorted(
+        [dict(record) for record in records if _is_successful_curve_record(record)],
+        key=lambda record: int(record["step"]),
+    )
+    if not successful_records:
+        return {
+            "checkpoint_count": 0,
+            "task_count": 0,
+            "best_step": 0,
+            "best_roc_auc": float("nan"),
+            "final_step": 0,
+            "final_roc_auc": float("nan"),
+            "adjacent_ci_overlap_fraction": None,
+        }
+    best_record = max(successful_records, key=lambda record: float(record["roc_auc"]))
+    final_record = successful_records[-1]
+    task_count = max(
+        int(
+            record.get(
+                "dataset_count",
+                len(record["dataset_roc_auc"])
+                if isinstance(record.get("dataset_roc_auc"), Mapping)
+                else 0,
+            )
+        )
+        for record in successful_records
+    )
+    return {
+        "checkpoint_count": int(len(successful_records)),
+        "task_count": int(task_count),
+        "best_step": int(best_record["step"]),
+        "best_roc_auc": float(best_record["roc_auc"]),
+        "final_step": int(final_record["step"]),
+        "final_roc_auc": float(final_record["roc_auc"]),
+        "adjacent_ci_overlap_fraction": curve_adjacent_ci_overlap_fraction(successful_records),
+    }
+
+
+def summarize_checkpoint_curve(
+    records: list[dict[str, Any]],
+    *,
+    bootstrap_samples: int = 0,
+    bootstrap_confidence: float = 0.95,
+    bootstrap_seed: int = 0,
+) -> dict[str, Any]:
+    """Build one checkpoint-trace summary with failure and CI metadata."""
+
+    successful_records = [
+        dict(record)
+        for record in records
+        if _is_successful_curve_record(record)
+    ]
+    failed_records = [
+        dict(record)
+        for record in records
+        if not _is_successful_curve_record(record)
+    ]
+    annotated_successful_records = annotate_curve_records_with_task_statistics(
+        successful_records,
+        bootstrap_samples=int(bootstrap_samples),
+        bootstrap_confidence=float(bootstrap_confidence),
+        bootstrap_seed=int(bootstrap_seed),
+    )
+    sorted_successful_records = sorted(
+        annotated_successful_records,
+        key=lambda record: int(record["step"]),
+    )
+    trace_summary = curve_summary(sorted_successful_records)
+    best_record = (
+        None
+        if not sorted_successful_records
+        else max(sorted_successful_records, key=lambda record: float(record["roc_auc"]))
+    )
+    final_record = None if not sorted_successful_records else sorted_successful_records[-1]
+    best_checkpoint_path = (
+        None
+        if best_record is None or best_record.get("checkpoint_path") is None
+        else str(best_record["checkpoint_path"])
+    )
+    final_checkpoint_path = (
+        None
+        if final_record is None or final_record.get("checkpoint_path") is None
+        else str(final_record["checkpoint_path"])
+    )
+    sorted_records = sorted(
+        [dict(record) for record in sorted_successful_records + failed_records],
+        key=lambda record: int(record["step"]),
+    )
+    for record in sorted_records:
+        checkpoint_path = (
+            None if record.get("checkpoint_path") is None else str(record["checkpoint_path"])
+        )
+        record["is_best_checkpoint"] = bool(
+            checkpoint_path is not None and checkpoint_path == best_checkpoint_path
+        )
+        record["is_final_checkpoint"] = bool(
+            checkpoint_path is not None and checkpoint_path == final_checkpoint_path
+        )
+    return {
+        "records": sorted_records,
+        "successful_records": sorted_successful_records,
+        "failed_records": sorted(
+            [dict(record) for record in failed_records],
+            key=lambda record: int(record["step"]),
+        ),
+        "summary": trace_summary,
+        "checkpoint_count": int(len(sorted_records)),
+        "successful_checkpoint_count": int(len(sorted_successful_records)),
+        "failed_checkpoint_count": int(len(failed_records)),
+        "best_record": None if best_record is None else dict(best_record),
+        "final_record": None if final_record is None else dict(final_record),
+        "best_checkpoint_path": best_checkpoint_path,
+        "final_checkpoint_path": final_checkpoint_path,
+        "last_attempted_step": 0 if not sorted_records else int(sorted_records[-1]["step"]),
+        "last_attempted_checkpoint_path": (
+            None
+            if not sorted_records or sorted_records[-1].get("checkpoint_path") is None
+            else str(sorted_records[-1]["checkpoint_path"])
+        ),
+        "best_to_final_roc_auc_delta": (
+            None
+            if best_record is None or final_record is None
+            else float(final_record["roc_auc"]) - float(best_record["roc_auc"])
+        ),
+        "bootstrap": {
+            "samples": int(bootstrap_samples),
+            "confidence": float(bootstrap_confidence),
+            "seed": int(bootstrap_seed),
+        },
+    }
 
 
 def resolve_device(device: str) -> str:
@@ -630,6 +908,7 @@ def evaluate_tab_foundry_run(
     datasets: Mapping[str, tuple[np.ndarray, np.ndarray]],
     device: str,
     allow_checkpoint_failures: bool = False,
+    allow_missing_values: bool = False,
 ) -> list[dict[str, Any]]:
     """Evaluate smoke-run checkpoints on the notebook benchmark suite."""
 
@@ -641,16 +920,27 @@ def evaluate_tab_foundry_run(
         checkpoint_path = Path(str(snapshot["path"]))
         try:
             classifier = TabFoundryClassifier(checkpoint_path, device=resolved_device)
-            metrics = evaluate_classifier(classifier, datasets)
+            metrics = evaluate_classifier(
+                classifier,
+                datasets,
+                allow_missing_values=allow_missing_values,
+            )
         except Exception as exc:
             if not allow_checkpoint_failures:
                 raise
+            failed_dataset = None
+            error_type = type(exc).__name__
+            if isinstance(exc, BenchmarkDatasetEvaluationError):
+                failed_dataset = exc.dataset_name
+                error_type = str(exc.error_type)
             curve_records.append(
                 {
                     "checkpoint_path": str(checkpoint_path),
                     "step": int(snapshot["step"]),
                     "training_time": float(snapshot["elapsed_seconds"]),
                     "evaluation_error": str(exc),
+                    "evaluation_error_type": error_type,
+                    "failed_dataset": failed_dataset,
                 }
             )
             continue
@@ -829,6 +1119,20 @@ def build_comparison_summary(
             if values
         }
 
+    def _dataset_delta_summary(
+        records: list[dict[str, Any]],
+        *,
+        from_step: float,
+        to_step: float,
+    ) -> dict[str, float]:
+        from_metrics = _dataset_summary(records, step=from_step)
+        to_metrics = _dataset_summary(records, step=to_step)
+        shared_dataset_names = sorted(set(from_metrics) & set(to_metrics))
+        return {
+            dataset_name: float(to_metrics[dataset_name]) - float(from_metrics[dataset_name])
+            for dataset_name in shared_dataset_names
+        }
+
     def _identity(records: list[dict[str, Any]]) -> dict[str, str | None]:
         if not records:
             return {
@@ -845,6 +1149,17 @@ def build_comparison_summary(
             else str(first["benchmark_profile"]),
         }
 
+    tab_foundry_curve = summarize_checkpoint_curve(
+        tab_foundry_records,
+        bootstrap_samples=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SAMPLES,
+        bootstrap_confidence=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE,
+        bootstrap_seed=DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SEED,
+    )
+    tab_foundry_successful_records = cast(
+        list[dict[str, Any]],
+        tab_foundry_curve["successful_records"],
+    )
+    tab_foundry_curve_summary = cast(dict[str, Any], tab_foundry_curve["summary"])
     summary = {
         "dataset_count": int(len(benchmark_tasks)),
         "benchmark_bundle": benchmark_bundle_summary(
@@ -852,9 +1167,22 @@ def build_comparison_summary(
             source_path=benchmark_bundle_path,
         ),
         "tab_foundry": {
-            **_summary_metrics(tab_foundry_records),
+            "best_step": float(tab_foundry_curve_summary["best_step"]),
+            "best_training_time": float(
+                0.0
+                if tab_foundry_curve["best_record"] is None
+                else cast(dict[str, Any], tab_foundry_curve["best_record"])["training_time"]
+            ),
+            "best_roc_auc": float(tab_foundry_curve_summary["best_roc_auc"]),
+            "final_step": float(tab_foundry_curve_summary["final_step"]),
+            "final_training_time": float(
+                0.0
+                if tab_foundry_curve["final_record"] is None
+                else cast(dict[str, Any], tab_foundry_curve["final_record"])["training_time"]
+            ),
+            "final_roc_auc": float(tab_foundry_curve_summary["final_roc_auc"]),
             "run_dir": str(tab_foundry_run_dir.expanduser().resolve()),
-            **_identity(tab_foundry_records),
+            **_identity(tab_foundry_successful_records),
         },
         "nanotabpfn": {
             **_summary_metrics(nanotabpfn_records),
@@ -866,13 +1194,39 @@ def build_comparison_summary(
     tab_foundry_summary = cast(dict[str, Any], summary["tab_foundry"])
     nanotabpfn_summary = cast(dict[str, Any], summary["nanotabpfn"])
     tab_foundry_summary["best_dataset_roc_auc"] = _dataset_summary(
-        tab_foundry_records,
+        tab_foundry_successful_records,
         step=float(tab_foundry_summary["best_step"]),
     )
     tab_foundry_summary["final_dataset_roc_auc"] = _dataset_summary(
-        tab_foundry_records,
+        tab_foundry_successful_records,
         step=float(tab_foundry_summary["final_step"]),
     )
+    tab_foundry_summary["best_to_final_dataset_roc_auc_delta"] = _dataset_delta_summary(
+        tab_foundry_successful_records,
+        from_step=float(tab_foundry_summary["best_step"]),
+        to_step=float(tab_foundry_summary["final_step"]),
+    )
+    tab_foundry_summary["best_to_final_roc_auc_delta"] = tab_foundry_curve[
+        "best_to_final_roc_auc_delta"
+    ]
+    tab_foundry_summary["checkpoint_diagnostics"] = {
+        "checkpoint_count": int(tab_foundry_curve["checkpoint_count"]),
+        "successful_checkpoint_count": int(tab_foundry_curve["successful_checkpoint_count"]),
+        "failed_checkpoint_count": int(tab_foundry_curve["failed_checkpoint_count"]),
+        "task_count": int(tab_foundry_curve_summary["task_count"]),
+        "adjacent_ci_overlap_fraction": tab_foundry_curve_summary[
+            "adjacent_ci_overlap_fraction"
+        ],
+        "best_checkpoint_path": tab_foundry_curve["best_checkpoint_path"],
+        "final_checkpoint_path": tab_foundry_curve["final_checkpoint_path"],
+        "last_attempted_step": int(tab_foundry_curve["last_attempted_step"]),
+        "last_attempted_checkpoint_path": tab_foundry_curve["last_attempted_checkpoint_path"],
+        "bootstrap": dict(cast(dict[str, Any], tab_foundry_curve["bootstrap"])),
+        "best_checkpoint": tab_foundry_curve["best_record"],
+        "final_checkpoint": tab_foundry_curve["final_record"],
+        "checkpoints": cast(list[dict[str, Any]], tab_foundry_curve["records"]),
+        "failed_checkpoints": cast(list[dict[str, Any]], tab_foundry_curve["failed_records"]),
+    }
     nanotabpfn_summary["best_dataset_roc_auc"] = _dataset_summary(
         nanotabpfn_records,
         step=float(nanotabpfn_summary["best_step"]),
@@ -881,6 +1235,14 @@ def build_comparison_summary(
         nanotabpfn_records,
         step=float(nanotabpfn_summary["final_step"]),
     )
+    nanotabpfn_summary["best_to_final_dataset_roc_auc_delta"] = _dataset_delta_summary(
+        nanotabpfn_records,
+        from_step=float(nanotabpfn_summary["best_step"]),
+        to_step=float(nanotabpfn_summary["final_step"]),
+    )
+    nanotabpfn_summary["best_to_final_roc_auc_delta"] = float(
+        nanotabpfn_summary["final_roc_auc"]
+    ) - float(nanotabpfn_summary["best_roc_auc"])
     if math.isnan(float(tab_foundry_summary["final_roc_auc"])):
         raise RuntimeError("tab-foundry benchmark produced no ROC AUC values")
     if math.isnan(float(nanotabpfn_summary["final_roc_auc"])):

--- a/src/tab_foundry/bench/prior_dump.py
+++ b/src/tab_foundry/bench/prior_dump.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from tab_foundry.data.validation import assert_no_non_finite_values
 from tab_foundry.types import TaskBatch
 
 
@@ -33,10 +34,12 @@ class PriorDumpTaskBatchReader:
         *,
         num_steps: int,
         batch_size: int,
+        allow_missing_values: bool = False,
     ) -> None:
         self.path = path.expanduser().resolve()
         self.num_steps = int(num_steps)
         self.batch_size = int(batch_size)
+        self.allow_missing_values = bool(allow_missing_values)
         if self.num_steps <= 0:
             raise ValueError(f"num_steps must be >= 1, got {self.num_steps}")
         if self.batch_size <= 0:
@@ -94,6 +97,17 @@ class PriorDumpTaskBatchReader:
                         dtype=np.float32,
                     )
                 )
+                if not self.allow_missing_values:
+                    assert_no_non_finite_values(
+                        {
+                            "x_batch": x_batch.numpy(),
+                            "y_batch": y_batch.numpy(),
+                        },
+                        context=(
+                            "prior dump batch "
+                            f"path={self.path}, dataset_indices={batch_dataset_indices}"
+                        ),
+                    )
                 tasks: list[TaskBatch] = []
                 for local_index, dataset_index in enumerate(batch_dataset_indices):
                     n_features = int(num_features[local_index])

--- a/src/tab_foundry/cli/commands/build_manifest.py
+++ b/src/tab_foundry/cli/commands/build_manifest.py
@@ -16,13 +16,16 @@ def _run(args: argparse.Namespace) -> int:
         train_ratio=args.train_ratio,
         val_ratio=args.val_ratio,
         filter_policy=str(args.filter_policy),
+        missing_value_policy=str(args.missing_value_policy),
     )
     print(
         "Manifest built:",
         f"path={summary.out_path}",
         f"filter_policy={summary.filter_policy}",
+        f"missing_value_policy={summary.missing_value_policy}",
         f"discovered={summary.discovered_records}",
         f"excluded={summary.excluded_records}",
+        f"excluded_for_missing_values={summary.excluded_for_missing_values}",
         f"total={summary.total_records}",
         f"train={summary.train_records}",
         f"val={summary.val_records}",
@@ -33,6 +36,11 @@ def _run(args: argparse.Namespace) -> int:
             f"{status}={count}" for status, count in summary.filter_status_counts.items()
         )
         print("Filter status counts:", counts)
+    if summary.missing_value_status_counts:
+        counts = ", ".join(
+            f"{status}={count}" for status, count in summary.missing_value_status_counts.items()
+        )
+        print("Missing-value status counts:", counts)
     for warning in summary.warnings:
         print("Warning:", warning)
     return 0
@@ -58,5 +66,10 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         default="include_all",
         help="Dataset selection policy based on dagzoo filter metadata",
     )
+    parser.add_argument(
+        "--missing-value-policy",
+        choices=("allow_any", "forbid_any"),
+        default="allow_any",
+        help="Dataset selection policy for NaN/Inf-containing inputs",
+    )
     parser.set_defaults(func=_run)
-

--- a/src/tab_foundry/data/dataset.py
+++ b/src/tab_foundry/data/dataset.py
@@ -13,6 +13,7 @@ import pyarrow.parquet as pq
 import torch
 from torch.utils.data import Dataset
 
+from tab_foundry.data.validation import assert_no_non_finite_values
 from tab_foundry.preprocessing import preprocess_runtime_task_arrays
 from tab_foundry.types import TaskBatch
 
@@ -246,6 +247,7 @@ class PackedParquetTaskDataset(Dataset[TaskBatch]):
         all_nan_fill: float = 0.0,
         label_mapping: str = "train_only_remap",
         unseen_test_label_policy: str = "filter",
+        allow_missing_values: bool = False,
         seed: int = 0,
     ) -> None:
         self.manifest_path = manifest_path.expanduser().resolve()
@@ -257,6 +259,7 @@ class PackedParquetTaskDataset(Dataset[TaskBatch]):
         self.all_nan_fill = float(all_nan_fill)
         self.label_mapping = str(label_mapping)
         self.unseen_test_label_policy = str(unseen_test_label_policy)
+        self.allow_missing_values = bool(allow_missing_values)
         self.seed = int(seed)
 
         table = pq.read_table(self.manifest_path)
@@ -274,6 +277,14 @@ class PackedParquetTaskDataset(Dataset[TaskBatch]):
 
     def __getitem__(self, index: int) -> TaskBatch:
         record = self.records[index]
+        if (
+            not self.allow_missing_values
+            and str(record.get("missing_value_status", "")).strip() == "contains_nan_or_inf"
+        ):
+            raise RuntimeError(
+                "manifest record contains NaN or Inf while allow_missing_values=False: "
+                f"dataset_id={record.get('dataset_id')!r}, manifest_path={self.manifest_path}"
+            )
         loaded = _load_manifest_task_record(
             self.manifest_path,
             split=self.split,
@@ -285,6 +296,19 @@ class PackedParquetTaskDataset(Dataset[TaskBatch]):
         x_test = loaded.x_test
         y_test = loaded.y_test
         metadata = loaded.metadata
+        if not self.allow_missing_values:
+            assert_no_non_finite_values(
+                {
+                    "x_train": x_train,
+                    "y_train": y_train,
+                    "x_test": x_test,
+                    "y_test": y_test,
+                },
+                context=(
+                    "manifest-backed task dataset "
+                    f"dataset_id={record.get('dataset_id')!r}"
+                ),
+            )
 
         x_train, y_train = _subsample_rows(
             x_train,

--- a/src/tab_foundry/data/manifest.py
+++ b/src/tab_foundry/data/manifest.py
@@ -10,8 +10,19 @@ import os
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+
+from tab_foundry.data.validation import (
+    MISSING_VALUE_STATUS_CLEAN,
+    MISSING_VALUE_STATUS_CONTAINS_NAN_OR_INF,
+    SUPPORTED_MISSING_VALUE_POLICIES,
+    missing_value_status,
+)
+
+
+_MANIFEST_SUMMARY_METADATA_KEY = b"tab_foundry_manifest_summary"
 
 
 @dataclass(slots=True)
@@ -26,7 +37,10 @@ class ManifestSummary:
     train_records: int
     val_records: int
     test_records: int
+    missing_value_policy: str = "allow_any"
+    excluded_for_missing_values: int = 0
     filter_status_counts: dict[str, int] = field(default_factory=dict)
+    missing_value_status_counts: dict[str, int] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
 
 
@@ -138,8 +152,10 @@ def _is_record_selected(
 def _build_manifest_warnings(
     *,
     filter_policy: str,
+    missing_value_policy: str,
     selected_records: int,
     excluded_records: int,
+    excluded_for_missing_values: int,
     filter_status_counts: Counter[str],
 ) -> list[str]:
     warnings: list[str] = []
@@ -158,6 +174,12 @@ def _build_manifest_warnings(
     elif excluded_records > 0:
         warnings.append(
             f"Excluded {excluded_records} dataset(s) under filter_policy={filter_policy}."
+        )
+    if missing_value_policy == "forbid_any" and excluded_for_missing_values > 0:
+        warnings.append(
+            "Excluded "
+            f"{excluded_for_missing_values} dataset(s) containing NaN or Inf under "
+            "missing_value_policy=forbid_any."
         )
 
     if selected_records <= 0:
@@ -225,6 +247,50 @@ def _coerce_optional_int(value: Any, *, default: int, context: str) -> int:
         raise RuntimeError(f"{context} must be int-compatible or null, got {value!r}") from exc
 
 
+def _missing_value_status_by_dataset(split_path: Path) -> dict[int, str]:
+    """Summarize non-finite status for each dataset_index in one packed split parquet."""
+
+    try:
+        table = pq.read_table(split_path, columns=["dataset_index", "x", "y"])
+    except Exception as exc:  # pragma: no cover - pyarrow error typing is backend-specific
+        raise RuntimeError(f"failed to scan packed split for missing values: {split_path}") from exc
+
+    if table.num_rows <= 0:
+        return {}
+
+    dataset_indices = table["dataset_index"].to_pylist()
+    x_rows = table["x"].to_pylist()
+    y_values = table["y"].to_pylist()
+    status_by_dataset: dict[int, str] = {}
+    for dataset_index, x_row, y_value in zip(dataset_indices, x_rows, y_values, strict=False):
+        key = int(dataset_index)
+        if status_by_dataset.get(key) == MISSING_VALUE_STATUS_CONTAINS_NAN_OR_INF:
+            continue
+        current = missing_value_status(
+            {"x": x_row, "y": np.asarray([y_value])},
+            context=f"packed split {split_path} dataset_index={key}",
+        )
+        status_by_dataset[key] = current
+    return status_by_dataset
+
+
+def _manifest_schema_metadata(*, summary: ManifestSummary) -> dict[bytes, bytes]:
+    payload = {
+        "filter_policy": summary.filter_policy,
+        "missing_value_policy": summary.missing_value_policy,
+        "discovered_records": int(summary.discovered_records),
+        "excluded_records": int(summary.excluded_records),
+        "excluded_for_missing_values": int(summary.excluded_for_missing_values),
+        "total_records": int(summary.total_records),
+        "train_records": int(summary.train_records),
+        "val_records": int(summary.val_records),
+        "test_records": int(summary.test_records),
+        "filter_status_counts": dict(summary.filter_status_counts),
+        "missing_value_status_counts": dict(summary.missing_value_status_counts),
+    }
+    return {_MANIFEST_SUMMARY_METADATA_KEY: json.dumps(payload, sort_keys=True).encode("utf-8")}
+
+
 def build_manifest(
     data_roots: list[Path],
     out_path: Path,
@@ -232,6 +298,7 @@ def build_manifest(
     train_ratio: float = 0.90,
     val_ratio: float = 0.05,
     filter_policy: str = "include_all",
+    missing_value_policy: str = "allow_any",
 ) -> ManifestSummary:
     """Scan parquet roots and persist manifest parquet."""
 
@@ -243,6 +310,11 @@ def build_manifest(
         raise ValueError(
             f"filter_policy must be one of {SUPPORTED_FILTER_POLICIES}, got {filter_policy!r}"
         )
+    if missing_value_policy not in SUPPORTED_MISSING_VALUE_POLICIES:
+        raise ValueError(
+            "missing_value_policy must be one of "
+            f"{SUPPORTED_MISSING_VALUE_POLICIES}, got {missing_value_policy!r}"
+        )
 
     out_path = out_path.expanduser().resolve()
     manifest_dir = out_path.parent
@@ -251,6 +323,8 @@ def build_manifest(
     records: list[dict[str, Any]] = []
     discovered_records = 0
     status_counts: Counter[str] = Counter()
+    missing_value_status_counts: Counter[str] = Counter()
+    excluded_for_missing_values = 0
     for root in roots:
         if not root.exists():
             continue
@@ -261,6 +335,8 @@ def build_manifest(
             metadata_path = shard_dir / "metadata.ndjson"
             if not (train_path.exists() and test_path.exists() and metadata_path.exists()):
                 continue
+            train_missing_status = _missing_value_status_by_dataset(train_path)
+            test_missing_status = _missing_value_status_by_dataset(test_path)
 
             shard_id = _extract_shard_id(shard_dir)
             for offset, size, record_sha256, record in _read_metadata_records(metadata_path):
@@ -286,6 +362,27 @@ def build_manifest(
                     filter_status=filter_status,
                     filter_accepted=filter_accepted,
                 ):
+                    continue
+                train_missing_value_status = train_missing_status.get(
+                    dataset_index,
+                    MISSING_VALUE_STATUS_CLEAN,
+                )
+                test_missing_value_status = test_missing_status.get(
+                    dataset_index,
+                    MISSING_VALUE_STATUS_CLEAN,
+                )
+                record_missing_value_status = (
+                    MISSING_VALUE_STATUS_CLEAN
+                    if train_missing_value_status == MISSING_VALUE_STATUS_CLEAN
+                    and test_missing_value_status == MISSING_VALUE_STATUS_CLEAN
+                    else MISSING_VALUE_STATUS_CONTAINS_NAN_OR_INF
+                )
+                missing_value_status_counts[record_missing_value_status] += 1
+                if (
+                    missing_value_policy == "forbid_any"
+                    and record_missing_value_status != MISSING_VALUE_STATUS_CLEAN
+                ):
+                    excluded_for_missing_values += 1
                     continue
 
                 dsid = _dataset_id(
@@ -327,6 +424,8 @@ def build_manifest(
                         "filter_mode": filter_mode,
                         "filter_status": filter_status,
                         "filter_accepted": filter_accepted,
+                        "missing_value_policy": missing_value_policy,
+                        "missing_value_status": record_missing_value_status,
                     }
                 )
 
@@ -334,7 +433,9 @@ def build_manifest(
         raise RuntimeError("no datasets discovered while building manifest")
     if not records:
         raise RuntimeError(
-            f"no datasets matched filter_policy={filter_policy!r} while building manifest"
+            "no datasets matched "
+            f"filter_policy={filter_policy!r} and missing_value_policy={missing_value_policy!r} "
+            "while building manifest"
         )
 
     records.sort(
@@ -348,27 +449,34 @@ def build_manifest(
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    table = pa.Table.from_pylist(records)
-    pq.write_table(table, out_path, compression="zstd")
-
     train_records = sum(1 for record in records if record["split"] == "train")
     val_records = sum(1 for record in records if record["split"] == "val")
     test_records = sum(1 for record in records if record["split"] == "test")
     excluded_records = discovered_records - len(records)
-    return ManifestSummary(
+    summary = ManifestSummary(
         out_path=out_path,
         filter_policy=filter_policy,
+        missing_value_policy=missing_value_policy,
         discovered_records=discovered_records,
         excluded_records=excluded_records,
+        excluded_for_missing_values=excluded_for_missing_values,
         total_records=len(records),
         train_records=train_records,
         val_records=val_records,
         test_records=test_records,
         filter_status_counts=dict(sorted(status_counts.items())),
+        missing_value_status_counts=dict(sorted(missing_value_status_counts.items())),
         warnings=_build_manifest_warnings(
             filter_policy=filter_policy,
+            missing_value_policy=missing_value_policy,
             selected_records=len(records),
             excluded_records=excluded_records,
+            excluded_for_missing_values=excluded_for_missing_values,
             filter_status_counts=status_counts,
         ),
     )
+    table = pa.Table.from_pylist(records).replace_schema_metadata(
+        _manifest_schema_metadata(summary=summary)
+    )
+    pq.write_table(table, out_path, compression="zstd")
+    return summary

--- a/src/tab_foundry/data/sources/manifest.py
+++ b/src/tab_foundry/data/sources/manifest.py
@@ -39,5 +39,6 @@ def build_manifest_task_dataset(
         all_nan_fill=float(preprocessing_surface.all_nan_fill),
         label_mapping=str(preprocessing_surface.label_mapping),
         unseen_test_label_policy=str(preprocessing_surface.unseen_test_label_policy),
+        allow_missing_values=bool(data_surface.allow_missing_values),
         seed=seed,
     )

--- a/src/tab_foundry/data/surface.py
+++ b/src/tab_foundry/data/surface.py
@@ -21,6 +21,7 @@ class DataSurfaceConfig:
     source: str
     manifest_path: Path | None
     filter_policy: str | None
+    allow_missing_values: bool
     train_row_cap: int | None
     test_row_cap: int | None
     dagzoo_provenance: dict[str, Any] | None
@@ -53,6 +54,10 @@ def resolve_data_surface(data_cfg: Mapping[str, Any] | None) -> DataSurfaceConfi
     if filter_policy_raw is None:
         filter_policy_raw = cfg.get("filter_policy")
     filter_policy = None if filter_policy_raw is None else str(filter_policy_raw).strip()
+    allow_missing_values_raw = overrides.get("allow_missing_values")
+    if allow_missing_values_raw is None:
+        allow_missing_values_raw = cfg.get("allow_missing_values")
+    allow_missing_values = bool(allow_missing_values_raw) if allow_missing_values_raw is not None else False
     dagzoo_provenance_raw = overrides.get("dagzoo_provenance")
     if dagzoo_provenance_raw is None:
         dagzoo_provenance_raw = cfg.get("dagzoo_provenance")
@@ -80,6 +85,7 @@ def resolve_data_surface(data_cfg: Mapping[str, Any] | None) -> DataSurfaceConfi
         source=source,
         manifest_path=manifest_path,
         filter_policy=filter_policy,
+        allow_missing_values=allow_missing_values,
         train_row_cap=None if train_row_cap_raw is None else int(train_row_cap_raw),
         test_row_cap=None if test_row_cap_raw is None else int(test_row_cap_raw),
         dagzoo_provenance=dagzoo_provenance,

--- a/src/tab_foundry/data/validation.py
+++ b/src/tab_foundry/data/validation.py
@@ -1,0 +1,55 @@
+"""Shared numeric validation helpers for dataset inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+MISSING_VALUE_STATUS_CLEAN = "clean"
+MISSING_VALUE_STATUS_CONTAINS_NAN_OR_INF = "contains_nan_or_inf"
+SUPPORTED_MISSING_VALUE_POLICIES = ("allow_any", "forbid_any")
+
+
+def _numeric_array(value: Any, *, context: str) -> np.ndarray:
+    array = np.asarray(value)
+    if np.issubdtype(array.dtype, np.number) or np.issubdtype(array.dtype, np.bool_):
+        return array
+    try:
+        return np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"{context} must be numeric to validate missing-value policy") from exc
+
+
+def contains_non_finite_values(value: Any, *, context: str) -> bool:
+    """Return whether a numeric tensor/array/list contains NaN or Inf."""
+
+    array = _numeric_array(value, context=context)
+    if array.size <= 0:
+        return False
+    return bool(np.any(~np.isfinite(array)))
+
+
+def missing_value_status(named_arrays: Mapping[str, Any], *, context: str) -> str:
+    """Summarize whether any named arrays contain NaN or Inf."""
+
+    for name, value in named_arrays.items():
+        if contains_non_finite_values(value, context=f"{context}.{name}"):
+            return MISSING_VALUE_STATUS_CONTAINS_NAN_OR_INF
+    return MISSING_VALUE_STATUS_CLEAN
+
+
+def assert_no_non_finite_values(named_arrays: Mapping[str, Any], *, context: str) -> None:
+    """Raise when any named arrays contain NaN or Inf."""
+
+    offenders = [
+        name
+        for name, value in named_arrays.items()
+        if contains_non_finite_values(value, context=f"{context}.{name}")
+    ]
+    if offenders:
+        joined = ", ".join(offenders)
+        raise RuntimeError(
+            f"{context} contains NaN or Inf in {joined} while allow_missing_values=False"
+        )

--- a/src/tab_foundry/training/surface.py
+++ b/src/tab_foundry/training/surface.py
@@ -21,6 +21,7 @@ from tab_foundry.preprocessing import resolve_preprocessing_surface
 
 
 TRAINING_SURFACE_SCHEMA = "tab-foundry-training-surface-v1"
+_MANIFEST_SUMMARY_METADATA_KEY = b"tab_foundry_manifest_summary"
 
 
 def _utc_now() -> str:
@@ -50,11 +51,29 @@ def _distribution(values: list[int]) -> dict[str, Any]:
 
 
 def _manifest_characteristics(manifest_path: Path) -> dict[str, Any]:
-    table = pq.read_table(manifest_path)
+    parquet_file = pq.ParquetFile(manifest_path)
+    table = parquet_file.read()
     rows = table.to_pylist()
+    missing_value_statuses = [
+        str(status).strip()
+        if isinstance((status := row.get("missing_value_status")), str) and str(status).strip()
+        else None
+        for row in rows
+    ]
     split_counts = Counter(str(row.get("split", "missing")) for row in rows)
     task_counts = Counter(str(row.get("task", "missing")) for row in rows)
     filter_status_counts = Counter(str(row.get("filter_status", "missing")) for row in rows)
+    missing_value_status_counts = Counter(str(row.get("missing_value_status", "missing")) for row in rows)
+    has_complete_missing_value_metadata = bool(rows) and all(
+        status is not None for status in missing_value_statuses
+    )
+    missing_value_policies = sorted(
+        {
+            str(row["missing_value_policy"])
+            for row in rows
+            if isinstance(row.get("missing_value_policy"), str) and row["missing_value_policy"].strip()
+        }
+    )
     source_root_ids = sorted(
         {
             str(row["source_root_id"])
@@ -82,6 +101,11 @@ def _manifest_characteristics(manifest_path: Path) -> dict[str, Any]:
         for row in rows
         if row.get("n_classes") is not None
     ]
+    raw_metadata = parquet_file.schema_arrow.metadata or {}
+    persisted_summary = None
+    raw_summary = raw_metadata.get(_MANIFEST_SUMMARY_METADATA_KEY)
+    if raw_summary is not None:
+        persisted_summary = json.loads(raw_summary.decode("utf-8"))
     return {
         "record_count": int(len(rows)),
         "split_counts": dict(sorted(split_counts.items())),
@@ -90,6 +114,14 @@ def _manifest_characteristics(manifest_path: Path) -> dict[str, Any]:
         "feature_count_distribution": _distribution(n_features),
         "class_count_distribution": _distribution(n_classes),
         "filter_status_counts": dict(sorted(filter_status_counts.items())),
+        "missing_value_status_counts": dict(sorted(missing_value_status_counts.items())),
+        "missing_value_policy": None if len(missing_value_policies) != 1 else missing_value_policies[0],
+        "all_records_no_missing": (
+            None
+            if not has_complete_missing_value_metadata
+            else missing_value_status_counts.get("contains_nan_or_inf", 0) == 0
+        ),
+        "persisted_summary": persisted_summary,
         "source_root_ids": source_root_ids,
         "source_shard_relpath_summary": {
             "unique_count": int(len(shard_counts)),
@@ -204,6 +236,7 @@ def build_training_surface_record(
             "surface_label": data_label,
             "source": str(data_surface.source),
             "filter_policy": data_surface.filter_policy,
+            "allow_missing_values": bool(data_surface.allow_missing_values),
             "manifest": manifest_payload,
             "dagzoo_provenance": data_surface.dagzoo_provenance,
             "train_row_cap": data_surface.train_row_cap,

--- a/tests/benchmark/test_bounce_diagnosis.py
+++ b/tests/benchmark/test_bounce_diagnosis.py
@@ -11,13 +11,17 @@ import tab_foundry.bench.bounce_diagnosis as diagnosis_module
 import tab_foundry.bench.nanotabpfn as benchmark_module
 
 
-def test_default_confirmation_bundle_is_larger_than_medium() -> None:
-    medium = benchmark_module.load_benchmark_bundle(benchmark_module.default_benchmark_bundle_path())
-    large = benchmark_module.load_benchmark_bundle(
-        diagnosis_module.default_confirmation_benchmark_bundle_path()
+def test_mainline_bundle_loader_rejects_missing_permitting_large_bundle_by_default() -> None:
+    large_bundle_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tab_foundry"
+        / "bench"
+        / "nanotabpfn_openml_binary_large_v1.json"
     )
 
-    assert int(len(large["task_ids"])) > int(len(medium["task_ids"]))
+    with pytest.raises(RuntimeError, match="permits missing-valued inputs"):
+        _ = benchmark_module.load_benchmark_bundle(large_bundle_path)
 
 
 def test_annotate_curve_records_with_task_statistics_adds_dataset_count_and_ci() -> None:
@@ -56,15 +60,38 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
     confirmation_bundle_path = tmp_path / "large.json"
     primary_bundle_path.write_text("{}", encoding="utf-8")
     confirmation_bundle_path.write_text("{}", encoding="utf-8")
+    policy_calls: list[tuple[str, bool]] = []
 
-    def _fake_load_bundle(path: Path | None = None) -> dict[str, Any]:
+    def _fake_load_bundle(path: Path | None = None) -> tuple[dict[str, Any], bool]:
         resolved = None if path is None else Path(path).resolve()
         if resolved == confirmation_bundle_path.resolve():
-            return {
-                "name": "large",
+            policy_calls.append(("load_confirmation", True))
+            return (
+                {
+                    "name": "large",
+                    "version": 1,
+                    "selection": {"new_instances": 4, "max_missing_pct": 5.0},
+                    "task_ids": list(range(1, 13)),
+                    "tasks": [
+                        {
+                            "task_id": task_id,
+                            "dataset_name": f"d{task_id}",
+                            "n_rows": 4,
+                            "n_features": 2,
+                            "n_classes": 2,
+                        }
+                        for task_id in range(1, 13)
+                    ],
+                },
+                True,
+            )
+        policy_calls.append(("load_primary", False))
+        return (
+            {
+                "name": "medium",
                 "version": 1,
-                "selection": {"new_instances": 4},
-                "task_ids": list(range(1, 13)),
+                "selection": {"new_instances": 4, "max_missing_pct": 0.0},
+                "task_ids": list(range(1, 11)),
                 "tasks": [
                     {
                         "task_id": task_id,
@@ -73,33 +100,21 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
                         "n_features": 2,
                         "n_classes": 2,
                     }
-                    for task_id in range(1, 13)
+                    for task_id in range(1, 11)
                 ],
-            }
-        return {
-            "name": "medium",
-            "version": 1,
-            "selection": {"new_instances": 4},
-            "task_ids": list(range(1, 11)),
-            "tasks": [
-                {
-                    "task_id": task_id,
-                    "dataset_name": f"d{task_id}",
-                    "n_rows": 4,
-                    "n_features": 2,
-                    "n_classes": 2,
-                }
-                for task_id in range(1, 11)
-            ],
-        }
+            },
+            False,
+        )
 
     def _fake_load_datasets(
         *,
         new_instances: int,
         benchmark_bundle_path: Path | None = None,
+        allow_missing_values: bool = False,
     ) -> tuple[dict[str, tuple[list[float], list[int]]], list[dict[str, Any]]]:
         del new_instances
         if benchmark_bundle_path is not None and Path(benchmark_bundle_path).resolve() == confirmation_bundle_path.resolve():
+            policy_calls.append(("datasets_confirmation", bool(allow_missing_values)))
             return (
                 {f"d{task_id}": ([0.0], [0]) for task_id in range(1, 13)},
                 [
@@ -113,6 +128,7 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
                     for task_id in range(1, 13)
                 ],
             )
+        policy_calls.append(("datasets_primary", bool(allow_missing_values)))
         return (
             {f"d{task_id}": ([0.0], [0]) for task_id in range(1, 11)},
             [
@@ -133,10 +149,12 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
         datasets: dict[str, tuple[list[float], list[int]]],
         device: str,
         allow_checkpoint_failures: bool = False,
+        allow_missing_values: bool = False,
     ) -> list[dict[str, Any]]:
         assert device == "cpu"
         assert allow_checkpoint_failures is True
         if len(datasets) == 12:
+            policy_calls.append(("evaluate_confirmation", bool(allow_missing_values)))
             return [
                 {
                     "checkpoint_path": "/tmp/step_000025.pt",
@@ -153,6 +171,7 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
                     "dataset_roc_auc": {f"d{task_id}": 0.74 + (0.005 * (task_id % 2)) for task_id in range(1, 13)},
                 },
             ]
+        policy_calls.append(("evaluate_primary", bool(allow_missing_values)))
         return [
                 {
                     "checkpoint_path": "/tmp/step_000025.pt",
@@ -176,7 +195,11 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
                 },
             ]
 
-    monkeypatch.setattr(diagnosis_module, "load_benchmark_bundle", _fake_load_bundle)
+    monkeypatch.setattr(
+        diagnosis_module,
+        "load_benchmark_bundle_for_execution",
+        _fake_load_bundle,
+    )
     monkeypatch.setattr(diagnosis_module, "load_openml_benchmark_datasets", _fake_load_datasets)
     monkeypatch.setattr(diagnosis_module, "evaluate_tab_foundry_run", _fake_evaluate_run)
     monkeypatch.setattr(
@@ -206,6 +229,14 @@ def test_run_benchmark_bounce_diagnosis_writes_summary_and_flags_benchmark_noise
     assert written["schema"] == diagnosis_module.DIAGNOSIS_SCHEMA
     assert Path(written["artifacts"]["primary_bundle_curve_jsonl"]).exists()
     assert Path(written["artifacts"]["confirmation_bundle_curve_jsonl"]).exists()
+    assert policy_calls == [
+        ("load_primary", False),
+        ("datasets_primary", False),
+        ("evaluate_primary", False),
+        ("load_confirmation", True),
+        ("datasets_confirmation", True),
+        ("evaluate_confirmation", True),
+    ]
 
 
 def test_run_benchmark_bounce_diagnosis_dense_rerun_uses_prior_path_and_flags_aliasing(
@@ -344,3 +375,253 @@ def test_run_benchmark_bounce_diagnosis_dense_rerun_uses_prior_path_and_flags_al
         }
     ]
     assert "checkpoint_aliasing" in summary["classification"]["primary_causes"]
+
+
+def test_run_benchmark_bounce_diagnosis_without_confirmation_uses_primary_bundle_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "train_history.jsonl").write_text("{}\n", encoding="utf-8")
+    out_root = tmp_path / "diagnosis"
+    primary_bundle_path = tmp_path / "medium.json"
+    primary_bundle_path.write_text("{}", encoding="utf-8")
+    policy_calls: list[tuple[str, bool]] = []
+
+    def _fake_load_bundle(path: Path | None = None) -> tuple[dict[str, Any], bool]:
+        assert path is not None
+        assert Path(path).resolve() == primary_bundle_path.resolve()
+        policy_calls.append(("load_primary", False))
+        return (
+                {
+                    "name": "medium",
+                    "version": 1,
+                    "selection": {"new_instances": 4, "max_missing_pct": 0.0},
+                    "task_ids": [1, 2],
+                "tasks": [
+                    {"task_id": 1, "dataset_name": "d1", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                    {"task_id": 2, "dataset_name": "d2", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                ],
+            },
+            False,
+        )
+
+    def _fake_load_datasets(
+        *,
+        new_instances: int,
+        benchmark_bundle_path: Path | None = None,
+        allow_missing_values: bool = False,
+    ) -> tuple[dict[str, tuple[list[float], list[int]]], list[dict[str, Any]]]:
+        assert new_instances == 4
+        assert benchmark_bundle_path is not None
+        assert Path(benchmark_bundle_path).resolve() == primary_bundle_path.resolve()
+        policy_calls.append(("datasets_primary", bool(allow_missing_values)))
+        return (
+            {"d1": ([0.0], [0]), "d2": ([0.0], [0])},
+            [
+                {"task_id": 1, "dataset_name": "d1", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                {"task_id": 2, "dataset_name": "d2", "n_rows": 4, "n_features": 2, "n_classes": 2},
+            ],
+        )
+
+    def _fake_evaluate_run(
+        _run_dir: Path,
+        *,
+        datasets: dict[str, tuple[list[float], list[int]]],
+        device: str,
+        allow_checkpoint_failures: bool = False,
+        allow_missing_values: bool = False,
+    ) -> list[dict[str, Any]]:
+        assert device == "cpu"
+        assert allow_checkpoint_failures is True
+        assert allow_missing_values is False
+        policy_calls.append(("evaluate_primary", bool(allow_missing_values)))
+        assert list(datasets) == ["d1", "d2"]
+        return [
+            {
+                "checkpoint_path": "/tmp/step_000025.pt",
+                "step": 25,
+                "training_time": 1.0,
+                "roc_auc": 0.71,
+                "dataset_roc_auc": {"d1": 0.72, "d2": 0.70},
+            },
+            {
+                "checkpoint_path": "/tmp/step_000050.pt",
+                "step": 50,
+                "training_time": 2.0,
+                "roc_auc": 0.70,
+                "dataset_roc_auc": {"d1": 0.71, "d2": 0.69},
+            },
+        ]
+
+    monkeypatch.setattr(
+        diagnosis_module,
+        "load_benchmark_bundle_for_execution",
+        _fake_load_bundle,
+    )
+    monkeypatch.setattr(diagnosis_module, "load_openml_benchmark_datasets", _fake_load_datasets)
+    monkeypatch.setattr(diagnosis_module, "evaluate_tab_foundry_run", _fake_evaluate_run)
+    monkeypatch.setattr(
+        diagnosis_module,
+        "load_history",
+        lambda _path: [
+            {"step": 25, "train_loss": 0.5, "grad_norm": 1.0},
+            {"step": 50, "train_loss": 0.49, "grad_norm": 1.1},
+        ],
+    )
+
+    summary = diagnosis_module.run_benchmark_bounce_diagnosis(
+        diagnosis_module.BenchmarkBounceDiagnosisConfig(
+            run_dir=run_dir,
+            out_root=out_root,
+            device="cpu",
+            benchmark_bundle_path=primary_bundle_path,
+            bootstrap_samples=64,
+        )
+    )
+
+    assert summary["bundles"]["confirmation"] is None
+    assert summary["artifacts"]["confirmation_bundle_curve_jsonl"] is None
+    assert summary["bundle_analysis"]["confirmation"] is None
+    assert policy_calls == [
+        ("load_primary", False),
+        ("datasets_primary", False),
+        ("evaluate_primary", False),
+    ]
+
+
+def test_run_benchmark_bounce_diagnosis_dense_confirmation_inherits_missing_value_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    dense_run_dir = tmp_path / "dense_run"
+    dense_run_dir.mkdir()
+    (run_dir / "train_history.jsonl").write_text("{}\n", encoding="utf-8")
+    out_root = tmp_path / "diagnosis"
+    primary_bundle_path = tmp_path / "medium.json"
+    confirmation_bundle_path = tmp_path / "large.json"
+    primary_bundle_path.write_text("{}", encoding="utf-8")
+    confirmation_bundle_path.write_text("{}", encoding="utf-8")
+    policy_calls: list[tuple[str, bool]] = []
+
+    def _fake_load_bundle(path: Path | None = None) -> tuple[dict[str, Any], bool]:
+        assert path is not None
+        resolved = Path(path).resolve()
+        if resolved == confirmation_bundle_path.resolve():
+            policy_calls.append(("load_large", True))
+            return (
+                {
+                    "name": "large",
+                    "version": 1,
+                    "selection": {"new_instances": 4, "max_missing_pct": 5.0},
+                    "task_ids": [1, 2],
+                    "tasks": [
+                        {"task_id": 1, "dataset_name": "d1", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                        {"task_id": 2, "dataset_name": "d2", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                    ],
+                },
+                True,
+            )
+        policy_calls.append(("load_medium", False))
+        return (
+            {
+                "name": "medium",
+                "version": 1,
+                "selection": {"new_instances": 4, "max_missing_pct": 0.0},
+                "task_ids": [1, 2],
+                "tasks": [
+                    {"task_id": 1, "dataset_name": "d1", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                    {"task_id": 2, "dataset_name": "d2", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                ],
+            },
+            False,
+        )
+
+    def _fake_load_datasets(
+        *,
+        new_instances: int,
+        benchmark_bundle_path: Path | None = None,
+        allow_missing_values: bool = False,
+    ) -> tuple[dict[str, tuple[list[float], list[int]]], list[dict[str, Any]]]:
+        assert new_instances == 4
+        assert benchmark_bundle_path is not None
+        resolved = Path(benchmark_bundle_path).resolve()
+        label = "datasets_large" if resolved == confirmation_bundle_path.resolve() else "datasets_medium"
+        policy_calls.append((label, bool(allow_missing_values)))
+        return (
+            {"d1": ([0.0], [0]), "d2": ([0.0], [0])},
+            [
+                {"task_id": 1, "dataset_name": "d1", "n_rows": 4, "n_features": 2, "n_classes": 2},
+                {"task_id": 2, "dataset_name": "d2", "n_rows": 4, "n_features": 2, "n_classes": 2},
+            ],
+        )
+
+    def _fake_evaluate_run(
+        actual_run_dir: Path,
+        *,
+        datasets: dict[str, tuple[list[float], list[int]]],
+        device: str,
+        allow_checkpoint_failures: bool = False,
+        allow_missing_values: bool = False,
+    ) -> list[dict[str, Any]]:
+        assert device == "cpu"
+        assert allow_checkpoint_failures is True
+        assert list(datasets) == ["d1", "d2"]
+        label = "evaluate_dense" if Path(actual_run_dir).resolve() == dense_run_dir.resolve() else "evaluate_run"
+        policy_calls.append((label, bool(allow_missing_values)))
+        return [
+            {
+                "checkpoint_path": "/tmp/step_000025.pt",
+                "step": 25,
+                "training_time": 1.0,
+                "roc_auc": 0.71 if not allow_missing_values else 0.72,
+                "dataset_roc_auc": {"d1": 0.72, "d2": 0.70},
+            },
+            {
+                "checkpoint_path": "/tmp/step_000050.pt",
+                "step": 50,
+                "training_time": 2.0,
+                "roc_auc": 0.70 if not allow_missing_values else 0.71,
+                "dataset_roc_auc": {"d1": 0.71, "d2": 0.69},
+            },
+        ]
+
+    monkeypatch.setattr(diagnosis_module, "load_benchmark_bundle_for_execution", _fake_load_bundle)
+    monkeypatch.setattr(diagnosis_module, "load_openml_benchmark_datasets", _fake_load_datasets)
+    monkeypatch.setattr(diagnosis_module, "evaluate_tab_foundry_run", _fake_evaluate_run)
+    monkeypatch.setattr(diagnosis_module, "_run_dense_checkpoint_rerun", lambda _config: dense_run_dir)
+    monkeypatch.setattr(
+        diagnosis_module,
+        "load_history",
+        lambda _path: [
+            {"step": 25, "train_loss": 0.5, "grad_norm": 1.0},
+            {"step": 50, "train_loss": 0.49, "grad_norm": 1.1},
+        ],
+    )
+
+    summary = diagnosis_module.run_benchmark_bounce_diagnosis(
+        diagnosis_module.BenchmarkBounceDiagnosisConfig(
+            run_dir=run_dir,
+            out_root=out_root,
+            device="cpu",
+            benchmark_bundle_path=primary_bundle_path,
+            confirmation_benchmark_bundle_path=confirmation_bundle_path,
+            dense_checkpoint_every=10,
+        )
+    )
+
+    assert summary["bundles"]["confirmation"]["benchmark_bundle"]["allow_missing_values"] is True
+    assert policy_calls == [
+        ("load_medium", False),
+        ("datasets_medium", False),
+        ("evaluate_run", False),
+        ("load_large", True),
+        ("datasets_large", True),
+        ("evaluate_run", True),
+        ("load_large", True),
+        ("datasets_large", True),
+        ("evaluate_dense", True),
+    ]

--- a/tests/benchmark/test_control_baseline.py
+++ b/tests/benchmark/test_control_baseline.py
@@ -33,6 +33,7 @@ def _write_comparison_summary(
     run_dir: Path,
     benchmark_bundle_source_path: str,
     final_roc_auc: float = 0.83,
+    include_diagnostics: bool = False,
 ) -> Path:
     payload = {
         "dataset_count": 1,
@@ -42,6 +43,16 @@ def _write_comparison_summary(
             "source_path": benchmark_bundle_source_path,
             "task_count": 1,
             "task_ids": [1],
+            "selection": {
+                "new_instances": 6,
+                "task_type": "supervised_classification",
+                "max_features": 10,
+                "max_classes": 2,
+                "max_missing_pct": 0.0,
+                "min_minority_class_pct": 2.5,
+            },
+            "allow_missing_values": False,
+            "all_tasks_no_missing": True,
         },
         "tab_foundry": {
             "best_step": 25.0,
@@ -64,6 +75,90 @@ def _write_comparison_summary(
             "num_seeds": 2,
         },
     }
+    if include_diagnostics:
+        payload["tab_foundry"]["best_to_final_roc_auc_delta"] = float(final_roc_auc) - 0.81
+        payload["tab_foundry"]["checkpoint_diagnostics"] = {
+            "checkpoint_count": 2,
+            "successful_checkpoint_count": 1,
+            "failed_checkpoint_count": 1,
+            "task_count": 1,
+            "adjacent_ci_overlap_fraction": None,
+            "best_checkpoint_path": "/tmp/step_000025.pt",
+            "final_checkpoint_path": "/tmp/step_000025.pt",
+            "last_attempted_step": 50,
+            "last_attempted_checkpoint_path": "/tmp/step_000050.pt",
+            "bootstrap": {"samples": 2000, "confidence": 0.95, "seed": 0},
+            "best_checkpoint": {
+                "checkpoint_path": "/tmp/step_000025.pt",
+                "step": 25,
+                "training_time": 1.2,
+                "roc_auc": 0.81,
+                "dataset_roc_auc": {"toy": 0.81},
+                "dataset_count": 1,
+                "roc_auc_task_bootstrap_ci": {
+                    "samples": 2000,
+                    "confidence": 0.95,
+                    "lower": 0.81,
+                    "upper": 0.81,
+                },
+                "is_best_checkpoint": True,
+                "is_final_checkpoint": True,
+            },
+            "final_checkpoint": {
+                "checkpoint_path": "/tmp/step_000025.pt",
+                "step": 25,
+                "training_time": 1.2,
+                "roc_auc": 0.81,
+                "dataset_roc_auc": {"toy": 0.81},
+                "dataset_count": 1,
+                "roc_auc_task_bootstrap_ci": {
+                    "samples": 2000,
+                    "confidence": 0.95,
+                    "lower": 0.81,
+                    "upper": 0.81,
+                },
+                "is_best_checkpoint": True,
+                "is_final_checkpoint": True,
+            },
+            "checkpoints": [
+                {
+                    "checkpoint_path": "/tmp/step_000025.pt",
+                    "step": 25,
+                    "training_time": 1.2,
+                    "roc_auc": 0.81,
+                    "dataset_roc_auc": {"toy": 0.81},
+                    "dataset_count": 1,
+                    "roc_auc_task_bootstrap_ci": {
+                        "samples": 2000,
+                        "confidence": 0.95,
+                        "lower": 0.81,
+                        "upper": 0.81,
+                    },
+                    "is_best_checkpoint": True,
+                    "is_final_checkpoint": True,
+                },
+                {
+                    "checkpoint_path": "/tmp/step_000050.pt",
+                    "step": 50,
+                    "training_time": 2.4,
+                    "evaluation_error": "benchmark evaluation failed for dataset 'toy': Input contains NaN.",
+                    "evaluation_error_type": "ValueError",
+                    "failed_dataset": "toy",
+                    "is_best_checkpoint": False,
+                    "is_final_checkpoint": False,
+                },
+            ],
+            "failed_checkpoints": [
+                {
+                    "checkpoint_path": "/tmp/step_000050.pt",
+                    "step": 50,
+                    "training_time": 2.4,
+                    "evaluation_error": "benchmark evaluation failed for dataset 'toy': Input contains NaN.",
+                    "evaluation_error_type": "ValueError",
+                    "failed_dataset": "toy",
+                }
+            ],
+        }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
@@ -181,6 +276,53 @@ def test_freeze_control_baseline_validates_summary_run_dir(
             comparison_summary_path=summary_path,
             registry_path=registry_path,
         )
+
+
+def test_freeze_control_baseline_accepts_richer_checkpoint_diagnostics_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    registry_path = repo_root / "src" / "tab_foundry" / "bench" / "control_baselines_v1.json"
+    run_dir = repo_root / "outputs" / "control_baselines" / "cls_benchmark_linear_v2" / "train"
+    manifest_path = repo_root / "data" / "manifests" / "default.parquet"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_bytes(b"manifest")
+    benchmark_bundle_path = (
+        repo_root / "src" / "tab_foundry" / "bench" / "nanotabpfn_openml_binary_medium_v1.json"
+    )
+    benchmark_bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    benchmark_bundle_path.write_text("{}\n", encoding="utf-8")
+    _ = _write_checkpoint(
+        run_dir / "checkpoints" / "best.pt",
+        manifest_path="data/manifests/default.parquet",
+        seed=11,
+    )
+    summary_path = repo_root / "outputs" / "control_baselines" / "cls_benchmark_linear_v2" / "benchmark" / "comparison_summary.json"
+    _ = _write_comparison_summary(
+        summary_path,
+        run_dir=run_dir,
+        benchmark_bundle_source_path="src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        include_diagnostics=True,
+    )
+    monkeypatch.setattr(control_baseline_module, "project_root", lambda: repo_root)
+
+    frozen = control_baseline_module.freeze_control_baseline(
+        baseline_id="cls_benchmark_linear_v2",
+        experiment="cls_benchmark_linear",
+        config_profile="cls_benchmark_linear",
+        budget_class="short-run",
+        run_dir=run_dir,
+        comparison_summary_path=summary_path,
+        registry_path=registry_path,
+    )
+
+    assert frozen["baseline"]["benchmark_bundle"]["source_path"] == (
+        "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json"
+    )
+    assert frozen["baseline"]["seed_set"] == [11]
+    assert frozen["baseline"]["tab_foundry_metrics"]["best_roc_auc"] == pytest.approx(0.81)
+    assert frozen["baseline"]["tab_foundry_metrics"]["final_roc_auc"] == pytest.approx(0.83)
 
 
 def test_checked_in_control_baseline_registry_preserves_v1_and_adds_v2() -> None:

--- a/tests/benchmark/test_nanotabpfn_compare.py
+++ b/tests/benchmark/test_nanotabpfn_compare.py
@@ -476,12 +476,13 @@ def test_run_nanotabpfn_benchmark_orchestrates_external_helper(
         json.dumps(benchmark_bundle, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    policy_calls: dict[str, list[bool]] = {"load": [], "datasets": [], "evaluate": []}
 
     monkeypatch.setattr(
         compare_module,
         "load_openml_benchmark_datasets",
-        lambda *, new_instances=200, benchmark_bundle_path=None: (
-            {
+        lambda *, new_instances=200, benchmark_bundle_path=None, allow_missing_values=False: (
+            policy_calls["datasets"].append(bool(allow_missing_values)) or {
                 "toy": (
                     np.zeros((6, 2), dtype=np.float32),
                     np.asarray([0, 1, 0, 1, 0, 1], dtype=np.int64),
@@ -491,19 +492,36 @@ def test_run_nanotabpfn_benchmark_orchestrates_external_helper(
         ),
     )
     monkeypatch.setattr(compare_module, "default_benchmark_bundle_path", lambda: source_bundle_path)
-    monkeypatch.setattr(compare_module, "load_benchmark_bundle", lambda path=None: benchmark_bundle)
+    monkeypatch.setattr(
+        compare_module,
+        "load_benchmark_bundle_for_execution",
+        lambda path=None: (
+            policy_calls["load"].append(False) or benchmark_bundle,
+            False,
+        ),
+    )
     monkeypatch.setattr(
         compare_module,
         "evaluate_tab_foundry_run",
-        lambda *_args, **_kwargs: [
-            {
-                "checkpoint_path": "/tmp/step_000025.pt",
-                "step": 25,
-                "training_time": 1.2,
-                "roc_auc": 0.81,
-                "dataset_roc_auc": {"toy": 0.81},
-            }
-        ],
+        lambda *_args, **_kwargs: (
+            policy_calls["evaluate"].append(bool(_kwargs["allow_missing_values"])) or [
+                {
+                    "checkpoint_path": "/tmp/step_000025.pt",
+                    "step": 25,
+                    "training_time": 1.2,
+                    "roc_auc": 0.81,
+                    "dataset_roc_auc": {"toy": 0.81},
+                },
+                {
+                    "checkpoint_path": "/tmp/step_000050.pt",
+                    "step": 50,
+                    "training_time": 2.4,
+                    "evaluation_error": "benchmark evaluation failed for dataset 'toy': Input contains NaN.",
+                    "evaluation_error_type": "ValueError",
+                    "failed_dataset": "toy",
+                },
+            ]
+        ),
     )
     monkeypatch.setattr(
         compare_module,
@@ -604,6 +622,7 @@ def test_run_nanotabpfn_benchmark_orchestrates_external_helper(
     assert captured["check"] is True
     assert Path(captured["cmd"][0]) == nanotab_python.resolve()
     assert Path(captured["cmd"][1]) == Path(compare_module.__file__).resolve().with_name("nanotabpfn_helper.py")
+    assert policy_calls == {"load": [False], "datasets": [False], "evaluate": [False]}
     assert summary["dataset_count"] == 1
     assert summary["tab_foundry"]["best_step"] == pytest.approx(25.0)
     assert summary["tab_foundry"]["best_roc_auc"] == pytest.approx(0.81)
@@ -616,9 +635,33 @@ def test_run_nanotabpfn_benchmark_orchestrates_external_helper(
     assert summary["benchmark_bundle"]["task_count"] == 1
     assert summary["benchmark_bundle"]["task_ids"] == [1]
     assert summary["benchmark_bundle"]["source_path"] == str(source_bundle_path.resolve())
+    assert summary["benchmark_bundle"]["allow_missing_values"] is False
+    assert summary["benchmark_bundle"]["all_tasks_no_missing"] is True
     assert summary["tab_foundry"]["manifest_path"] == "data/manifests/binary.parquet"
     assert summary["tab_foundry"]["model_size"]["total_params"] == 1234
     assert summary["tab_foundry"]["training_diagnostics"]["mean_grad_norm"] == pytest.approx(0.4)
+    assert summary["tab_foundry"]["best_to_final_roc_auc_delta"] == pytest.approx(0.0)
+    assert summary["tab_foundry"]["best_to_final_dataset_roc_auc_delta"] == {
+        "toy": pytest.approx(0.0)
+    }
+    diagnostics = summary["tab_foundry"]["checkpoint_diagnostics"]
+    assert diagnostics["checkpoint_count"] == 2
+    assert diagnostics["successful_checkpoint_count"] == 1
+    assert diagnostics["failed_checkpoint_count"] == 1
+    assert diagnostics["task_count"] == 1
+    assert diagnostics["best_checkpoint_path"] == "/tmp/step_000025.pt"
+    assert diagnostics["final_checkpoint_path"] == "/tmp/step_000025.pt"
+    assert diagnostics["last_attempted_step"] == 50
+    assert diagnostics["last_attempted_checkpoint_path"] == "/tmp/step_000050.pt"
+    assert diagnostics["bootstrap"]["samples"] == benchmark_module.DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_SAMPLES
+    assert diagnostics["best_checkpoint"]["roc_auc_task_bootstrap_ci"]["confidence"] == pytest.approx(
+        benchmark_module.DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE
+    )
+    assert diagnostics["checkpoints"][0]["is_best_checkpoint"] is True
+    assert diagnostics["checkpoints"][0]["is_final_checkpoint"] is True
+    assert diagnostics["checkpoints"][1]["evaluation_error_type"] == "ValueError"
+    assert diagnostics["checkpoints"][1]["failed_dataset"] == "toy"
+    assert diagnostics["failed_checkpoints"][0]["failed_dataset"] == "toy"
     assert summary["artifacts"]["training_surface_record_json"] == str(
         (smoke_run_dir / "training_surface_record.json").resolve()
     )
@@ -629,8 +672,141 @@ def test_run_nanotabpfn_benchmark_orchestrates_external_helper(
     assert written_summary["artifacts"]["training_surface_record_json"] == str(
         (smoke_run_dir / "training_surface_record.json").resolve()
     )
+    assert written_summary["tab_foundry"]["checkpoint_diagnostics"]["failed_checkpoint_count"] == 1
     written_bundle = json.loads((out_root / "benchmark_tasks.json").read_text(encoding="utf-8"))
     assert written_bundle == benchmark_bundle
+
+
+def test_run_nanotabpfn_benchmark_explicit_large_bundle_allows_missing_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    smoke_run_dir = tmp_path / "smoke_run"
+    smoke_run_dir.mkdir()
+    nanotab_root = tmp_path / "nano"
+    (nanotab_root / ".venv" / "bin").mkdir(parents=True)
+    (nanotab_root / ".venv" / "bin" / "python").write_text("#!/bin/sh\n", encoding="utf-8")
+    prior_dump = nanotab_root / "300k_150x5_2.h5"
+    prior_dump.write_bytes(b"prior")
+    out_root = tmp_path / "benchmark_out"
+    large_bundle_path = tmp_path / "large_bundle.json"
+    large_bundle_path.write_text("{}", encoding="utf-8")
+    reuse_curve_path = tmp_path / "reuse_curve.jsonl"
+    reuse_curve_path.write_text(
+        json.dumps(
+            {
+                "seed": 0,
+                "step": 25,
+                "training_time": 2.0,
+                "roc_auc": 0.78,
+                "dataset_roc_auc": {"toy": 0.78},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    policy_calls: dict[str, list[bool]] = {"load": [], "datasets": [], "evaluate": []}
+    benchmark_bundle = {
+        "name": "large_bundle",
+        "version": 1,
+        "selection": {
+            "new_instances": 6,
+            "task_type": "supervised_classification",
+            "max_features": 10,
+            "max_classes": 2,
+            "max_missing_pct": 5.0,
+            "min_minority_class_pct": 2.5,
+        },
+        "task_ids": [1],
+        "tasks": [
+            {
+                "task_id": 1,
+                "dataset_name": "toy",
+                "n_rows": 6,
+                "n_features": 2,
+                "n_classes": 2,
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        compare_module,
+        "load_benchmark_bundle_for_execution",
+        lambda path=None: (
+            policy_calls["load"].append(True) or benchmark_bundle,
+            True,
+        ),
+    )
+    monkeypatch.setattr(
+        compare_module,
+        "load_openml_benchmark_datasets",
+        lambda *, new_instances=200, benchmark_bundle_path=None, allow_missing_values=False: (
+            policy_calls["datasets"].append(bool(allow_missing_values)) or {
+                "toy": (
+                    np.zeros((6, 2), dtype=np.float32),
+                    np.asarray([0, 1, 0, 1, 0, 1], dtype=np.int64),
+                )
+            },
+            [{"task_id": 1, "dataset_name": "toy", "n_rows": 6, "n_features": 2, "n_classes": 2}],
+        ),
+    )
+    monkeypatch.setattr(
+        compare_module,
+        "evaluate_tab_foundry_run",
+        lambda *_args, **_kwargs: (
+            policy_calls["evaluate"].append(bool(_kwargs["allow_missing_values"])) or [
+                {
+                    "checkpoint_path": "/tmp/step_000025.pt",
+                    "step": 25,
+                    "training_time": 1.2,
+                    "roc_auc": 0.81,
+                    "dataset_roc_auc": {"toy": 0.81},
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        compare_module,
+        "summarize_checkpoint_curve",
+        lambda records, **_kwargs: {"records": records},
+    )
+    monkeypatch.setattr(compare_module, "plot_comparison_curve", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        compare_module,
+        "build_comparison_summary",
+        lambda **_kwargs: {
+            "dataset_count": 1,
+            "benchmark_bundle": {"name": "large_bundle", "allow_missing_values": True},
+            "tab_foundry": {},
+            "nanotabpfn": {},
+        },
+    )
+    monkeypatch.setattr(
+        compare_module,
+        "derive_benchmark_run_record",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError(
+                "checkpoint config must include explicit model.arch metadata for benchmark "
+                "registration; legacy checkpoints without persisted model.arch cannot be "
+                "registered"
+            )
+        ),
+    )
+
+    summary = compare_module.run_nanotabpfn_benchmark(
+        compare_module.NanoTabPFNBenchmarkConfig(
+            tab_foundry_run_dir=smoke_run_dir,
+            out_root=out_root,
+            nanotabpfn_root=nanotab_root,
+            nanotab_prior_dump=prior_dump,
+            benchmark_bundle_path=large_bundle_path,
+            reuse_nanotabpfn_curve_path=reuse_curve_path,
+        )
+    )
+
+    assert policy_calls == {"load": [True], "datasets": [True], "evaluate": [True]}
+    assert summary["benchmark_bundle"]["allow_missing_values"] is True
 
 
 def test_run_nanotabpfn_benchmark_honors_nondefault_bundle_path(
@@ -682,17 +858,19 @@ def test_run_nanotabpfn_benchmark_honors_nondefault_bundle_path(
 
     captured: dict[str, Any] = {}
 
-    def _fake_load_bundle(path: Path | None = None) -> dict[str, Any]:
+    def _fake_load_bundle(path: Path | None = None) -> tuple[dict[str, Any], bool]:
         captured["bundle_path"] = None if path is None else str(Path(path).resolve())
-        return benchmark_bundle
+        return benchmark_bundle, False
 
     def _fake_load_datasets(
         *,
         new_instances: int = 200,
         benchmark_bundle_path: Path | None = None,
+        allow_missing_values: bool = False,
     ) -> tuple[dict[str, tuple[np.ndarray, np.ndarray]], list[dict[str, Any]]]:
         captured["dataset_new_instances"] = int(new_instances)
         captured["dataset_bundle_path"] = None if benchmark_bundle_path is None else str(Path(benchmark_bundle_path).resolve())
+        captured["dataset_allow_missing_values"] = bool(allow_missing_values)
         return (
             {
                 "toy_multi": (
@@ -704,7 +882,7 @@ def test_run_nanotabpfn_benchmark_honors_nondefault_bundle_path(
         )
 
     monkeypatch.setattr(compare_module, "default_benchmark_bundle_path", lambda: default_bundle_path)
-    monkeypatch.setattr(compare_module, "load_benchmark_bundle", _fake_load_bundle)
+    monkeypatch.setattr(compare_module, "load_benchmark_bundle_for_execution", _fake_load_bundle)
     monkeypatch.setattr(compare_module, "load_openml_benchmark_datasets", _fake_load_datasets)
     monkeypatch.setattr(
         compare_module,
@@ -813,6 +991,7 @@ def test_run_nanotabpfn_benchmark_honors_nondefault_bundle_path(
     assert captured["bundle_path"] == str(source_bundle_path.resolve())
     assert captured["dataset_new_instances"] == 6
     assert captured["dataset_bundle_path"] == str(source_bundle_path.resolve())
+    assert captured["dataset_allow_missing_values"] is False
     assert summary["benchmark_bundle"]["source_path"] == str(source_bundle_path.resolve())
     assert summary["artifacts"]["training_surface_record_json"] == str(
         (smoke_run_dir / "training_surface_record.json").resolve()
@@ -854,11 +1033,15 @@ def test_run_nanotabpfn_benchmark_skips_legacy_record_derivation_failure(
     benchmark_bundle = json.loads(source_bundle_path.read_text(encoding="utf-8"))
 
     monkeypatch.setattr(compare_module, "default_benchmark_bundle_path", lambda: source_bundle_path)
-    monkeypatch.setattr(compare_module, "load_benchmark_bundle", lambda path=None: benchmark_bundle)
+    monkeypatch.setattr(
+        compare_module,
+        "load_benchmark_bundle_for_execution",
+        lambda path=None: (benchmark_bundle, False),
+    )
     monkeypatch.setattr(
         compare_module,
         "load_openml_benchmark_datasets",
-        lambda *, new_instances=200, benchmark_bundle_path=None: (
+        lambda *, new_instances=200, benchmark_bundle_path=None, allow_missing_values=False: (
             {
                 "toy": (
                     np.zeros((6, 2), dtype=np.float32),
@@ -1097,7 +1280,7 @@ def test_run_nanotabpfn_benchmark_includes_control_baseline_annotation(
     monkeypatch.setattr(
         compare_module,
         "load_openml_benchmark_datasets",
-        lambda *, new_instances=200, benchmark_bundle_path=None: (
+        lambda *, new_instances=200, benchmark_bundle_path=None, allow_missing_values=False: (
             {
                 "toy": (
                     np.zeros((6, 2), dtype=np.float32),
@@ -1108,7 +1291,11 @@ def test_run_nanotabpfn_benchmark_includes_control_baseline_annotation(
         ),
     )
     monkeypatch.setattr(compare_module, "default_benchmark_bundle_path", lambda: source_bundle_path)
-    monkeypatch.setattr(compare_module, "load_benchmark_bundle", lambda path=None: benchmark_bundle)
+    monkeypatch.setattr(
+        compare_module,
+        "load_benchmark_bundle_for_execution",
+        lambda path=None: (benchmark_bundle, False),
+    )
     monkeypatch.setattr(
         compare_module,
         "evaluate_tab_foundry_run",
@@ -1290,3 +1477,7 @@ def test_build_comparison_summary_preserves_model_identity_metadata(tmp_path: Pa
     assert summary["tab_foundry"]["model_arch"] == "tabfoundry_staged"
     assert summary["tab_foundry"]["model_stage"] == "nano_exact"
     assert summary["tab_foundry"]["benchmark_profile"] == "nano_exact"
+    assert summary["benchmark_bundle"]["allow_missing_values"] is False
+    assert summary["benchmark_bundle"]["all_tasks_no_missing"] is True
+    assert summary["tab_foundry"]["checkpoint_diagnostics"]["checkpoint_count"] == 1
+    assert summary["tab_foundry"]["checkpoint_diagnostics"]["failed_checkpoint_count"] == 0

--- a/tests/benchmark/test_openml_benchmark_bundle.py
+++ b/tests/benchmark/test_openml_benchmark_bundle.py
@@ -337,6 +337,23 @@ def test_checked_in_binary_medium_bundle_loads() -> None:
     assert all(int(task["n_classes"]) == 2 for task in bundle["tasks"])
 
 
+def test_checked_in_binary_large_bundle_requires_explicit_missing_value_opt_in() -> None:
+    bundle_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tab_foundry"
+        / "bench"
+        / "nanotabpfn_openml_binary_large_v1.json"
+    )
+
+    with pytest.raises(RuntimeError, match="permits missing-valued inputs"):
+        _ = benchmark_module.load_benchmark_bundle(bundle_path)
+
+    bundle = benchmark_module.load_benchmark_bundle(bundle_path, allow_missing_values=True)
+
+    assert bundle["name"] == "nanotabpfn_openml_binary_large"
+
+
 def test_load_openml_benchmark_datasets_accepts_checked_in_multiclass_bundle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/benchmark/test_prior_train.py
+++ b/tests/benchmark/test_prior_train.py
@@ -128,6 +128,20 @@ def test_prior_dump_reader_rejects_non_binary_dump(tmp_path: Path) -> None:
         _ = next(iter(PriorDumpTaskBatchReader(path, num_steps=1, batch_size=1)))
 
 
+def test_prior_dump_reader_rejects_nan_or_inf_inputs_by_default(tmp_path: Path) -> None:
+    path = _write_prior_dump(
+        tmp_path / "prior_nonfinite.h5",
+        x=np.asarray([[[1.0, np.nan], [2.0, 3.0], [4.0, np.inf]]], dtype=np.float32),
+        y=np.asarray([[0, 1, 0]], dtype=np.int64),
+        num_features=np.asarray([2], dtype=np.int64),
+        num_datapoints=np.asarray([3], dtype=np.int64),
+        single_eval_pos=np.asarray([2], dtype=np.int64),
+    )
+
+    with pytest.raises(RuntimeError, match="contains NaN or Inf"):
+        _ = next(iter(PriorDumpTaskBatchReader(path, num_steps=1, batch_size=1)))
+
+
 @lru_cache(maxsize=1)
 def _nanotabpfn_module():
     model_path = Path("~/dev/nanoTabPFN/model.py").expanduser()

--- a/tests/data/test_manifest_and_dataset.py
+++ b/tests/data/test_manifest_and_dataset.py
@@ -21,6 +21,12 @@ from tab_foundry.model.factory import build_model
 from tab_foundry.preprocessing import apply_fitted_preprocessor, fit_fitted_preprocessor
 
 
+def _manifest_summary_metadata(path: Path) -> dict[str, Any]:
+    metadata = pq.ParquetFile(path).schema_arrow.metadata or {}
+    raw = metadata[b"tab_foundry_manifest_summary"]
+    return json.loads(raw.decode("utf-8"))
+
+
 def _classification_metadata(
     *,
     n_features: int,
@@ -177,16 +183,24 @@ def test_manifest_and_dataset_loading(tmp_path: Path) -> None:
     assert summary.total_records == 1
     assert summary.discovered_records == 1
     assert summary.excluded_records == 0
+    assert summary.excluded_for_missing_values == 0
+    assert summary.missing_value_policy == "allow_any"
     assert summary.filter_status_counts == {"not_run": 1}
+    assert summary.missing_value_status_counts == {"clean": 1}
     assert summary.warnings
 
     table = pq.read_table(manifest_path)
     row = table.to_pylist()[0]
+    persisted_summary = _manifest_summary_metadata(manifest_path)
     split = row["split"]
     assert row["source_shard_relpath"] == "shard_00000"
     assert row["filter_mode"] == "deferred"
     assert row["filter_status"] == "not_run"
     assert row["filter_accepted"] is None
+    assert row["missing_value_policy"] == "allow_any"
+    assert row["missing_value_status"] == "clean"
+    assert persisted_summary["missing_value_policy"] == "allow_any"
+    assert persisted_summary["missing_value_status_counts"] == {"clean": 1}
 
     ds = PackedParquetTaskDataset(manifest_path, split=split, task="classification")
     sample = ds[0]
@@ -226,6 +240,65 @@ def test_manifest_accepted_only_excludes_unaccepted_records(tmp_path: Path) -> N
     assert len(rows) == 1
     assert rows[0]["dataset_index"] == 0
     assert rows[0]["filter_status"] == "accepted"
+
+
+def test_manifest_forbid_any_excludes_datasets_with_nan_or_inf(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    clean_x_train, clean_y_train, clean_x_test, clean_y_test = _classification_arrays(seed=7)
+    dirty_x_train, dirty_y_train, dirty_x_test, dirty_y_test = _classification_arrays(seed=11)
+    dirty_x_train[0, 0] = np.nan
+    dirty_x_test[1, 1] = np.inf
+    datasets = [
+        {
+            "dataset_index": 0,
+            "x_train": clean_x_train,
+            "y_train": clean_y_train,
+            "x_test": clean_x_test,
+            "y_test": clean_y_test,
+            "feature_types": ["num"] * clean_x_train.shape[1],
+            "metadata": _classification_metadata(
+                n_features=clean_x_train.shape[1],
+                seed=7,
+                filter_status="accepted",
+                filter_accepted=True,
+            ),
+        },
+        {
+            "dataset_index": 1,
+            "x_train": dirty_x_train,
+            "y_train": dirty_y_train,
+            "x_test": dirty_x_test,
+            "y_test": dirty_y_test,
+            "feature_types": ["num"] * dirty_x_train.shape[1],
+            "metadata": _classification_metadata(
+                n_features=dirty_x_train.shape[1],
+                seed=11,
+                filter_status="accepted",
+                filter_accepted=True,
+            ),
+        },
+    ]
+    _ = _write_packed_shard(root / "shard_00000", datasets=datasets)
+
+    manifest_path = tmp_path / "manifest.parquet"
+    summary = build_manifest(
+        [root],
+        manifest_path,
+        filter_policy="accepted_only",
+        missing_value_policy="forbid_any",
+    )
+    rows = pq.read_table(manifest_path).to_pylist()
+    persisted_summary = _manifest_summary_metadata(manifest_path)
+
+    assert summary.discovered_records == 2
+    assert summary.total_records == 1
+    assert summary.excluded_records == 1
+    assert summary.excluded_for_missing_values == 1
+    assert summary.missing_value_status_counts == {"clean": 1, "contains_nan_or_inf": 1}
+    assert rows[0]["dataset_index"] == 0
+    assert rows[0]["missing_value_status"] == "clean"
+    assert persisted_summary["missing_value_policy"] == "forbid_any"
+    assert persisted_summary["excluded_for_missing_values"] == 1
 
 
 def test_manifest_accepted_only_requires_at_least_one_record(tmp_path: Path) -> None:
@@ -343,6 +416,7 @@ def test_dataset_keeps_nan_features_when_impute_missing_is_false_but_still_remap
         split=str(row["split"]),
         task="classification",
         impute_missing=False,
+        allow_missing_values=True,
     )
     sample = ds[0]
 
@@ -351,6 +425,38 @@ def test_dataset_keeps_nan_features_when_impute_missing_is_false_but_still_remap
     assert sample.y_train.tolist() == [0, 1, 0]
     assert sample.y_test.tolist() == [1]
     assert sample.num_classes == 2
+
+
+def test_dataset_rejects_missing_inputs_by_default(tmp_path: Path) -> None:
+    shard_dir = tmp_path / "run" / "shard_00000"
+    dataset = {
+        "dataset_index": 0,
+        "x_train": np.array([[1.0, np.nan], [2.0, 3.0], [3.0, 4.0]], dtype=np.float32),
+        "y_train": np.array([0, 1, 0], dtype=np.int64),
+        "x_test": np.array([[4.0, 5.0], [6.0, np.inf]], dtype=np.float32),
+        "y_test": np.array([1, 0], dtype=np.int64),
+        "feature_types": ["num", "num"],
+        "metadata": _classification_metadata(
+            n_features=2,
+            n_classes=2,
+            seed=7,
+            filter_status="accepted",
+            filter_accepted=True,
+        ),
+    }
+    _ = _write_packed_shard(shard_dir, datasets=[dataset])
+
+    manifest_path = tmp_path / "manifest.parquet"
+    _ = build_manifest([tmp_path / "run"], manifest_path)
+    row = pq.read_table(manifest_path).to_pylist()[0]
+    ds = PackedParquetTaskDataset(
+        manifest_path=manifest_path,
+        split=str(row["split"]),
+        task="classification",
+    )
+
+    with pytest.raises(RuntimeError, match="contains NaN or Inf"):
+        _ = ds[0]
 
 
 def test_cli_parser_rejects_removed_preprocessor_state_surface() -> None:
@@ -401,6 +507,7 @@ def test_dataset_and_reference_consumer_share_runtime_preprocessing_semantics(
         manifest_path=manifest_path,
         split=str(row["split"]),
         task="classification",
+        allow_missing_values=True,
     )
     sample = ds[0]
 

--- a/tests/property/test_hypothesis_surfaces.py
+++ b/tests/property/test_hypothesis_surfaces.py
@@ -118,6 +118,8 @@ def test_normalize_benchmark_bundle_rejects_task_id_order_drift(
     override_filter_policy=st.one_of(st.none(), _LABEL_TEXT),
     top_surface_label=st.one_of(st.none(), _LABEL_TEXT),
     override_surface_label=st.one_of(st.none(), _LABEL_TEXT),
+    top_allow_missing_values=st.one_of(st.none(), st.booleans()),
+    override_allow_missing_values=st.one_of(st.none(), st.booleans()),
     top_train_row_cap=st.one_of(st.none(), st.integers(min_value=1, max_value=50_000)),
     override_train_row_cap=st.one_of(st.none(), st.integers(min_value=1, max_value=50_000)),
     top_test_row_cap=st.one_of(st.none(), st.integers(min_value=1, max_value=50_000)),
@@ -140,6 +142,8 @@ def test_resolve_data_surface_respects_override_precedence(
     override_filter_policy: str | None,
     top_surface_label: str | None,
     override_surface_label: str | None,
+    top_allow_missing_values: bool | None,
+    override_allow_missing_values: bool | None,
     top_train_row_cap: int | None,
     override_train_row_cap: int | None,
     top_test_row_cap: int | None,
@@ -152,6 +156,7 @@ def test_resolve_data_surface_respects_override_precedence(
         "manifest_path": top_manifest,
         "filter_policy": top_filter_policy,
         "surface_label": top_surface_label,
+        "allow_missing_values": top_allow_missing_values,
         "train_row_cap": top_train_row_cap,
         "test_row_cap": top_test_row_cap,
         "dagzoo_provenance": top_provenance,
@@ -162,6 +167,7 @@ def test_resolve_data_surface_respects_override_precedence(
                 "manifest_path": override_manifest,
                 "filter_policy": override_filter_policy,
                 "surface_label": override_surface_label,
+                "allow_missing_values": override_allow_missing_values,
                 "train_row_cap": override_train_row_cap,
                 "test_row_cap": override_test_row_cap,
                 "dagzoo_provenance": override_provenance,
@@ -177,6 +183,13 @@ def test_resolve_data_surface_respects_override_precedence(
         None if override_filter_policy is None and top_filter_policy is None else str(override_filter_policy or top_filter_policy).strip()
     )
     expected_surface_label = str(top_surface_label or override_surface_label or expected_source).strip()
+    expected_allow_missing_values = (
+        override_allow_missing_values
+        if override_allow_missing_values is not None
+        else top_allow_missing_values
+        if top_allow_missing_values is not None
+        else False
+    )
     expected_train_row_cap = override_train_row_cap if override_train_row_cap is not None else top_train_row_cap
     expected_test_row_cap = override_test_row_cap if override_test_row_cap is not None else top_test_row_cap
     expected_provenance = override_provenance if override_provenance is not None else top_provenance
@@ -184,6 +197,7 @@ def test_resolve_data_surface_respects_override_precedence(
     assert resolved.source == expected_source
     assert resolved.surface_label == expected_surface_label
     assert resolved.filter_policy == expected_filter_policy
+    assert resolved.allow_missing_values is expected_allow_missing_values
     assert resolved.train_row_cap == expected_train_row_cap
     assert resolved.test_row_cap == expected_test_row_cap
     assert resolved.dagzoo_provenance == expected_provenance

--- a/tests/research/test_system_delta.py
+++ b/tests/research/test_system_delta.py
@@ -144,6 +144,24 @@ def test_grouped_tokenizer_guard_is_captured_in_catalog_and_materialized_queue()
     assert "genuinely isolatable tokenization experiment" in grouped_row["next_action"]
 
 
+def test_missingness_rows_are_deferred_from_the_main_campaign() -> None:
+    queue = load_system_delta_queue(
+        sweep_id="binary_md_v1",
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+
+    impute_row = next(row for row in queue["rows"] if row["delta_id"] == "delta_preproc_impute_missing_off")
+    fill_row = next(row for row in queue["rows"] if row["delta_id"] == "delta_preproc_all_nan_fill_nonzero")
+
+    assert impute_row["status"] == "deferred_separate_workstream"
+    assert impute_row["interpretation_status"] == "blocked"
+    assert "main no-missing campaign" in impute_row["next_action"]
+    assert fill_row["status"] == "deferred_separate_workstream"
+    assert fill_row["interpretation_status"] == "blocked"
+    assert "missingness workstream" in fill_row["next_action"]
+
+
 def test_active_alias_queue_matches_materialized_active_sweep() -> None:
     materialized = load_system_delta_queue(
         sweep_id="binary_md_v1",

--- a/tests/training/test_surface.py
+++ b/tests/training/test_surface.py
@@ -33,6 +33,8 @@ def _write_manifest(path: Path) -> Path:
                 "filter_mode": "curated",
                 "filter_status": "accepted",
                 "filter_accepted": True,
+                "missing_value_policy": "forbid_any",
+                "missing_value_status": "clean",
             },
             {
                 "dataset_id": "root_a/shard_0/dataset_000002",
@@ -55,7 +57,41 @@ def _write_manifest(path: Path) -> Path:
                 "filter_mode": "curated",
                 "filter_status": "accepted",
                 "filter_accepted": True,
+                "missing_value_policy": "forbid_any",
+                "missing_value_status": "clean",
             },
+        ]
+    )
+    pq.write_table(table, path)
+    return path
+
+
+def _write_legacy_manifest(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(
+        [
+            {
+                "dataset_id": "root_a/shard_0/dataset_000001",
+                "source_root_id": "root_a",
+                "source_shard_relpath": "shard_0",
+                "split": "train",
+                "task": "classification",
+                "dataset_index": 1,
+                "train_path": "train.parquet",
+                "test_path": "test.parquet",
+                "metadata_path": "metadata.ndjson",
+                "metadata_offset_bytes": 0,
+                "metadata_size_bytes": 16,
+                "metadata_sha256": "0" * 64,
+                "n_train": 24,
+                "n_test": 8,
+                "n_features": 6,
+                "n_classes": 2,
+                "seed": 1,
+                "filter_mode": "curated",
+                "filter_status": "accepted",
+                "filter_accepted": True,
+            }
         ]
     )
     pq.write_table(table, path)
@@ -115,10 +151,86 @@ def test_build_training_surface_record_captures_model_data_and_preprocessing_sur
     assert record["model"]["module_hyperparameters"]["row_pool"]["n_heads"] == 2
     assert record["data"]["manifest"]["characteristics"]["record_count"] == 2
     assert record["data"]["manifest"]["characteristics"]["split_counts"] == {"train": 1, "val": 1}
+    assert record["data"]["manifest"]["characteristics"]["missing_value_policy"] == "forbid_any"
+    assert record["data"]["manifest"]["characteristics"]["all_records_no_missing"] is True
+    assert record["data"]["allow_missing_values"] is False
     assert record["data"]["filter_policy"] == "accepted_only"
     assert record["data"]["dagzoo_provenance"]["commands"] == ["dagzoo filter --curated-out ..."]
     assert record["preprocessing"]["impute_missing"] is False
     assert record["preprocessing"]["all_nan_fill"] == 1.0
+
+
+def test_build_training_surface_record_marks_missing_inputs_when_manifest_is_dirty(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "manifest_dirty.parquet"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(
+        [
+            {
+                "dataset_id": "root_a/shard_0/dataset_000001",
+                "source_root_id": "root_a",
+                "source_shard_relpath": "shard_0",
+                "split": "train",
+                "task": "classification",
+                "dataset_index": 1,
+                "train_path": "train.parquet",
+                "test_path": "test.parquet",
+                "metadata_path": "metadata.ndjson",
+                "metadata_offset_bytes": 0,
+                "metadata_size_bytes": 16,
+                "metadata_sha256": "0" * 64,
+                "n_train": 24,
+                "n_test": 8,
+                "n_features": 6,
+                "n_classes": 2,
+                "seed": 1,
+                "filter_mode": "curated",
+                "filter_status": "accepted",
+                "filter_accepted": True,
+                "missing_value_policy": "allow_any",
+                "missing_value_status": "contains_nan_or_inf",
+            }
+        ]
+    )
+    pq.write_table(table, manifest_path)
+
+    record = build_training_surface_record(
+        raw_cfg={
+            "task": "classification",
+            "model": {"arch": "tabfoundry"},
+            "data": {
+                "source": "manifest",
+                "manifest_path": str(manifest_path),
+            },
+        },
+        run_dir=tmp_path / "run_dirty",
+    )
+
+    assert record["data"]["manifest"]["characteristics"]["all_records_no_missing"] is False
+
+
+def test_build_training_surface_record_marks_legacy_manifest_missingness_as_unknown(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_legacy_manifest(tmp_path / "manifest_legacy.parquet")
+
+    record = build_training_surface_record(
+        raw_cfg={
+            "task": "classification",
+            "model": {"arch": "tabfoundry"},
+            "data": {
+                "source": "manifest",
+                "manifest_path": str(manifest_path),
+            },
+        },
+        run_dir=tmp_path / "run_legacy",
+    )
+
+    assert record["data"]["manifest"]["characteristics"]["missing_value_status_counts"] == {
+        "missing": 1
+    }
+    assert record["data"]["manifest"]["characteristics"]["all_records_no_missing"] is None
 
 
 def test_build_training_surface_record_uses_row_cap_overrides_before_top_level_values(

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Summary
- remove TF-RD-015 from the roadmap and expand TF-RD-001’s current state, exit criteria, and dependency wording to cover the no-missing benchmark understanding plus checkpoint diagnostics and per-task traces
- keep BL-199, retitle it, and make it a child of BL-152 while refreshing BL-152/155/157/158/159 descriptions to align with the measurement-first policy
- ensure roadmap references and Linear backlog chains now point at the updated TF-RD-001 scope and supporting tickets

Testing
- Not run (not requested)