### PR TITLE
Improve WandB telemetry handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Training runs now use a shared internal Weights & Biases helper module, and
+  both the main trainer and exact-prior trainer emit richer additive wandb
+  scalar telemetry and end-of-run summaries without changing the logging config
+  surface or uploading artifact files.
+
 - Prior-dump queue reruns now emit additive instability-debug artifacts:
   `gradient_history.jsonl` for module-level gradient traces and
   `telemetry.json` for run summaries, checkpoint snapshots, missingness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.6.3"
+version = "0.6.4"
 description = "Tabfoundry tabular foundation model training on dagzoo packed shard outputs"
 readme = "README.md"
 license = "MIT"

--- a/src/tab_foundry/bench/prior_train.py
+++ b/src/tab_foundry/bench/prior_train.py
@@ -47,6 +47,12 @@ from tab_foundry.training.optimizer import build_optimizer
 from tab_foundry.training.surface import write_training_surface_record
 from tab_foundry.training.schedule import build_stage_configs, stage_base_lr, StageConfig
 from tab_foundry.training.trainer import _set_optimizer_base_lr, _set_optimizer_training_mode
+from tab_foundry.training.wandb import (
+    finish_wandb_run,
+    init_wandb_run,
+    log_wandb_metrics,
+    update_wandb_summary,
+)
 from tab_foundry.types import TrainResult
 
 
@@ -248,6 +254,73 @@ def _accumulate_missingness(
         prior_dump["last_batch"] = batch_missingness.to_dict()
 
 
+def _prior_wandb_summary_payload(
+    *,
+    output_dir: Path,
+    global_step: int,
+    telemetry_payload: dict[str, Any],
+) -> dict[str, Any]:
+    raw_gradient_summary = telemetry_payload.get("gradient_summary")
+    gradient_global = (
+        raw_gradient_summary.get("global")
+        if isinstance(raw_gradient_summary, dict)
+        else None
+    )
+    raw_missingness = telemetry_payload.get("missingness")
+    prior_dump_missingness = (
+        raw_missingness.get("prior_dump")
+        if isinstance(raw_missingness, dict)
+        else None
+    )
+    affected_indices = (
+        prior_dump_missingness.get("affected_dataset_indices")
+        if isinstance(prior_dump_missingness, dict)
+        else None
+    )
+    raw_artifacts = telemetry_payload.get("artifacts")
+    latest_checkpoint = (
+        raw_artifacts.get("latest_checkpoint")
+        if isinstance(raw_artifacts, dict)
+        else None
+    )
+    summary: dict[str, Any] = {
+        "run": {
+            "output_dir": str(output_dir),
+            "global_step": int(global_step),
+        },
+        "telemetry": {
+            "success": telemetry_payload.get("success"),
+            "checkpoint_snapshot_count": len(telemetry_payload.get("checkpoint_snapshots", [])),
+        },
+        "artifacts": {
+            "latest_checkpoint": latest_checkpoint,
+        },
+        "loss_summary": telemetry_payload.get("loss_summary"),
+        "gradient_summary": {
+            "global": gradient_global,
+        },
+    }
+    if isinstance(prior_dump_missingness, dict):
+        summary["missingness"] = {
+            "prior_dump": {
+                "batches_seen": prior_dump_missingness.get("batches_seen"),
+                "affected_batch_count": prior_dump_missingness.get("affected_batch_count"),
+                "affected_dataset_count": len(affected_indices)
+                if isinstance(affected_indices, list)
+                else None,
+                "non_finite_feature_count": prior_dump_missingness.get("non_finite_feature_count"),
+                "non_finite_label_count": prior_dump_missingness.get("non_finite_label_count"),
+            }
+        }
+    raw_error = telemetry_payload.get("error")
+    if isinstance(raw_error, dict):
+        summary["error"] = {
+            "type": raw_error.get("type"),
+            "message": raw_error.get("message"),
+        }
+    return summary
+
+
 def train_tabfoundry_simple_prior(
     cfg: DictConfig,
     *,
@@ -300,6 +373,10 @@ def train_tabfoundry_simple_prior(
         training_surface_path,
         raw_cfg=raw_cfg,
         run_dir=output_dir,
+    )
+    run = init_wandb_run(
+        cfg,
+        enabled=bool(getattr(cfg.logging, "use_wandb", False)),
     )
     artifacts: dict[str, Any] = {
         "train_history_jsonl": None if history_path is None else str(history_path),
@@ -441,6 +518,22 @@ def train_tabfoundry_simple_prior(
             loss_ema = update_loss_ema(history_step_loss, previous_ema=loss_ema)
             previous_train_loss = history_step_loss
             elapsed_seconds = time.perf_counter() - train_start
+            train_log: dict[str, Any] = {
+                "train/loss": float(history_step_loss),
+                "train/acc": float(history_step_acc),
+                "train/lr": float(optimizer.param_groups[0]["lr"]),
+                "train/grad_norm": float(final_grad_norm),
+                "train/loss_delta": loss_delta_value,
+                "train/loss_ema": loss_ema,
+                "train/elapsed_seconds": float(elapsed_seconds),
+                "train/train_elapsed_seconds": float(train_elapsed_seconds),
+                "train/grad_clip_threshold": float(grad_clip),
+                "train/grad_clip_triggered": grad_clip_triggered,
+                "train/stage": _PRIOR_STAGE_NAME,
+            }
+            for module_name, module_value in pre_clip_module_grad_norms.items():
+                train_log[f"train/module_grad_norm/{module_name}"] = float(module_value)
+            log_wandb_metrics(run, train_log, step=global_step)
             history_payload = history_record(
                 global_step=global_step,
                 stage_name=_PRIOR_STAGE_NAME,
@@ -524,6 +617,14 @@ def train_tabfoundry_simple_prior(
             training_surface_record=training_surface_payload,
         )
         write_training_telemetry(telemetry_output_path, telemetry_payload)
+        update_wandb_summary(
+            run,
+            _prior_wandb_summary_payload(
+                output_dir=output_dir,
+                global_step=global_step,
+                telemetry_payload=telemetry_payload,
+            ),
+        )
         return TrainResult(
             output_dir=output_dir,
             best_checkpoint=None,
@@ -557,7 +658,17 @@ def train_tabfoundry_simple_prior(
             error=exc,
         )
         write_training_telemetry(telemetry_output_path, telemetry_payload)
+        update_wandb_summary(
+            run,
+            _prior_wandb_summary_payload(
+                output_dir=output_dir,
+                global_step=global_step,
+                telemetry_payload=telemetry_payload,
+            ),
+        )
         raise
+    finally:
+        finish_wandb_run(run)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/tab_foundry/training/trainer.py
+++ b/src/tab_foundry/training/trainer.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 import math
-import os
 from pathlib import Path
 import time
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 from accelerate import Accelerator
 import torch
@@ -35,6 +34,7 @@ from .optimizer import build_optimizer
 from .runtime import build_accelerator_from_runtime
 from .schedule import build_stage_configs, stage_base_lr
 from .surface import write_training_surface_record
+from .wandb import finish_wandb_run, init_wandb_run, log_wandb_metrics, update_wandb_summary
 
 
 def _cycle(loader: DataLoader[TaskBatch]) -> Iterator[TaskBatch]:
@@ -156,44 +156,6 @@ def _evaluate_loader(
     return {"val_loss": val_loss, metric_name: val_score}
 
 
-def _wandb_init(cfg: DictConfig, *, enabled: bool) -> Any | None:
-    if not enabled:
-        return None
-    try:
-        import wandb
-    except Exception:
-        return None
-
-    api_key = _resolve_wandb_api_key()
-    mode: Literal["online", "offline"] = "online" if api_key else "offline"
-    cfg_payload = cast(dict[str, Any], OmegaConf.to_container(cfg, resolve=True))
-    return wandb.init(
-        project=str(cfg.logging.project),
-        name=str(cfg.logging.run_name),
-        mode=mode,
-        config=cfg_payload,
-    )
-
-
-def _resolve_wandb_api_key() -> str | None:
-    value = os.getenv("WANDB_API_KEY")
-    if value is not None:
-        normalized = value.strip()
-        if normalized:
-            return normalized
-
-    file_override = os.getenv("WANDB_API_KEY_FILE")
-    candidate = Path(file_override).expanduser() if file_override else Path("~/.wandb/wandb_api_key.txt").expanduser()
-    try:
-        normalized = candidate.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    if not normalized:
-        return None
-    os.environ["WANDB_API_KEY"] = normalized
-    return normalized
-
-
 def _resolve_grad_accum_steps(cfg: DictConfig) -> int:
     value = int(getattr(cfg, "grad_accum_steps", 1))
     if value <= 0:
@@ -277,6 +239,56 @@ def _expected_metric_keys(task: str) -> set[str]:
     return {"rmse", "grad_norm"}
 
 
+def _trainer_summary_payload(
+    *,
+    output_dir: Path,
+    optimizer_requested_name: str,
+    optimizer_resolved_name: str,
+    optimizer_fallback_reason: str | None,
+    global_step: int,
+    best_checkpoint: Path | None,
+    latest_checkpoint: Path | None,
+    best_val: float,
+    best_val_step: float,
+    last_val_metrics: dict[str, float] | None,
+    final_grad_norm: float,
+    grad_norm_sum: float,
+    grad_norm_count: int,
+    max_grad_norm: float,
+    train_elapsed_seconds: float,
+    wall_elapsed_seconds: float,
+    error: BaseException | None = None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "optimizer": {
+            "requested_name": optimizer_requested_name,
+            "resolved_name": optimizer_resolved_name,
+            "fallback_reason": optimizer_fallback_reason,
+        },
+        "run": {
+            "output_dir": str(output_dir),
+            "global_step": int(global_step),
+            "best_checkpoint": None if best_checkpoint is None else str(best_checkpoint.resolve()),
+            "latest_checkpoint": None if latest_checkpoint is None else str(latest_checkpoint.resolve()),
+        },
+        "metrics": {
+            "best_val_loss": float(best_val),
+            "best_val_step": float(best_val_step) if best_val_step > 0 else None,
+            "final_val_loss": None
+            if last_val_metrics is None
+            else float(last_val_metrics["val_loss"]),
+            "final_grad_norm": float(final_grad_norm),
+            "mean_grad_norm": float(grad_norm_sum / grad_norm_count) if grad_norm_count > 0 else 0.0,
+            "max_grad_norm": float(max_grad_norm),
+            "train_elapsed_seconds": float(train_elapsed_seconds),
+            "wall_elapsed_seconds": float(wall_elapsed_seconds),
+        },
+    }
+    if error is not None:
+        summary["error"] = {"type": type(error).__name__, "message": str(error)}
+    return summary
+
+
 def train(cfg: DictConfig) -> TrainResult:
     """Train from config."""
 
@@ -341,7 +353,10 @@ def train(cfg: DictConfig) -> TrainResult:
             run_dir=output_dir,
         )
 
-    run = _wandb_init(cfg, enabled=bool(cfg.logging.use_wandb and accelerator.is_main_process))
+    run = init_wandb_run(
+        cfg,
+        enabled=bool(getattr(cfg.logging, "use_wandb", False) and accelerator.is_main_process),
+    )
 
     raw_stages = cast(list[dict[str, object]], OmegaConf.to_container(cfg.schedule.stages, resolve=True))
     stage_configs = build_stage_configs(raw_stages)
@@ -371,8 +386,6 @@ def train(cfg: DictConfig) -> TrainResult:
             f"[optimizer] requested={optimizer_sel.requested_name} "
             f"resolved={optimizer_sel.resolved_name} fallback={optimizer_sel.fallback_reason}"
         )
-    if run is not None and accelerator.is_main_process:
-        run.log({"optimizer/fallback": 1.0 if optimizer_sel.fallback_reason else 0.0}, step=0)
 
     prepared_opts: list[tuple[str, torch.optim.Optimizer]] = []
     lr_scales: dict[str, list[float]] = {}
@@ -399,140 +412,98 @@ def train(cfg: DictConfig) -> TrainResult:
     previous_train_loss: float | None = None
     loss_ema: float | None = None
 
-    for stage in stage_configs:
-        _set_optimizer_training_mode(prepared_opts, training=True)
+    try:
+        for stage in stage_configs:
+            _set_optimizer_training_mode(prepared_opts, training=True)
 
-        for stage_step in range(1, stage.steps + 1):
-            model.train()
-            current_base_lr = stage_base_lr(
-                stage,
-                step=stage_step,
-                lr_min=float(cfg.optimizer.min_lr),
-            )
-            for opt_name, opt in prepared_opts:
-                _set_optimizer_base_lr(
-                    opt,
-                    base_lr=current_base_lr,
-                    scales=lr_scales[opt_name],
+            for stage_step in range(1, stage.steps + 1):
+                model.train()
+                current_base_lr = stage_base_lr(
+                    stage,
+                    step=stage_step,
+                    lr_min=float(cfg.optimizer.min_lr),
                 )
-            for _opt_name, opt in prepared_opts:
-                opt.zero_grad(set_to_none=True)
-            train_loss_sum = 0.0
-            train_loss_count = 0
-            train_metric_sums: dict[str, float] = {}
-            train_metric_counts: dict[str, int] = {}
-            step_train_start = time.perf_counter()
-            for _micro_step in range(grad_accum_steps):
-                batch = move_batch(next(train_iter), accelerator.device)
-                with accelerator.accumulate(model):
-                    with accelerator.autocast():
-                        output = model(batch)
-                        loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
-                    accelerator.backward(loss)
-                train_loss_sum += float(loss.detach().item())
-                train_loss_count += 1
-                for key, value in metrics.items():
-                    train_metric_sums[key] = train_metric_sums.get(key, 0.0) + float(value)
-                    train_metric_counts[key] = train_metric_counts.get(key, 0) + 1
-
-            local_grad_norm = total_grad_norm(model.parameters())
-            if float(cfg.runtime.grad_clip) > 0:
-                clipped = accelerator.clip_grad_norm_(model.parameters(), float(cfg.runtime.grad_clip))
-                local_grad_norm = normalize_grad_norm_value(clipped, fallback=local_grad_norm)
-            train_metric_sums["grad_norm"] = train_metric_sums.get("grad_norm", 0.0) + float(local_grad_norm)
-            train_metric_counts["grad_norm"] = train_metric_counts.get("grad_norm", 0) + 1
-
-            for _opt_name, opt in prepared_opts:
-                opt.step()
-
-            train_elapsed_seconds += time.perf_counter() - step_train_start
-            global_step += 1
-            metric_keys = sorted(set(train_metric_sums) | expected_keys)
-            # Pack loss + metric sums/counts into one tensor for a single all-reduce.
-            # Layout: [loss_sum, loss_count, key0_sum, key0_count, ...]
-            n_metrics = len(metric_keys)
-            packed = torch.zeros(
-                2 + 2 * n_metrics,
-                device=accelerator.device,
-                dtype=_reduction_float_dtype(accelerator.device),
-            )
-            packed[0] = train_loss_sum
-            packed[1] = train_loss_count
-            for i, key in enumerate(metric_keys):
-                packed[2 + 2 * i] = train_metric_sums.get(key, 0.0)
-                packed[2 + 2 * i + 1] = train_metric_counts.get(key, 0)
-            reduced = accelerator.reduce(packed, reduction="sum")
-
-            g_loss_sum = reduced[0].item()
-            g_loss_count = reduced[1].item()
-            train_loss = g_loss_sum / g_loss_count if g_loss_count > 0 else 0.0
-
-            lr_values = {name: float(opt.param_groups[0]["lr"]) for name, opt in prepared_opts}
-            first_lr = next(iter(lr_values.values()))
-            grad_norm_value = float("nan")
-            train_log: dict[str, float | str] = {
-                "train/loss": train_loss,
-                "train/lr": first_lr,
-                "stage": stage.name,
-                "step": float(global_step),
-            }
-            for name, value in lr_values.items():
-                train_log[f"train/lr_{name}"] = value
-            for i, key in enumerate(metric_keys):
-                g_sum = reduced[2 + 2 * i].item()
-                g_count = reduced[2 + 2 * i + 1].item()
-                metric_mean = g_sum / g_count if g_count > 0 else float("nan")
-                if math.isfinite(metric_mean):
-                    train_log[f"train/{key}"] = metric_mean
-                    if key == "grad_norm":
-                        grad_norm_value = float(metric_mean)
-                        grad_norm_sum += grad_norm_value
-                        grad_norm_count += 1
-                        max_grad_norm = max(max_grad_norm, grad_norm_value)
-                        final_grad_norm = grad_norm_value
-
-            if run is not None and accelerator.is_main_process:
-                run.log(train_log, step=global_step)
-
-            history_val_metrics: dict[str, float] | None = None
-            if global_step % int(cfg.runtime.eval_every) == 0:
-                _set_optimizer_training_mode(prepared_opts, training=False)
-                val_metrics = _evaluate_loader(
-                    model,
-                    val_loader,
-                    accelerator=accelerator,
-                    task=task,
-                    max_batches=int(cfg.runtime.val_batches),
-                )
-                if run is not None and accelerator.is_main_process:
-                    run.log({f"val/{k}": v for k, v in val_metrics.items()}, step=global_step)
-                history_val_metrics = val_metrics
-                last_val_metrics = val_metrics
-
-                if val_metrics["val_loss"] < best_val:
-                    best_val = val_metrics["val_loss"]
-                    best_val_step = float(global_step)
-                    best_checkpoint = output_dir / "checkpoints" / "best.pt"
-                    if accelerator.is_main_process:
-                        save_checkpoint(
-                            best_checkpoint,
-                            model_state=accelerator.get_state_dict(model),
-                            global_step=global_step,
-                            cfg=cfg,
-                        )
-                _set_optimizer_training_mode(prepared_opts, training=True)
-
-            if checkpoint_every is not None and global_step % checkpoint_every == 0:
-                snapshot_checkpoint = output_dir / "checkpoints" / f"step_{global_step:06d}.pt"
-                if accelerator.is_main_process:
-                    save_checkpoint(
-                        snapshot_checkpoint,
-                        model_state=accelerator.get_state_dict(model),
-                        global_step=global_step,
-                        cfg=cfg,
+                for opt_name, opt in prepared_opts:
+                    _set_optimizer_base_lr(
+                        opt,
+                        base_lr=current_base_lr,
+                        scales=lr_scales[opt_name],
                     )
+                for _opt_name, opt in prepared_opts:
+                    opt.zero_grad(set_to_none=True)
+                train_loss_sum = 0.0
+                train_loss_count = 0
+                train_metric_sums: dict[str, float] = {}
+                train_metric_counts: dict[str, int] = {}
+                step_train_start = time.perf_counter()
+                for _micro_step in range(grad_accum_steps):
+                    batch = move_batch(next(train_iter), accelerator.device)
+                    with accelerator.accumulate(model):
+                        with accelerator.autocast():
+                            output = model(batch)
+                            loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
+                        accelerator.backward(loss)
+                    train_loss_sum += float(loss.detach().item())
+                    train_loss_count += 1
+                    for key, value in metrics.items():
+                        train_metric_sums[key] = train_metric_sums.get(key, 0.0) + float(value)
+                        train_metric_counts[key] = train_metric_counts.get(key, 0) + 1
 
-            if history_path is not None and accelerator.is_main_process:
+                local_grad_norm = total_grad_norm(model.parameters())
+                if float(cfg.runtime.grad_clip) > 0:
+                    clipped = accelerator.clip_grad_norm_(model.parameters(), float(cfg.runtime.grad_clip))
+                    local_grad_norm = normalize_grad_norm_value(clipped, fallback=local_grad_norm)
+                train_metric_sums["grad_norm"] = train_metric_sums.get("grad_norm", 0.0) + float(local_grad_norm)
+                train_metric_counts["grad_norm"] = train_metric_counts.get("grad_norm", 0) + 1
+
+                for _opt_name, opt in prepared_opts:
+                    opt.step()
+
+                train_elapsed_seconds += time.perf_counter() - step_train_start
+                global_step += 1
+                metric_keys = sorted(set(train_metric_sums) | expected_keys)
+                # Pack loss + metric sums/counts into one tensor for a single all-reduce.
+                # Layout: [loss_sum, loss_count, key0_sum, key0_count, ...]
+                n_metrics = len(metric_keys)
+                packed = torch.zeros(
+                    2 + 2 * n_metrics,
+                    device=accelerator.device,
+                    dtype=_reduction_float_dtype(accelerator.device),
+                )
+                packed[0] = train_loss_sum
+                packed[1] = train_loss_count
+                for i, key in enumerate(metric_keys):
+                    packed[2 + 2 * i] = train_metric_sums.get(key, 0.0)
+                    packed[2 + 2 * i + 1] = train_metric_counts.get(key, 0)
+                reduced = accelerator.reduce(packed, reduction="sum")
+
+                g_loss_sum = reduced[0].item()
+                g_loss_count = reduced[1].item()
+                train_loss = g_loss_sum / g_loss_count if g_loss_count > 0 else 0.0
+
+                lr_values = {name: float(opt.param_groups[0]["lr"]) for name, opt in prepared_opts}
+                first_lr = next(iter(lr_values.values()))
+                grad_norm_value = float("nan")
+                train_log: dict[str, Any] = {
+                    "train/loss": train_loss,
+                    "train/lr": first_lr,
+                    "train/stage": stage.name,
+                }
+                for name, value in lr_values.items():
+                    train_log[f"train/lr_{name}"] = value
+                for i, key in enumerate(metric_keys):
+                    g_sum = reduced[2 + 2 * i].item()
+                    g_count = reduced[2 + 2 * i + 1].item()
+                    metric_mean = g_sum / g_count if g_count > 0 else float("nan")
+                    if math.isfinite(metric_mean):
+                        train_log[f"train/{key}"] = metric_mean
+                        if key == "grad_norm":
+                            grad_norm_value = float(metric_mean)
+                            grad_norm_sum += grad_norm_value
+                            grad_norm_count += 1
+                            max_grad_norm = max(max_grad_norm, grad_norm_value)
+                            final_grad_norm = grad_norm_value
+
                 current_train_loss = float(train_loss)
                 loss_delta_value = train_loss_delta(
                     current_train_loss,
@@ -540,83 +511,184 @@ def train(cfg: DictConfig) -> TrainResult:
                 )
                 loss_ema = update_loss_ema(current_train_loss, previous_ema=loss_ema)
                 previous_train_loss = current_train_loss
-                train_metrics_for_history = {
-                    key.removeprefix("train/"): float(value)
-                    for key, value in train_log.items()
-                    if key.startswith("train/")
-                    and isinstance(value, (int, float))
-                    and key != "train/lr"
-                    and math.isfinite(float(value))
-                }
-                append_history_record(
-                    history_path,
-                    history_record(
-                        global_step=global_step,
-                        stage_name=stage.name,
-                        train_loss=float(train_loss),
-                        train_metrics=train_metrics_for_history,
-                        lr=float(first_lr),
-                        grad_norm=None if not math.isfinite(grad_norm_value) else float(grad_norm_value),
-                        elapsed_seconds=time.perf_counter() - train_start,
-                        train_elapsed_seconds=train_elapsed_seconds,
-                        val_metrics=history_val_metrics,
-                        train_loss_delta=loss_delta_value,
-                        train_loss_ema=loss_ema,
-                        grad_clip_threshold=float(cfg.runtime.grad_clip),
-                        grad_clip_triggered=bool(
-                            float(cfg.runtime.grad_clip) > 0
-                            and math.isfinite(grad_norm_value)
-                            and float(grad_norm_value) > float(cfg.runtime.grad_clip)
-                        ),
-                    ),
+                elapsed_seconds = time.perf_counter() - train_start
+                grad_clip_threshold = float(cfg.runtime.grad_clip)
+                grad_clip_triggered = bool(
+                    grad_clip_threshold > 0
+                    and math.isfinite(grad_norm_value)
+                    and float(grad_norm_value) > grad_clip_threshold
                 )
+                train_log["train/loss_delta"] = loss_delta_value
+                train_log["train/loss_ema"] = loss_ema
+                train_log["train/elapsed_seconds"] = elapsed_seconds
+                train_log["train/train_elapsed_seconds"] = train_elapsed_seconds
+                train_log["train/grad_clip_threshold"] = grad_clip_threshold
+                train_log["train/grad_clip_triggered"] = grad_clip_triggered
+                log_wandb_metrics(run, train_log, step=global_step)
 
-            if max_steps is not None and global_step >= max_steps:
-                stop_requested = True
-            if target_train_seconds is not None and train_elapsed_seconds >= target_train_seconds:
-                stop_requested = True
+                history_val_metrics: dict[str, float] | None = None
+                if global_step % int(cfg.runtime.eval_every) == 0:
+                    _set_optimizer_training_mode(prepared_opts, training=False)
+                    val_metrics = _evaluate_loader(
+                        model,
+                        val_loader,
+                        accelerator=accelerator,
+                        task=task,
+                        max_batches=int(cfg.runtime.val_batches),
+                    )
+                    log_wandb_metrics(
+                        run,
+                        {f"val/{k}": v for k, v in val_metrics.items()},
+                        step=global_step,
+                    )
+                    history_val_metrics = val_metrics
+                    last_val_metrics = val_metrics
+
+                    if val_metrics["val_loss"] < best_val:
+                        best_val = val_metrics["val_loss"]
+                        best_val_step = float(global_step)
+                        best_checkpoint = output_dir / "checkpoints" / "best.pt"
+                        if accelerator.is_main_process:
+                            save_checkpoint(
+                                best_checkpoint,
+                                model_state=accelerator.get_state_dict(model),
+                                global_step=global_step,
+                                cfg=cfg,
+                            )
+                    _set_optimizer_training_mode(prepared_opts, training=True)
+
+                if checkpoint_every is not None and global_step % checkpoint_every == 0:
+                    snapshot_checkpoint = output_dir / "checkpoints" / f"step_{global_step:06d}.pt"
+                    if accelerator.is_main_process:
+                        save_checkpoint(
+                            snapshot_checkpoint,
+                            model_state=accelerator.get_state_dict(model),
+                            global_step=global_step,
+                            cfg=cfg,
+                        )
+
+                if history_path is not None and accelerator.is_main_process:
+                    train_metrics_for_history = {
+                        key.removeprefix("train/"): float(value)
+                        for key, value in train_log.items()
+                        if key.startswith("train/")
+                        and isinstance(value, (int, float))
+                        and key != "train/lr"
+                        and math.isfinite(float(value))
+                    }
+                    append_history_record(
+                        history_path,
+                        history_record(
+                            global_step=global_step,
+                            stage_name=stage.name,
+                            train_loss=float(train_loss),
+                            train_metrics=train_metrics_for_history,
+                            lr=float(first_lr),
+                            grad_norm=None if not math.isfinite(grad_norm_value) else float(grad_norm_value),
+                            elapsed_seconds=elapsed_seconds,
+                            train_elapsed_seconds=train_elapsed_seconds,
+                            val_metrics=history_val_metrics,
+                            train_loss_delta=loss_delta_value,
+                            train_loss_ema=loss_ema,
+                            grad_clip_threshold=grad_clip_threshold,
+                            grad_clip_triggered=grad_clip_triggered,
+                        ),
+                    )
+
+                if max_steps is not None and global_step >= max_steps:
+                    stop_requested = True
+                if target_train_seconds is not None and train_elapsed_seconds >= target_train_seconds:
+                    stop_requested = True
+                if stop_requested:
+                    break
+
+            latest_checkpoint = output_dir / "checkpoints" / f"latest_{stage.name}.pt"
+            if accelerator.is_main_process:
+                save_checkpoint(
+                    latest_checkpoint,
+                    model_state=accelerator.get_state_dict(model),
+                    global_step=global_step,
+                    cfg=cfg,
+                )
             if stop_requested:
                 break
 
-        latest_checkpoint = output_dir / "checkpoints" / f"latest_{stage.name}.pt"
-        if accelerator.is_main_process:
-            save_checkpoint(
-                latest_checkpoint,
-                model_state=accelerator.get_state_dict(model),
+        accelerator.wait_for_everyone()
+
+        wall_elapsed_seconds = time.perf_counter() - train_start
+        if best_checkpoint is None and latest_checkpoint is not None:
+            best_checkpoint = output_dir / "checkpoints" / "best.pt"
+            if accelerator.is_main_process:
+                save_checkpoint(
+                    best_checkpoint,
+                    model_state=accelerator.get_state_dict(model),
+                    global_step=global_step,
+                    cfg=cfg,
+                )
+
+        result = TrainResult(
+            output_dir=output_dir,
+            best_checkpoint=best_checkpoint,
+            latest_checkpoint=latest_checkpoint,
+            global_step=global_step,
+            metrics={
+                "best_val_loss": float(best_val),
+                "best_val_step": float(best_val_step),
+                "final_val_loss": float(last_val_metrics["val_loss"])
+                if last_val_metrics is not None
+                else float(best_val),
+                "final_grad_norm": float(final_grad_norm),
+                "mean_grad_norm": float(grad_norm_sum / grad_norm_count) if grad_norm_count > 0 else 0.0,
+                "max_grad_norm": float(max_grad_norm),
+                "train_elapsed_seconds": float(train_elapsed_seconds),
+                "wall_elapsed_seconds": float(wall_elapsed_seconds),
+            },
+        )
+        update_wandb_summary(
+            run,
+            _trainer_summary_payload(
+                output_dir=output_dir,
+                optimizer_requested_name=optimizer_sel.requested_name,
+                optimizer_resolved_name=optimizer_sel.resolved_name,
+                optimizer_fallback_reason=optimizer_sel.fallback_reason,
                 global_step=global_step,
-                cfg=cfg,
-            )
-        if stop_requested:
-            break
-
-    accelerator.wait_for_everyone()
-    if run is not None and accelerator.is_main_process:
-        run.finish()
-
-    wall_elapsed_seconds = time.perf_counter() - train_start
-    if best_checkpoint is None and latest_checkpoint is not None:
-        best_checkpoint = output_dir / "checkpoints" / "best.pt"
-        if accelerator.is_main_process:
-            save_checkpoint(
-                best_checkpoint,
-                model_state=accelerator.get_state_dict(model),
+                best_checkpoint=best_checkpoint,
+                latest_checkpoint=latest_checkpoint,
+                best_val=best_val,
+                best_val_step=best_val_step,
+                last_val_metrics=last_val_metrics,
+                final_grad_norm=final_grad_norm,
+                grad_norm_sum=grad_norm_sum,
+                grad_norm_count=grad_norm_count,
+                max_grad_norm=max_grad_norm,
+                train_elapsed_seconds=train_elapsed_seconds,
+                wall_elapsed_seconds=wall_elapsed_seconds,
+            ),
+        )
+        return result
+    except Exception as exc:
+        update_wandb_summary(
+            run,
+            _trainer_summary_payload(
+                output_dir=output_dir,
+                optimizer_requested_name=optimizer_sel.requested_name,
+                optimizer_resolved_name=optimizer_sel.resolved_name,
+                optimizer_fallback_reason=optimizer_sel.fallback_reason,
                 global_step=global_step,
-                cfg=cfg,
-            )
-
-    return TrainResult(
-        output_dir=output_dir,
-        best_checkpoint=best_checkpoint,
-        latest_checkpoint=latest_checkpoint,
-        global_step=global_step,
-        metrics={
-            "best_val_loss": float(best_val),
-            "best_val_step": float(best_val_step),
-            "final_val_loss": float(last_val_metrics["val_loss"]) if last_val_metrics is not None else float(best_val),
-            "final_grad_norm": float(final_grad_norm),
-            "mean_grad_norm": float(grad_norm_sum / grad_norm_count) if grad_norm_count > 0 else 0.0,
-            "max_grad_norm": float(max_grad_norm),
-            "train_elapsed_seconds": float(train_elapsed_seconds),
-            "wall_elapsed_seconds": float(wall_elapsed_seconds),
-        },
-    )
+                best_checkpoint=best_checkpoint,
+                latest_checkpoint=latest_checkpoint,
+                best_val=best_val,
+                best_val_step=best_val_step,
+                last_val_metrics=last_val_metrics,
+                final_grad_norm=final_grad_norm,
+                grad_norm_sum=grad_norm_sum,
+                grad_norm_count=grad_norm_count,
+                max_grad_norm=max_grad_norm,
+                train_elapsed_seconds=train_elapsed_seconds,
+                wall_elapsed_seconds=time.perf_counter() - train_start,
+                error=exc,
+            ),
+        )
+        raise
+    finally:
+        finish_wandb_run(run)

--- a/src/tab_foundry/training/wandb.py
+++ b/src/tab_foundry/training/wandb.py
@@ -1,0 +1,129 @@
+"""Shared Weights & Biases helpers for training entrypoints."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import math
+import os
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def _normalize_wandb_value(value: object) -> Any | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, Path):
+        return str(value.expanduser().resolve())
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, float):
+        return float(value) if math.isfinite(float(value)) else None
+    return None
+
+
+def _normalized_wandb_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for key, value in payload.items():
+        resolved = _normalize_wandb_value(value)
+        if resolved is not None:
+            normalized[str(key)] = resolved
+    return normalized
+
+
+def _flatten_summary_payload(
+    payload: Mapping[str, Any],
+    *,
+    prefix: str = "",
+) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    for key, value in payload.items():
+        key_str = str(key)
+        dotted_key = key_str if not prefix else f"{prefix}/{key_str}"
+        if isinstance(value, Mapping):
+            flattened.update(_flatten_summary_payload(value, prefix=dotted_key))
+            continue
+        resolved = _normalize_wandb_value(value)
+        if resolved is not None:
+            flattened[dotted_key] = resolved
+    return flattened
+
+
+def resolve_wandb_api_key() -> str | None:
+    value = os.getenv("WANDB_API_KEY")
+    if value is not None:
+        normalized = value.strip()
+        if normalized:
+            return normalized
+
+    file_override = os.getenv("WANDB_API_KEY_FILE")
+    candidate = (
+        Path(file_override).expanduser()
+        if file_override
+        else Path("~/.wandb/wandb_api_key.txt").expanduser()
+    )
+    try:
+        normalized = candidate.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not normalized:
+        return None
+    os.environ["WANDB_API_KEY"] = normalized
+    return normalized
+
+
+def init_wandb_run(cfg: DictConfig, *, enabled: bool) -> Any | None:
+    if not enabled:
+        return None
+    try:
+        import wandb
+    except Exception:
+        return None
+
+    api_key = resolve_wandb_api_key()
+    mode: Literal["online", "offline"] = "online" if api_key else "offline"
+    cfg_payload = cast(dict[str, Any], OmegaConf.to_container(cfg, resolve=True))
+    return wandb.init(
+        project=str(cfg.logging.project),
+        name=str(cfg.logging.run_name),
+        mode=mode,
+        config=cfg_payload,
+    )
+
+
+def log_wandb_metrics(run: Any | None, payload: Mapping[str, Any], *, step: int) -> None:
+    if run is None:
+        return
+    log = getattr(run, "log", None)
+    if not callable(log):
+        return
+    normalized = _normalized_wandb_payload(payload)
+    if not normalized:
+        return
+    log(normalized, step=int(step))
+
+
+def update_wandb_summary(run: Any | None, payload: Mapping[str, Any]) -> None:
+    if run is None:
+        return
+    summary = getattr(run, "summary", None)
+    if summary is None:
+        return
+    for key, value in _flatten_summary_payload(payload).items():
+        try:
+            summary[key] = value
+        except Exception:
+            continue
+
+
+def finish_wandb_run(run: Any | None) -> None:
+    if run is None:
+        return
+    finish = getattr(run, "finish", None)
+    if callable(finish):
+        finish()

--- a/tests/benchmark/test_prior_train.py
+++ b/tests/benchmark/test_prior_train.py
@@ -271,6 +271,19 @@ class _LrTrackingOptimizer(_CountingOptimizer):
         super().step()
 
 
+class _FakeWandbRun:
+    def __init__(self) -> None:
+        self.logged: list[tuple[dict[str, object], int]] = []
+        self.summary: dict[str, object] = {}
+        self.finished = False
+
+    def log(self, payload: dict[str, object], *, step: int) -> None:
+        self.logged.append((dict(payload), int(step)))
+
+    def finish(self) -> None:
+        self.finished = True
+
+
 def _prior_cfg(
     tmp_path: Path,
     *,
@@ -1429,6 +1442,129 @@ def test_train_tabfoundry_simple_prior_writes_failure_telemetry_for_nonfinite_la
     assert telemetry["missingness"]["prior_dump"]["affected_dataset_indices"] == [0]
     assert telemetry["missingness"]["prior_dump"]["non_finite_feature_count"] == 0
     assert telemetry["missingness"]["prior_dump"]["non_finite_label_count"] == 1
+
+
+def test_train_tabfoundry_simple_prior_logs_wandb_metrics_and_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = _write_prior_dump(
+        tmp_path / "prior_wandb.h5",
+        x=np.asarray(
+            [
+                [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+                [[2.0, 1.0], [4.0, 3.0], [6.0, 5.0], [8.0, 7.0]],
+            ],
+            dtype=np.float32,
+        ),
+        y=np.asarray(
+            [
+                [0, 1, 0, 1],
+                [1, 0, 1, 1],
+            ],
+            dtype=np.int64,
+        ),
+        num_features=np.asarray([2, 2], dtype=np.int64),
+        num_datapoints=np.asarray([4, 4], dtype=np.int64),
+        single_eval_pos=np.asarray([2, 2], dtype=np.int64),
+    )
+    fake_run = _FakeWandbRun()
+    monkeypatch.setattr(prior_train_module, "build_model_from_spec", lambda _spec: _ConstantLogitModel())
+    monkeypatch.setattr(
+        prior_train_module,
+        "build_optimizer",
+        lambda *args, **kwargs: OptimizerSelection(
+            optimizers=[("schedulefree_adamw", _CountingOptimizer())],
+            requested_name="schedulefree_adamw",
+            resolved_name="schedulefree_adamw",
+            fallback_reason=None,
+        ),
+    )
+    monkeypatch.setattr(
+        prior_train_module,
+        "module_grad_norms",
+        lambda _model: {"decoder": 0.25},
+    )
+    monkeypatch.setattr(prior_train_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+    cfg = _prior_cfg(tmp_path, max_steps=2)
+    cfg.logging.use_wandb = True
+    cfg.logging.project = "test-project"
+    cfg.logging.run_name = "prior-wandb"
+
+    _ = prior_train_module.train_tabfoundry_simple_prior(
+        cfg,
+        prior_dump_path=path,
+        batch_size=2,
+    )
+
+    train_logs = [
+        (payload, step)
+        for payload, step in fake_run.logged
+        if "train/loss" in payload
+    ]
+    assert [step for _payload, step in train_logs] == [1, 2]
+    assert "train/loss_delta" not in train_logs[0][0]
+    assert train_logs[1][0]["train/stage"] == "prior_dump"
+    assert "train/loss_delta" in train_logs[1][0]
+    assert "train/loss_ema" in train_logs[1][0]
+    assert "train/elapsed_seconds" in train_logs[1][0]
+    assert "train/train_elapsed_seconds" in train_logs[1][0]
+    assert "train/grad_clip_threshold" in train_logs[1][0]
+    assert "train/grad_clip_triggered" in train_logs[1][0]
+    assert train_logs[1][0]["train/module_grad_norm/decoder"] == pytest.approx(0.25)
+    assert fake_run.finished is True
+    assert fake_run.summary["run/output_dir"] == str((tmp_path / "train_out").resolve())
+    assert fake_run.summary["run/global_step"] == 2
+    assert fake_run.summary["telemetry/success"] is True
+    assert fake_run.summary["telemetry/checkpoint_snapshot_count"] == 2
+    assert fake_run.summary["artifacts/latest_checkpoint"].endswith("latest.pt")
+    assert fake_run.summary["loss_summary/final_train_loss"] >= 0.0
+    assert fake_run.summary["gradient_summary/global/final_grad_norm"] >= 0.0
+    assert fake_run.summary["missingness/prior_dump/non_finite_feature_count"] == 0
+
+
+def test_train_tabfoundry_simple_prior_logs_wandb_failure_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = _write_prior_dump(
+        tmp_path / "prior_wandb_nonfinite.h5",
+        x=np.asarray([[[1.0, np.nan], [2.0, 3.0], [4.0, 5.0]]], dtype=np.float32),
+        y=np.asarray([[0, 1, 0]], dtype=np.int64),
+        num_features=np.asarray([2], dtype=np.int64),
+        num_datapoints=np.asarray([3], dtype=np.int64),
+        single_eval_pos=np.asarray([2], dtype=np.int64),
+    )
+    fake_run = _FakeWandbRun()
+    monkeypatch.setattr(prior_train_module, "build_model_from_spec", lambda _spec: _ConstantLogitModel())
+    monkeypatch.setattr(
+        prior_train_module,
+        "build_optimizer",
+        lambda *args, **kwargs: OptimizerSelection(
+            optimizers=[("schedulefree_adamw", _CountingOptimizer())],
+            requested_name="schedulefree_adamw",
+            resolved_name="schedulefree_adamw",
+            fallback_reason=None,
+        ),
+    )
+    monkeypatch.setattr(prior_train_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+    cfg = _prior_cfg(tmp_path, max_steps=1)
+    cfg.logging.use_wandb = True
+    cfg.logging.project = "test-project"
+    cfg.logging.run_name = "prior-wandb-failure"
+
+    with pytest.raises(PriorDumpNonFiniteInputError):
+        _ = prior_train_module.train_tabfoundry_simple_prior(
+            cfg,
+            prior_dump_path=path,
+            batch_size=1,
+        )
+
+    assert fake_run.finished is True
+    assert fake_run.summary["telemetry/success"] is False
+    assert fake_run.summary["error/type"] == "PriorDumpNonFiniteInputError"
+    assert "contains NaN or Inf" in str(fake_run.summary["error/message"])
+    assert fake_run.summary["missingness/prior_dump/affected_batch_count"] == 1
 
 
 def test_evaluate_tab_foundry_run_supports_runs_without_best_checkpoint(

--- a/tests/training/test_train_eval_smoke.py
+++ b/tests/training/test_train_eval_smoke.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 import json
-import os
 from pathlib import Path
 from types import SimpleNamespace
-import sys
 
 from omegaconf import OmegaConf
 import pytest
@@ -97,6 +95,19 @@ class _TinyClassifier(nn.Module):
         )
 
 
+class _FakeWandbRun:
+    def __init__(self) -> None:
+        self.logged: list[tuple[dict[str, object], int]] = []
+        self.summary: dict[str, object] = {}
+        self.finished = False
+
+    def log(self, payload: dict[str, object], *, step: int) -> None:
+        self.logged.append((dict(payload), int(step)))
+
+    def finish(self) -> None:
+        self.finished = True
+
+
 def _classification_cfg(tmp_path: Path) -> object:
     return OmegaConf.create(
         {
@@ -146,7 +157,7 @@ def _install_classification_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
         "build_accelerator_from_runtime",
         lambda *_args, **_kwargs: _FakeAccelerator(),
     )
-    monkeypatch.setattr(trainer_module, "_wandb_init", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(trainer_module, "init_wandb_run", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(trainer_module, "model_build_spec_from_mappings", lambda **_kwargs: fake_spec)
     monkeypatch.setattr(
         evaluate_module,
@@ -249,56 +260,6 @@ def test_train_rejects_non_empty_history_jsonl(tmp_path: Path, monkeypatch: pyte
         _ = trainer_module.train(cfg)
 
 
-def test_wandb_init_uses_api_key_file_when_env_missing(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    cfg = _classification_cfg(tmp_path)
-    cfg.logging.use_wandb = True
-    key_path = tmp_path / "wandb_api_key.txt"
-    key_path.write_text("secret-key\n", encoding="utf-8")
-
-    calls: list[dict[str, object]] = []
-
-    def _fake_init(**kwargs: object) -> dict[str, object]:
-        calls.append(dict(kwargs))
-        return dict(kwargs)
-
-    monkeypatch.delenv("WANDB_API_KEY", raising=False)
-    monkeypatch.setenv("WANDB_API_KEY_FILE", str(key_path))
-    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(init=_fake_init))
-
-    run = trainer_module._wandb_init(cfg, enabled=True)
-
-    assert run is not None
-    assert calls[0]["mode"] == "online"
-    assert os.environ["WANDB_API_KEY"] == "secret-key"
-
-
-def test_wandb_init_falls_back_to_offline_without_any_api_key(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    cfg = _classification_cfg(tmp_path)
-    cfg.logging.use_wandb = True
-
-    calls: list[dict[str, object]] = []
-
-    def _fake_init(**kwargs: object) -> dict[str, object]:
-        calls.append(dict(kwargs))
-        return dict(kwargs)
-
-    monkeypatch.delenv("WANDB_API_KEY", raising=False)
-    monkeypatch.delenv("WANDB_API_KEY_FILE", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(init=_fake_init))
-
-    run = trainer_module._wandb_init(cfg, enabled=True)
-
-    assert run is not None
-    assert calls[0]["mode"] == "offline"
-
-
 def test_train_rejects_existing_checkpoint_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -362,3 +323,49 @@ def test_train_history_uses_linear_schedule_values(
         if line.strip()
     ]
     assert [record["lr"] for record in records] == pytest.approx([1.0e-3, 7.0e-4, 4.0e-4, 1.0e-4])
+
+
+def test_train_logs_enriched_wandb_metrics_and_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_classification_fakes(monkeypatch)
+    cfg = _classification_cfg(tmp_path)
+    cfg.logging.use_wandb = True
+    cfg.schedule.stages = [{"name": "stage1", "steps": 2, "lr_max": 1.0e-3}]
+    fake_run = _FakeWandbRun()
+    monkeypatch.setattr(trainer_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+
+    result = trainer_module.train(cfg)
+
+    train_logs = [
+        (payload, step)
+        for payload, step in fake_run.logged
+        if "train/loss" in payload
+    ]
+    assert [step for _payload, step in train_logs] == [1, 2]
+    assert "train/loss_delta" not in train_logs[0][0]
+    assert train_logs[1][0]["train/stage"] == "stage1"
+    assert "train/loss_delta" in train_logs[1][0]
+    assert "train/loss_ema" in train_logs[1][0]
+    assert "train/elapsed_seconds" in train_logs[1][0]
+    assert "train/train_elapsed_seconds" in train_logs[1][0]
+    assert "train/grad_clip_threshold" in train_logs[1][0]
+    assert "train/grad_clip_triggered" in train_logs[1][0]
+    assert "train/lr_adamw" in train_logs[1][0]
+    val_logs = [
+        (payload, step)
+        for payload, step in fake_run.logged
+        if "val/val_loss" in payload
+    ]
+    assert [step for _payload, step in val_logs] == [1, 2]
+    assert fake_run.finished is True
+    assert fake_run.summary["optimizer/requested_name"] == "adamw"
+    assert fake_run.summary["optimizer/resolved_name"] == "adamw"
+    assert fake_run.summary["run/output_dir"] == str(result.output_dir)
+    assert fake_run.summary["run/global_step"] == 2
+    assert fake_run.summary["run/best_checkpoint"] == str(result.best_checkpoint.resolve())
+    assert fake_run.summary["run/latest_checkpoint"] == str(result.latest_checkpoint.resolve())
+    assert fake_run.summary["metrics/best_val_loss"] >= 0.0
+    assert fake_run.summary["metrics/final_grad_norm"] >= 0.0
+    assert fake_run.summary["metrics/wall_elapsed_seconds"] >= 0.0

--- a/tests/training/test_wandb.py
+++ b/tests/training/test_wandb.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+from omegaconf import OmegaConf
+import pytest
+
+from tab_foundry.training import wandb as wandb_module
+
+
+class _FakeRun:
+    def __init__(self) -> None:
+        self.logged: list[tuple[dict[str, object], int]] = []
+        self.summary: dict[str, object] = {}
+        self.finished = False
+
+    def log(self, payload: dict[str, object], *, step: int) -> None:
+        self.logged.append((dict(payload), int(step)))
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+def _wandb_cfg(tmp_path: Path):
+    return OmegaConf.create(
+        {
+            "logging": {
+                "use_wandb": True,
+                "project": "test-project",
+                "run_name": f"run-{tmp_path.name}",
+            }
+        }
+    )
+
+
+def test_init_wandb_run_uses_api_key_file_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cfg = _wandb_cfg(tmp_path)
+    key_path = tmp_path / "wandb_api_key.txt"
+    key_path.write_text("secret-key\n", encoding="utf-8")
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_init(**kwargs: object) -> dict[str, object]:
+        calls.append(dict(kwargs))
+        return dict(kwargs)
+
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.setenv("WANDB_API_KEY_FILE", str(key_path))
+    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(init=_fake_init))
+
+    run = wandb_module.init_wandb_run(cfg, enabled=True)
+
+    assert run is not None
+    assert calls[0]["mode"] == "online"
+    assert os.environ["WANDB_API_KEY"] == "secret-key"
+
+
+def test_init_wandb_run_falls_back_to_offline_without_any_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cfg = _wandb_cfg(tmp_path)
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_init(**kwargs: object) -> dict[str, object]:
+        calls.append(dict(kwargs))
+        return dict(kwargs)
+
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.delenv("WANDB_API_KEY_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(init=_fake_init))
+
+    run = wandb_module.init_wandb_run(cfg, enabled=True)
+
+    assert run is not None
+    assert calls[0]["mode"] == "offline"
+
+
+def test_wandb_helpers_normalize_metrics_and_summary() -> None:
+    run = _FakeRun()
+
+    wandb_module.log_wandb_metrics(
+        run,
+        {
+            "train/loss": 1.25,
+            "train/stage": "stage1",
+            "train/flag": True,
+            "train/skip": None,
+            "train/bad": float("inf"),
+        },
+        step=3,
+    )
+
+    assert run.logged == [
+        (
+            {
+                "train/loss": 1.25,
+                "train/stage": "stage1",
+                "train/flag": True,
+            },
+            3,
+        )
+    ]
+
+    wandb_module.update_wandb_summary(
+        run,
+        {
+            "metrics": {"final_loss": 0.5, "bad": float("nan")},
+            "run": {"output_dir": Path("/tmp/demo"), "global_step": 3},
+            "error": {"message": "boom"},
+            "skip": None,
+        },
+    )
+
+    assert run.summary["metrics/final_loss"] == 0.5
+    assert run.summary["run/output_dir"] == str(Path("/tmp/demo").resolve())
+    assert run.summary["run/global_step"] == 3
+    assert run.summary["error/message"] == "boom"
+    assert "metrics/bad" not in run.summary
+    wandb_module.finish_wandb_run(run)
+    assert run.finished is True

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Summary
- add the new `src/tab_foundry/training/wandb.py` helpers and point both the trainer and prior-train workflows at them with a single lifecycle
- expand the trainer/prior-train telemetry payloads per plan so we capture the requested scalars and summary metadata
- bump the package to 0.6.4 and document the change in `CHANGELOG.md`

Testing
- Not run (not requested)