### PR TITLE
Log existing loss metrics to wandb summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-03-16
+
+### Changed
+
+- Standalone checkpoint evaluation now uses the shared internal Weights &
+  Biases helper when `logging.use_wandb=true`, logging the existing computed
+  `eval/loss` plus task-specific `eval/acc` or `eval/rmse` scalars and a
+  compact summary payload without changing CLI flags or evaluation result
+  schemas.
+
+- Main trainer wandb summaries now retain the final already-computed training
+  loss state, including additive `metrics/final_train_loss`,
+  `metrics/final_train_loss_ema`, and task-specific
+  `metrics/final_train_acc` or `metrics/final_train_rmse`, without changing
+  `train_history.jsonl` or `TrainResult`.
+
 ## [0.6.5] - 2026-03-16
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.6.5"
+version = "0.6.6"
 description = "Tabfoundry tabular foundation model training on dagzoo packed shard outputs"
 readme = "README.md"
 license = "MIT"

--- a/src/tab_foundry/training/evaluate.py
+++ b/src/tab_foundry/training/evaluate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from omegaconf import DictConfig, OmegaConf
 import torch
@@ -20,6 +20,7 @@ from .batching import move_batch
 from .distributed import _global_mean_from_local
 from .runtime import build_accelerator_from_runtime
 from .trainer import _compute_loss_and_metrics
+from .wandb import finish_wandb_run, init_wandb_run, log_wandb_metrics, update_wandb_summary
 
 
 def _checkpoint_preprocessing_settings(
@@ -69,6 +70,46 @@ def _checkpoint_model_settings(
     )
 
 
+def _resolved_checkpoint_step(payload: Mapping[str, Any]) -> int:
+    raw_value = payload.get("global_step")
+    if raw_value is None:
+        return 0
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return 0
+    return max(value, 0)
+
+
+def _evaluation_summary_payload(
+    *,
+    checkpoint: Path,
+    split: str,
+    max_batches: int,
+    global_step: int,
+    metrics: Mapping[str, float] | None = None,
+    error: BaseException | None = None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "run": {
+            "checkpoint": str(checkpoint),
+            "split": split,
+            "global_step": int(global_step),
+        },
+        "eval": {
+            "max_batches": int(max_batches),
+        },
+    }
+    if metrics is not None:
+        summary["metrics"] = {
+            str(key): float(value)
+            for key, value in metrics.items()
+        }
+    if error is not None:
+        summary["error"] = {"type": type(error).__name__, "message": str(error)}
+    return summary
+
+
 def evaluate_checkpoint(cfg: DictConfig) -> EvalResult:
     """Evaluate a saved checkpoint."""
 
@@ -80,10 +121,12 @@ def evaluate_checkpoint(cfg: DictConfig) -> EvalResult:
     model_spec = _checkpoint_model_settings(payload, cfg)
     preprocessing_cfg = _checkpoint_preprocessing_settings(payload, cfg)
     task = model_spec.task
+    eval_step = _resolved_checkpoint_step(payload)
     model = build_model_from_spec(model_spec)
     model.load_state_dict(payload["model"])
 
     split = str(cfg.eval.split)
+    max_batches = int(cfg.eval.max_batches)
     ds = build_task_dataset(
         cfg.data,
         split=split,
@@ -101,6 +144,12 @@ def evaluate_checkpoint(cfg: DictConfig) -> EvalResult:
     accelerator = build_accelerator_from_runtime(cfg.runtime)
     model, loader = accelerator.prepare(model, loader)
     model.eval()
+    logging_cfg = cfg.get("logging")
+    use_wandb = bool(getattr(logging_cfg, "use_wandb", False)) if logging_cfg is not None else False
+    run = init_wandb_run(
+        cfg,
+        enabled=bool(use_wandb and accelerator.is_main_process),
+    )
 
     loss_sum = 0.0
     score_sum = 0.0
@@ -108,29 +157,60 @@ def evaluate_checkpoint(cfg: DictConfig) -> EvalResult:
 
     metric_name = "acc" if task == "classification" else "rmse"
 
-    with torch.no_grad():
-        for i, batch in enumerate(loader):
-            if i >= int(cfg.eval.max_batches):
-                break
-            batch = move_batch(batch, accelerator.device)
-            with accelerator.autocast():
-                output = model(batch)
-                loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
-            loss_sum += float(loss.item())
-            score_sum += metrics.get(metric_name, 0.0)
-            count += 1
+    try:
+        with torch.no_grad():
+            for i, batch in enumerate(loader):
+                if i >= max_batches:
+                    break
+                batch = move_batch(batch, accelerator.device)
+                with accelerator.autocast():
+                    output = model(batch)
+                    loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
+                loss_sum += float(loss.item())
+                score_sum += metrics.get(metric_name, 0.0)
+                count += 1
 
-    dev = accelerator.device
-    loss_value = _global_mean_from_local(
-        accelerator, local_sum=loss_sum, local_count=count, device=dev, default=float("inf"),
-    )
-    metric_value = _global_mean_from_local(
-        accelerator, local_sum=score_sum, local_count=count, device=dev, default=0.0,
-    )
-    return EvalResult(
-        checkpoint=checkpoint,
-        metrics={
+        dev = accelerator.device
+        loss_value = _global_mean_from_local(
+            accelerator, local_sum=loss_sum, local_count=count, device=dev, default=float("inf"),
+        )
+        metric_value = _global_mean_from_local(
+            accelerator, local_sum=score_sum, local_count=count, device=dev, default=0.0,
+        )
+        result_metrics = {
             "loss": loss_value,
             metric_name: metric_value,
-        },
-    )
+        }
+        log_wandb_metrics(
+            run,
+            {f"eval/{key}": value for key, value in result_metrics.items()},
+            step=eval_step,
+        )
+        update_wandb_summary(
+            run,
+            _evaluation_summary_payload(
+                checkpoint=checkpoint,
+                split=split,
+                max_batches=max_batches,
+                global_step=eval_step,
+                metrics=result_metrics,
+            ),
+        )
+        return EvalResult(
+            checkpoint=checkpoint,
+            metrics=result_metrics,
+        )
+    except Exception as exc:
+        update_wandb_summary(
+            run,
+            _evaluation_summary_payload(
+                checkpoint=checkpoint,
+                split=split,
+                max_batches=max_batches,
+                global_step=eval_step,
+                error=exc,
+            ),
+        )
+        raise
+    finally:
+        finish_wandb_run(run)

--- a/src/tab_foundry/training/trainer.py
+++ b/src/tab_foundry/training/trainer.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 import math
 from pathlib import Path
 import time
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 from accelerate import Accelerator
 import torch
@@ -250,6 +250,9 @@ def _trainer_summary_payload(
     latest_checkpoint: Path | None,
     best_val: float,
     best_val_step: float,
+    final_train_loss: float | None,
+    final_train_loss_ema: float | None,
+    last_train_metrics: Mapping[str, float] | None,
     last_val_metrics: dict[str, float] | None,
     final_grad_norm: float,
     grad_norm_sum: float,
@@ -259,6 +262,34 @@ def _trainer_summary_payload(
     wall_elapsed_seconds: float,
     error: BaseException | None = None,
 ) -> dict[str, Any]:
+    def _summary_float(value: float | None) -> float | None:
+        if value is None:
+            return None
+        value_f = float(value)
+        return value_f if math.isfinite(value_f) else None
+
+    metrics_payload: dict[str, float | None] = {
+        "best_val_loss": float(best_val),
+        "best_val_step": float(best_val_step) if best_val_step > 0 else None,
+        "final_train_loss": _summary_float(final_train_loss),
+        "final_train_loss_ema": _summary_float(final_train_loss_ema),
+        "final_val_loss": None
+        if last_val_metrics is None
+        else _summary_float(last_val_metrics.get("val_loss")),
+        "final_grad_norm": float(final_grad_norm),
+        "mean_grad_norm": float(grad_norm_sum / grad_norm_count) if grad_norm_count > 0 else 0.0,
+        "max_grad_norm": float(max_grad_norm),
+        "train_elapsed_seconds": float(train_elapsed_seconds),
+        "wall_elapsed_seconds": float(wall_elapsed_seconds),
+    }
+    if last_train_metrics is not None:
+        final_train_acc = _summary_float(last_train_metrics.get("acc"))
+        if final_train_acc is not None:
+            metrics_payload["final_train_acc"] = final_train_acc
+        final_train_rmse = _summary_float(last_train_metrics.get("rmse"))
+        if final_train_rmse is not None:
+            metrics_payload["final_train_rmse"] = final_train_rmse
+
     summary: dict[str, Any] = {
         "optimizer": {
             "requested_name": optimizer_requested_name,
@@ -271,18 +302,7 @@ def _trainer_summary_payload(
             "best_checkpoint": None if best_checkpoint is None else str(best_checkpoint.resolve()),
             "latest_checkpoint": None if latest_checkpoint is None else str(latest_checkpoint.resolve()),
         },
-        "metrics": {
-            "best_val_loss": float(best_val),
-            "best_val_step": float(best_val_step) if best_val_step > 0 else None,
-            "final_val_loss": None
-            if last_val_metrics is None
-            else float(last_val_metrics["val_loss"]),
-            "final_grad_norm": float(final_grad_norm),
-            "mean_grad_norm": float(grad_norm_sum / grad_norm_count) if grad_norm_count > 0 else 0.0,
-            "max_grad_norm": float(max_grad_norm),
-            "train_elapsed_seconds": float(train_elapsed_seconds),
-            "wall_elapsed_seconds": float(wall_elapsed_seconds),
-        },
+        "metrics": metrics_payload,
     }
     if error is not None:
         summary["error"] = {"type": type(error).__name__, "message": str(error)}
@@ -411,6 +431,9 @@ def train(cfg: DictConfig) -> TrainResult:
     final_grad_norm = 0.0
     previous_train_loss: float | None = None
     loss_ema: float | None = None
+    final_train_loss: float | None = None
+    final_train_loss_ema: float | None = None
+    last_train_metrics: dict[str, float] | None = None
 
     try:
         for stage in stage_configs:
@@ -491,11 +514,13 @@ def train(cfg: DictConfig) -> TrainResult:
                 }
                 for name, value in lr_values.items():
                     train_log[f"train/lr_{name}"] = value
+                current_train_metrics: dict[str, float] = {}
                 for i, key in enumerate(metric_keys):
                     g_sum = reduced[2 + 2 * i].item()
                     g_count = reduced[2 + 2 * i + 1].item()
                     metric_mean = g_sum / g_count if g_count > 0 else float("nan")
                     if math.isfinite(metric_mean):
+                        current_train_metrics[key] = float(metric_mean)
                         train_log[f"train/{key}"] = metric_mean
                         if key == "grad_norm":
                             grad_norm_value = float(metric_mean)
@@ -524,6 +549,9 @@ def train(cfg: DictConfig) -> TrainResult:
                 train_log["train/train_elapsed_seconds"] = train_elapsed_seconds
                 train_log["train/grad_clip_threshold"] = grad_clip_threshold
                 train_log["train/grad_clip_triggered"] = grad_clip_triggered
+                final_train_loss = current_train_loss
+                final_train_loss_ema = loss_ema
+                last_train_metrics = current_train_metrics
                 log_wandb_metrics(run, train_log, step=global_step)
 
                 history_val_metrics: dict[str, float] | None = None
@@ -656,6 +684,9 @@ def train(cfg: DictConfig) -> TrainResult:
                 latest_checkpoint=latest_checkpoint,
                 best_val=best_val,
                 best_val_step=best_val_step,
+                final_train_loss=final_train_loss,
+                final_train_loss_ema=final_train_loss_ema,
+                last_train_metrics=last_train_metrics,
                 last_val_metrics=last_val_metrics,
                 final_grad_norm=final_grad_norm,
                 grad_norm_sum=grad_norm_sum,
@@ -679,6 +710,9 @@ def train(cfg: DictConfig) -> TrainResult:
                 latest_checkpoint=latest_checkpoint,
                 best_val=best_val,
                 best_val_step=best_val_step,
+                final_train_loss=final_train_loss,
+                final_train_loss_ema=final_train_loss_ema,
+                last_train_metrics=last_train_metrics,
                 last_val_metrics=last_val_metrics,
                 final_grad_norm=final_grad_norm,
                 grad_norm_sum=grad_norm_sum,

--- a/tests/training/test_train_eval_smoke.py
+++ b/tests/training/test_train_eval_smoke.py
@@ -13,7 +13,7 @@ from torch.utils.data import Dataset
 
 import tab_foundry.training.evaluate as evaluate_module
 import tab_foundry.training.trainer as trainer_module
-from tab_foundry.model.architectures.tabfoundry import ClassificationOutput
+from tab_foundry.model.architectures.tabfoundry import ClassificationOutput, RegressionOutput
 from tab_foundry.training.schedule import build_stage_configs
 from tab_foundry.types import TaskBatch
 
@@ -83,6 +83,28 @@ class _FakeTaskDataset(Dataset[TaskBatch]):
         )
 
 
+class _FakeRegressionTaskDataset(Dataset[TaskBatch]):
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        super().__init__()
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: int) -> TaskBatch:
+        seed = int(index) + 11
+        torch.manual_seed(seed)
+        x_train = torch.randn(6, 4)
+        y_train = torch.linspace(0.0, 1.0, steps=6, dtype=torch.float32)
+        return TaskBatch(
+            x_train=x_train,
+            y_train=y_train,
+            x_test=torch.randn(3, 4),
+            y_test=torch.linspace(0.2, 0.8, steps=3, dtype=torch.float32),
+            metadata={"dataset_index": index},
+            num_classes=None,
+        )
+
+
 class _TinyClassifier(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -92,6 +114,17 @@ class _TinyClassifier(nn.Module):
         return ClassificationOutput(
             logits=self.linear(batch.x_test),
             num_classes=3,
+        )
+
+
+class _TinyRegressor(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(4, 999)
+
+    def forward(self, batch: TaskBatch) -> RegressionOutput:
+        return RegressionOutput(
+            quantiles=self.linear(batch.x_test),
         )
 
 
@@ -143,6 +176,12 @@ def _classification_cfg(tmp_path: Path) -> object:
     )
 
 
+def _regression_cfg(tmp_path: Path) -> object:
+    cfg = _classification_cfg(tmp_path)
+    cfg.task = "regression"
+    return cfg
+
+
 def _install_classification_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_spec = SimpleNamespace(task="classification")
     monkeypatch.setattr(trainer_module, "build_task_dataset", lambda *_args, **_kwargs: _FakeTaskDataset())
@@ -166,6 +205,39 @@ def _install_classification_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(trainer_module, "build_model_from_spec", lambda _spec: _TinyClassifier())
     monkeypatch.setattr(evaluate_module, "build_model_from_spec", lambda _spec: _TinyClassifier())
+
+
+def _install_regression_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_spec = SimpleNamespace(task="regression")
+    monkeypatch.setattr(
+        trainer_module,
+        "build_task_dataset",
+        lambda *_args, **_kwargs: _FakeRegressionTaskDataset(),
+    )
+    monkeypatch.setattr(
+        evaluate_module,
+        "build_task_dataset",
+        lambda *_args, **_kwargs: _FakeRegressionTaskDataset(),
+    )
+    monkeypatch.setattr(
+        trainer_module,
+        "build_accelerator_from_runtime",
+        lambda *_args, **_kwargs: _FakeAccelerator(),
+    )
+    monkeypatch.setattr(
+        evaluate_module,
+        "build_accelerator_from_runtime",
+        lambda *_args, **_kwargs: _FakeAccelerator(),
+    )
+    monkeypatch.setattr(trainer_module, "init_wandb_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(trainer_module, "model_build_spec_from_mappings", lambda **_kwargs: fake_spec)
+    monkeypatch.setattr(
+        evaluate_module,
+        "checkpoint_model_build_spec_from_mappings",
+        lambda **_kwargs: fake_spec,
+    )
+    monkeypatch.setattr(trainer_module, "build_model_from_spec", lambda _spec: _TinyRegressor())
+    monkeypatch.setattr(evaluate_module, "build_model_from_spec", lambda _spec: _TinyRegressor())
 
 
 def test_train_smoke_runs_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -367,5 +439,91 @@ def test_train_logs_enriched_wandb_metrics_and_summary(
     assert fake_run.summary["run/best_checkpoint"] == str(result.best_checkpoint.resolve())
     assert fake_run.summary["run/latest_checkpoint"] == str(result.latest_checkpoint.resolve())
     assert fake_run.summary["metrics/best_val_loss"] >= 0.0
+    assert fake_run.summary["metrics/final_train_loss"] >= 0.0
+    assert 0.0 <= fake_run.summary["metrics/final_train_acc"] <= 1.0
+    assert fake_run.summary["metrics/final_train_loss_ema"] >= 0.0
     assert fake_run.summary["metrics/final_grad_norm"] >= 0.0
     assert fake_run.summary["metrics/wall_elapsed_seconds"] >= 0.0
+
+
+def test_evaluate_checkpoint_logs_wandb_metrics_for_classification(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_classification_fakes(monkeypatch)
+    cfg = _classification_cfg(tmp_path)
+    cfg.logging.use_wandb = True
+    checkpoint = tmp_path / "tiny_cls.pt"
+    model = _TinyClassifier()
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "config": {"task": "classification", "model": {}},
+            "global_step": 17,
+        },
+        checkpoint,
+    )
+    cfg.eval.checkpoint = str(checkpoint)
+    fake_run = _FakeWandbRun()
+    monkeypatch.setattr(evaluate_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+
+    result = evaluate_module.evaluate_checkpoint(cfg)
+
+    assert result.checkpoint == checkpoint.resolve()
+    assert fake_run.logged == [
+        (
+            {
+                "eval/loss": result.metrics["loss"],
+                "eval/acc": result.metrics["acc"],
+            },
+            17,
+        )
+    ]
+    assert fake_run.summary["run/checkpoint"] == str(checkpoint.resolve())
+    assert fake_run.summary["run/split"] == "val"
+    assert fake_run.summary["run/global_step"] == 17
+    assert fake_run.summary["eval/max_batches"] == 1
+    assert fake_run.summary["metrics/loss"] == result.metrics["loss"]
+    assert fake_run.summary["metrics/acc"] == result.metrics["acc"]
+    assert fake_run.finished is True
+
+
+def test_evaluate_checkpoint_logs_wandb_metrics_for_regression(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_regression_fakes(monkeypatch)
+    cfg = _regression_cfg(tmp_path)
+    cfg.logging.use_wandb = True
+    checkpoint = tmp_path / "tiny_reg.pt"
+    model = _TinyRegressor()
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "config": {"task": "regression", "model": {}},
+        },
+        checkpoint,
+    )
+    cfg.eval.checkpoint = str(checkpoint)
+    fake_run = _FakeWandbRun()
+    monkeypatch.setattr(evaluate_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+
+    result = evaluate_module.evaluate_checkpoint(cfg)
+
+    assert result.checkpoint == checkpoint.resolve()
+    assert fake_run.logged == [
+        (
+            {
+                "eval/loss": result.metrics["loss"],
+                "eval/rmse": result.metrics["rmse"],
+            },
+            0,
+        )
+    ]
+    assert fake_run.summary["run/checkpoint"] == str(checkpoint.resolve())
+    assert fake_run.summary["run/split"] == "val"
+    assert fake_run.summary["run/global_step"] == 0
+    assert fake_run.summary["eval/max_batches"] == 1
+    assert fake_run.summary["metrics/loss"] == result.metrics["loss"]
+    assert fake_run.summary["metrics/rmse"] == result.metrics["rmse"]
+    assert fake_run.finished is True

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Summary
- ensure wandb evaluation logging uses the shared adapter, emitting the existing loss and task metric plus metadata when evaluating checkpoints
- preserve current live training logging while copying final loss/metric keys into the wandb summary after training and for standalone prior-dump flows
- bump the package version to 0.6.6 and add the matching CHANGELOG entry for the behavior change

Testing
- Not run (not requested)