### PR TITLE
Add torchview sweep graph rendering CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-03-18
+
+### Added
+
+- Added `tab-foundry research sweep graph`, a torchview-based architecture
+  renderer for sweep anchors and selected sweep rows. The command writes SVG
+  outputs plus an `index.md` manifest under
+  `outputs/staged_ladder/research/<sweep_id>/architecture_graphs` by default.
+
+### Changed
+
+- User-facing note: repo installs now include the Python graph-rendering
+  dependencies needed for sweep architecture graphs. Rendering still requires
+  the Graphviz `dot` binary to be installed on the machine.
+
 ## [0.8.0] - 2026-03-18
 
 ### Changed

--- a/docs/development/codebase-navigation.md
+++ b/docs/development/codebase-navigation.md
@@ -82,6 +82,7 @@ Current canonical CLI namespaces:
 - `tab-foundry research sweep validate`
 - `tab-foundry research sweep set-active`
 - `tab-foundry research sweep execute`
+- `tab-foundry research sweep graph`
 - `tab-foundry research sweep promote`
 
 Shell helpers such as `scripts/build_manifest.sh`, `scripts/train_smoke.sh`,

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -521,6 +521,21 @@ Recommended loop:
    uv run tab-foundry research sweep next
    ```
 
+1. Render architecture graphs for the anchor or selected rows when you need a
+   structural view of the current sweep surface:
+
+   ```bash
+   uv sync
+   brew install graphviz
+   uv run tab-foundry research sweep graph --anchor
+   uv run tab-foundry research sweep graph --sweep-id <sweep_id> --order <order>
+   ```
+
+   The graph command writes SVGs and an `index.md` summary under
+   `outputs/staged_ladder/research/<sweep_id>/architecture_graphs` by default.
+   Run `tab-foundry research sweep graph --anchor` for the current canonical
+   surface. The command requires the Graphviz `dot` binary on `PATH`.
+
 1. Execute the active sweep's `ready` rows with the generic executor:
 
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.8.0"
+version = "0.8.1"
 description = "Tabfoundry tabular foundation model training on dagzoo packed shard outputs"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13,<3.14"
 dependencies = [
   "accelerate>=1.2",
+  "graphviz>=0.20",
   "hydra-core>=1.3",
   "numpy>=2.1",
   "omegaconf>=2.3",
@@ -20,6 +21,7 @@ dependencies = [
   "safetensors>=0.4",
   "schedulefree>=1.4",
   "torch>=2.8",
+  "torchview>=0.2.7",
   "wandb>=0.20",
 ]
 

--- a/src/tab_foundry/cli/groups/research.py
+++ b/src/tab_foundry/cli/groups/research.py
@@ -54,6 +54,12 @@ def _run_sweep_execute(argv: Sequence[str] | None = None) -> int:
     return execute_main(None if argv is None else list(argv))
 
 
+def _run_sweep_graph(argv: Sequence[str] | None = None) -> int:
+    from tab_foundry.research.sweep.graph import main as graph_main
+
+    return graph_main(None if argv is None else list(argv))
+
+
 def _run_sweep_promote(argv: Sequence[str] | None = None) -> int:
     from tab_foundry.research.system_delta_promote import main as promote_main
 
@@ -107,6 +113,12 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "execute",
         help="Execute selected system-delta sweep rows",
         delegate=_run_sweep_execute,
+    )
+    register_delegate_leaf(
+        sweep_nested,
+        "graph",
+        help="Render torchview architecture graphs for sweep targets",
+        delegate=_run_sweep_graph,
     )
     register_delegate_leaf(
         sweep_nested,

--- a/src/tab_foundry/research/sweep/graph.py
+++ b/src/tab_foundry/research/sweep/graph.py
@@ -1,0 +1,536 @@
+"""Render sweep architecture graphs with torchview."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence, cast
+
+from omegaconf import OmegaConf
+import torch
+
+from tab_foundry.bench.benchmark_run_registry import (
+    load_benchmark_run_registry,
+    resolve_registry_path_value,
+)
+from tab_foundry.model.factory import build_model_from_spec
+from tab_foundry.model.spec import (
+    ModelBuildSpec,
+    checkpoint_model_build_spec_from_mappings,
+    model_build_spec_from_mappings,
+)
+
+from .materialize import load_system_delta_queue, ordered_rows
+from .paths_io import (
+    _write_text,
+    default_catalog_path,
+    default_registry_path,
+    default_sweep_index_path,
+    default_sweeps_root,
+    repo_root,
+)
+from .runner import compose_cfg
+from .validation import ensure_mapping, ensure_non_empty_string
+
+
+_SAFE_FILENAME_CHARS_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class GraphPaths:
+    index_path: Path
+    catalog_path: Path
+    sweeps_root: Path
+    registry_path: Path
+
+    @classmethod
+    def default(cls) -> "GraphPaths":
+        return cls(
+            index_path=default_sweep_index_path(),
+            catalog_path=default_catalog_path(),
+            sweeps_root=default_sweeps_root(),
+            registry_path=default_registry_path(),
+        )
+
+
+@dataclass(frozen=True)
+class GraphTarget:
+    kind: str
+    title: str
+    filename: str
+    model_spec: ModelBuildSpec
+    metadata: dict[str, Any]
+
+
+class _ForwardBatchedWrapper(torch.nn.Module):
+    """Expose the repo's batched forward path as a simple tensor-only module."""
+
+    def __init__(self, model: torch.nn.Module, *, train_test_split_index: int) -> None:
+        super().__init__()
+        self.model = model
+        self.train_test_split_index = int(train_test_split_index)
+
+    def forward(self, x_all: torch.Tensor, y_train: torch.Tensor) -> torch.Tensor:
+        forward_batched = getattr(self.model, "forward_batched", None)
+        if not callable(forward_batched):
+            raise RuntimeError("selected model does not expose forward_batched()")
+        return cast(
+            torch.Tensor,
+            forward_batched(
+                x_all=x_all,
+                y_train=y_train,
+                train_test_split_index=self.train_test_split_index,
+            ),
+        )
+
+
+def _sanitize_filename_component(value: str) -> str:
+    sanitized = _SAFE_FILENAME_CHARS_RE.sub("_", value.strip())
+    return sanitized.strip("._") or "graph"
+
+
+def _load_json_mapping(path: Path, *, context: str) -> dict[str, Any]:
+    with path.expanduser().resolve().open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{context} must decode to a JSON object: {path.expanduser().resolve()}")
+    return cast(dict[str, Any], payload)
+
+
+def _queue_row_run_dir(queue_row: Mapping[str, Any]) -> Path:
+    delta_id = ensure_non_empty_string(
+        queue_row.get("delta_id", queue_row.get("delta_ref")),
+        context="queue row delta_id",
+    )
+    return repo_root() / "outputs" / ".graph_spec_resolution" / delta_id / "train"
+
+
+def resolve_queue_row_model_spec(queue_row: Mapping[str, Any]) -> ModelBuildSpec:
+    cfg = compose_cfg(
+        row=queue_row,
+        run_dir=_queue_row_run_dir(queue_row),
+        device="cpu",
+    )
+    task = str(getattr(cfg, "task", "classification")).strip().lower()
+    raw_model_cfg = OmegaConf.to_container(cfg.model, resolve=True)
+    if not isinstance(raw_model_cfg, dict):
+        raise RuntimeError("resolved queue-row cfg.model must be a mapping")
+    normalized_model_cfg = {str(key): value for key, value in raw_model_cfg.items()}
+    return model_build_spec_from_mappings(task=task, primary=normalized_model_cfg)
+
+
+def _training_surface_record_model_spec(training_surface_record_path: Path) -> ModelBuildSpec:
+    payload = _load_json_mapping(
+        training_surface_record_path,
+        context="training surface record",
+    )
+    model_payload = ensure_mapping(payload.get("model"), context="training surface record model")
+    build_spec_payload = ensure_mapping(
+        model_payload.get("build_spec"),
+        context="training surface record model.build_spec",
+    )
+    normalized_build_spec = {str(key): value for key, value in build_spec_payload.items()}
+    task = str(normalized_build_spec.get("task", "classification")).strip().lower()
+    return model_build_spec_from_mappings(task=task, primary=normalized_build_spec)
+
+
+def _checkpoint_model_spec_from_path(checkpoint_path: Path) -> ModelBuildSpec:
+    payload = torch.load(
+        checkpoint_path.expanduser().resolve(),
+        map_location="cpu",
+        weights_only=False,
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"checkpoint payload must be a mapping: {checkpoint_path.expanduser().resolve()}")
+    raw_cfg = payload.get("config")
+    checkpoint_cfg = raw_cfg if isinstance(raw_cfg, dict) else {}
+    task = str(checkpoint_cfg.get("task", "classification")).strip().lower()
+    raw_model_cfg = checkpoint_cfg.get("model")
+    model_cfg = raw_model_cfg if isinstance(raw_model_cfg, dict) else {}
+    raw_state_dict = payload.get("model")
+    state_dict = raw_state_dict if isinstance(raw_state_dict, dict) else None
+    return checkpoint_model_build_spec_from_mappings(
+        task=task,
+        primary=model_cfg,
+        state_dict=state_dict,
+    )
+
+
+def resolve_anchor_model_spec(
+    *,
+    queue: Mapping[str, Any],
+    registry_path: Path | None = None,
+) -> tuple[ModelBuildSpec, dict[str, Any]]:
+    anchor_run_id = ensure_non_empty_string(queue.get("anchor_run_id"), context="anchor_run_id")
+    for row in ordered_rows(queue):
+        row_run_id = row.get("run_id")
+        if isinstance(row_run_id, str) and row_run_id == anchor_run_id:
+            return resolve_queue_row_model_spec(row), {
+                "source": "queue_row",
+                "run_id": anchor_run_id,
+                "order": int(row["order"]),
+                "delta_id": str(row["delta_id"]),
+            }
+
+    registry = load_benchmark_run_registry(registry_path or default_registry_path())
+    runs = ensure_mapping(registry.get("runs"), context="benchmark registry runs")
+    raw_run = runs.get(anchor_run_id)
+    if not isinstance(raw_run, dict):
+        raise RuntimeError(f"anchor_run_id {anchor_run_id!r} is missing from the benchmark registry")
+    run = cast(dict[str, Any], raw_run)
+    artifacts = ensure_mapping(run.get("artifacts"), context=f"benchmark registry run {anchor_run_id}.artifacts")
+
+    raw_training_surface_path = artifacts.get("training_surface_record_path")
+    if isinstance(raw_training_surface_path, str) and raw_training_surface_path.strip():
+        training_surface_path = resolve_registry_path_value(raw_training_surface_path)
+        if training_surface_path.exists():
+            return _training_surface_record_model_spec(training_surface_path), {
+                "source": "training_surface_record",
+                "run_id": anchor_run_id,
+                "training_surface_record_path": str(training_surface_path),
+            }
+
+    raw_checkpoint_path = artifacts.get("best_checkpoint_path")
+    if isinstance(raw_checkpoint_path, str) and raw_checkpoint_path.strip():
+        checkpoint_path = resolve_registry_path_value(raw_checkpoint_path)
+        if checkpoint_path.exists():
+            return _checkpoint_model_spec_from_path(checkpoint_path), {
+                "source": "checkpoint",
+                "run_id": anchor_run_id,
+                "checkpoint_path": str(checkpoint_path),
+            }
+
+    raise RuntimeError(
+        "unable to resolve anchor model spec for "
+        f"{anchor_run_id!r}: no matching completed sweep row, readable "
+        "`training_surface_record.json`, or readable best checkpoint config"
+    )
+
+
+def _select_rows(
+    *,
+    queue: Mapping[str, Any],
+    all_rows: bool,
+    orders: Sequence[int],
+    delta_refs: Sequence[str],
+) -> list[dict[str, Any]]:
+    if all_rows and (orders or delta_refs):
+        raise RuntimeError("cannot combine --all-rows with --order or --delta-ref")
+
+    queue_rows = [cast(dict[str, Any], row) for row in ordered_rows(queue)]
+    if all_rows:
+        return queue_rows
+
+    order_set = {int(value) for value in orders}
+    delta_set = {str(value).strip() for value in delta_refs if str(value).strip()}
+    selected: list[dict[str, Any]] = []
+    seen_orders: set[int] = set()
+    for row in queue_rows:
+        order = int(row["order"])
+        delta_id = str(row["delta_id"])
+        if order not in order_set and delta_id not in delta_set:
+            continue
+        if order in seen_orders:
+            continue
+        selected.append(row)
+        seen_orders.add(order)
+
+    unknown_orders = sorted(order_set.difference({int(row["order"]) for row in selected}))
+    if unknown_orders:
+        raise RuntimeError(f"unknown sweep order(s): {unknown_orders}")
+    unknown_delta_refs = sorted(delta_set.difference({str(row['delta_id']) for row in selected}))
+    if unknown_delta_refs:
+        raise RuntimeError(f"unknown sweep delta_ref(s): {unknown_delta_refs}")
+    return selected
+
+
+def _build_targets(
+    *,
+    queue: Mapping[str, Any],
+    anchor: bool,
+    all_rows: bool,
+    orders: Sequence[int],
+    delta_refs: Sequence[str],
+    registry_path: Path,
+) -> list[GraphTarget]:
+    if not anchor and not all_rows and not orders and not delta_refs:
+        raise RuntimeError("select at least one target with --anchor, --all-rows, --order, or --delta-ref")
+
+    targets: list[GraphTarget] = []
+    if anchor:
+        model_spec, metadata = resolve_anchor_model_spec(queue=queue, registry_path=registry_path)
+        run_id = str(metadata["run_id"])
+        targets.append(
+            GraphTarget(
+                kind="anchor",
+                title=f"anchor:{run_id}",
+                filename=f"anchor__{_sanitize_filename_component(run_id)}.svg",
+                model_spec=model_spec,
+                metadata=metadata,
+            )
+        )
+
+    for row in _select_rows(
+        queue=queue,
+        all_rows=all_rows,
+        orders=orders,
+        delta_refs=delta_refs,
+    ):
+        order = int(row["order"])
+        delta_id = str(row["delta_id"])
+        targets.append(
+            GraphTarget(
+                kind="row",
+                title=f"row:{order:02d}:{delta_id}",
+                filename=f"row_{order:02d}__{_sanitize_filename_component(delta_id)}.svg",
+                model_spec=resolve_queue_row_model_spec(row),
+                metadata={
+                    "source": "queue_row",
+                    "order": order,
+                    "delta_id": delta_id,
+                    "run_id": row.get("run_id"),
+                    "status": str(row.get("status", "")),
+                },
+            )
+        )
+    return targets
+
+
+def _synthetic_inputs(spec: ModelBuildSpec) -> tuple[torch.Tensor, torch.Tensor, int]:
+    train_rows = 3
+    test_rows = 2
+    feature_count = 4
+    total_rows = train_rows + test_rows
+    x_all = torch.arange(total_rows * feature_count, dtype=torch.float32).reshape(1, total_rows, feature_count)
+    x_all = (x_all / float(feature_count)) - 1.0
+    max_classes = 2 if spec.arch == "tabfoundry_simple" else max(2, min(int(spec.many_class_base), 4))
+    y_train = torch.arange(train_rows, dtype=torch.int64).remainder(max_classes).reshape(1, train_rows)
+    return x_all, y_train, train_rows
+
+
+def _import_draw_graph() -> Any:
+    try:
+        from torchview import draw_graph
+    except Exception as exc:  # pragma: no cover - exercised when dependency is missing in user env
+        raise RuntimeError(
+            "torchview is not installed. Run `uv sync` in this repo before using "
+            "`tab-foundry research sweep graph`."
+        ) from exc
+    return draw_graph
+
+
+def _require_graphviz_dot() -> None:
+    if shutil.which("dot") is not None:
+        return
+    raise RuntimeError(
+        "Graphviz `dot` is required to render SVG architecture graphs. Install Graphviz "
+        "(for example `brew install graphviz` or `sudo apt-get install graphviz`) and "
+        "ensure `dot` is on PATH."
+    )
+
+
+def render_graph_target(target: GraphTarget, *, out_dir: Path) -> Path:
+    _require_graphviz_dot()
+    draw_graph = _import_draw_graph()
+
+    model = build_model_from_spec(target.model_spec)
+    model.to(torch.device("cpu"))
+    model.eval()
+    surface = getattr(model, "surface", None)
+    if surface is not None and getattr(surface, "head", None) == "many_class":
+        raise RuntimeError(
+            "tab-foundry research sweep graph currently supports direct-head models only; "
+            f"got staged head='many_class' for target {target.title!r}"
+        )
+
+    x_all, y_train, train_test_split_index = _synthetic_inputs(target.model_spec)
+    wrapper = _ForwardBatchedWrapper(model, train_test_split_index=train_test_split_index)
+    wrapper.eval()
+    with torch.no_grad():
+        graph = draw_graph(
+            wrapper,
+            input_data=[x_all, y_train],
+            graph_name=target.title,
+            mode="eval",
+            expand_nested=True,
+        )
+    visual_graph = getattr(graph, "visual_graph", None)
+    pipe = getattr(visual_graph, "pipe", None)
+    if not callable(pipe):
+        raise RuntimeError("torchview draw_graph() did not return a graphviz-backed visual graph")
+    rendered = pipe(format="svg")
+    rendered_bytes = rendered if isinstance(rendered, (bytes, bytearray)) else str(rendered).encode("utf-8")
+    out_path = out_dir.expanduser().resolve() / target.filename
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(rendered_bytes)
+    return out_path
+
+
+def _default_out_dir(*, sweep_id: str) -> Path:
+    return repo_root() / "outputs" / "staged_ladder" / "research" / sweep_id / "architecture_graphs"
+
+
+def _index_contents(
+    *,
+    sweep_id: str,
+    targets: Sequence[GraphTarget],
+    graph_paths: Sequence[Path],
+    out_dir: Path,
+) -> str:
+    lines = [
+        "# Sweep Architecture Graphs",
+        "",
+        f"- Sweep id: `{sweep_id}`",
+        f"- Output directory: `{out_dir}`",
+        f"- Target count: `{len(targets)}`",
+        "",
+    ]
+    for target, graph_path in zip(targets, graph_paths, strict=True):
+        lines.append(f"## {target.kind.title()} `{target.title}`")
+        lines.append("")
+        lines.append(f"- Graph path: `{graph_path}`")
+        lines.append(f"- Source: `{target.metadata.get('source', 'unknown')}`")
+        if target.kind == "anchor":
+            lines.append(f"- Anchor run id: `{target.metadata.get('run_id')}`")
+        else:
+            lines.append(f"- Order: `{target.metadata.get('order')}`")
+            lines.append(f"- Delta id: `{target.metadata.get('delta_id')}`")
+            run_id = target.metadata.get("run_id")
+            lines.append(f"- Queue run id: `{run_id if run_id is not None else 'none'}`")
+        lines.append(f"- Model arch: `{target.model_spec.arch}`")
+        lines.append(f"- Model stage: `{target.model_spec.stage}`")
+        lines.append(f"- Model stage label: `{target.model_spec.stage_label}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render_sweep_graphs(
+    *,
+    sweep_id: str | None = None,
+    anchor: bool = False,
+    all_rows: bool = False,
+    orders: Sequence[int] | None = None,
+    delta_refs: Sequence[str] | None = None,
+    out_dir: Path | None = None,
+    paths: GraphPaths | None = None,
+) -> dict[str, Any]:
+    resolved_paths = GraphPaths.default() if paths is None else paths
+    queue = load_system_delta_queue(
+        sweep_id=sweep_id,
+        index_path=resolved_paths.index_path,
+        catalog_path=resolved_paths.catalog_path,
+        sweeps_root=resolved_paths.sweeps_root,
+    )
+    resolved_sweep_id = ensure_non_empty_string(queue.get("sweep_id"), context="sweep_id")
+    targets = _build_targets(
+        queue=queue,
+        anchor=anchor,
+        all_rows=all_rows,
+        orders=[] if orders is None else [int(value) for value in orders],
+        delta_refs=[] if delta_refs is None else [str(value) for value in delta_refs],
+        registry_path=resolved_paths.registry_path,
+    )
+    resolved_out_dir = (out_dir or _default_out_dir(sweep_id=resolved_sweep_id)).expanduser().resolve()
+    resolved_out_dir.mkdir(parents=True, exist_ok=True)
+    graph_paths = [render_graph_target(target, out_dir=resolved_out_dir) for target in targets]
+    index_path = resolved_out_dir / "index.md"
+    _write_text(
+        index_path,
+        _index_contents(
+            sweep_id=resolved_sweep_id,
+            targets=targets,
+            graph_paths=graph_paths,
+            out_dir=resolved_out_dir,
+        ),
+    )
+    return {
+        "sweep_id": resolved_sweep_id,
+        "out_dir": str(resolved_out_dir),
+        "index_path": str(index_path),
+        "graphs": [
+            {
+                "kind": target.kind,
+                "title": target.title,
+                "path": str(path),
+                "source": target.metadata.get("source"),
+                "stage": target.model_spec.stage,
+                "stage_label": target.model_spec.stage_label,
+            }
+            for target, path in zip(targets, graph_paths, strict=True)
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render torchview architecture graphs for sweep targets")
+    parser.add_argument("--sweep-id", default=None, help="Sweep id to inspect; defaults to the active sweep")
+    parser.add_argument("--anchor", action="store_true", help="Render the selected sweep anchor graph")
+    parser.add_argument("--all-rows", action="store_true", help="Render graphs for every row in the sweep")
+    parser.add_argument("--order", type=int, action="append", default=[], help="Specific queue order to render")
+    parser.add_argument(
+        "--delta-ref",
+        action="append",
+        default=[],
+        help="Specific delta_ref / materialized delta_id to render; repeatable",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Optional output directory; defaults to outputs/staged_ladder/research/<sweep_id>/architecture_graphs",
+    )
+    parser.add_argument(
+        "--catalog-path",
+        default=str(default_catalog_path()),
+        help="Path to reference/system_delta_catalog.yaml",
+    )
+    parser.add_argument(
+        "--index-path",
+        default=str(default_sweep_index_path()),
+        help="Path to reference/system_delta_sweeps/index.yaml",
+    )
+    parser.add_argument(
+        "--registry-path",
+        default=str(default_registry_path()),
+        help="Path to benchmark_run_registry_v1.json",
+    )
+    parser.add_argument(
+        "--sweeps-root",
+        default=str(default_sweeps_root()),
+        help="Path to reference/system_delta_sweeps/",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = render_sweep_graphs(
+        sweep_id=None if args.sweep_id is None else str(args.sweep_id),
+        anchor=bool(args.anchor),
+        all_rows=bool(args.all_rows),
+        orders=[int(value) for value in args.order],
+        delta_refs=[str(value) for value in args.delta_ref],
+        out_dir=None if args.out_dir is None else Path(str(args.out_dir)),
+        paths=GraphPaths(
+            index_path=Path(str(args.index_path)).expanduser().resolve(),
+            catalog_path=Path(str(args.catalog_path)).expanduser().resolve(),
+            sweeps_root=Path(str(args.sweeps_root)).expanduser().resolve(),
+            registry_path=Path(str(args.registry_path)).expanduser().resolve(),
+        ),
+    )
+    print(
+        "Sweep graph render complete.",
+        f"sweep_id={result['sweep_id']}",
+        f"graphs={len(result['graphs'])}",
+        f"index={result['index_path']}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -5,6 +5,7 @@ import pytest
 import tab_foundry.bench.prior_train as prior_train_module
 import tab_foundry.cli as cli_module
 import tab_foundry.research.system_delta as system_delta_module
+import tab_foundry.research.sweep.graph as graph_module
 
 
 def test_nested_cli_bench_compare_delegates_to_compare_main(
@@ -72,3 +73,20 @@ def test_nested_cli_research_sweep_render_delegates_to_system_delta_main(
 
     assert exit_code == 0
     assert captured["argv"] == ["render", "--sweep-id", "binary_md_v1"]
+
+
+def test_nested_cli_research_sweep_graph_delegates_to_graph_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_graph_main(argv=None):
+        captured["argv"] = list(argv) if argv is not None else None
+        return 0
+
+    monkeypatch.setattr(graph_module, "main", _fake_graph_main)
+
+    exit_code = cli_module.main(["research", "sweep", "graph", "--anchor", "--order", "7"])
+
+    assert exit_code == 0
+    assert captured["argv"] == ["--anchor", "--order", "7"]

--- a/tests/research/test_sweep_graph.py
+++ b/tests/research/test_sweep_graph.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import tab_foundry.research.sweep.graph as graph_module
+from tab_foundry.model.spec import model_build_spec_from_mappings
+from tab_foundry.research.sweep.graph import GraphPaths
+from tab_foundry.research.system_delta import load_system_delta_queue
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _copy_reference_workspace(tmp_path: Path) -> tuple[Path, Path]:
+    reference_root = tmp_path / "reference"
+    sweeps_root = reference_root / "system_delta_sweeps"
+    source_sweeps_root = REPO_ROOT / "reference" / "system_delta_sweeps"
+    sweeps_root.mkdir(parents=True, exist_ok=True)
+    (reference_root / "system_delta_catalog.yaml").write_text(
+        (REPO_ROOT / "reference" / "system_delta_catalog.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sweeps_root / "index.yaml").write_text(
+        (source_sweeps_root / "index.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    for source_dir in sorted(source_sweeps_root.iterdir()):
+        if source_dir.name == "index.yaml" or not source_dir.is_dir():
+            continue
+        shutil.copytree(source_dir, sweeps_root / source_dir.name)
+    return reference_root, sweeps_root
+
+
+def test_resolve_queue_row_model_spec_matches_selected_sweep_surface() -> None:
+    queue = load_system_delta_queue(
+        sweep_id="input_norm_followup",
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+    row = next(row for row in queue["rows"] if int(row["order"]) == 7)
+
+    spec = graph_module.resolve_queue_row_model_spec(row)
+
+    assert spec.arch == "tabfoundry_staged"
+    assert spec.stage == "nano_exact"
+    assert spec.stage_label == "dpnb_input_norm_anchor_replay_batch64_sqrt"
+    assert spec.input_normalization == "train_zscore_clip"
+    assert spec.module_overrides == {
+        "table_block_style": "prenorm",
+        "allow_test_self_attention": False,
+        "row_pool": "row_cls",
+    }
+    assert spec.tfrow_cls_tokens == 2
+
+
+def test_resolve_anchor_model_spec_prefers_matching_completed_queue_row() -> None:
+    queue = load_system_delta_queue(
+        sweep_id="input_norm_followup",
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+
+    spec, metadata = graph_module.resolve_anchor_model_spec(
+        queue=queue,
+        registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+    )
+
+    assert metadata["source"] == "queue_row"
+    assert metadata["run_id"] == "sd_input_norm_followup_07_dpnb_input_norm_anchor_replay_batch64_sqrt_v2"
+    assert metadata["order"] == 7
+    assert spec.stage_label == "dpnb_input_norm_anchor_replay_batch64_sqrt"
+
+
+def test_resolve_anchor_model_spec_uses_training_surface_record_when_queue_row_missing(tmp_path: Path) -> None:
+    spec = model_build_spec_from_mappings(
+        task="classification",
+        primary={
+            "arch": "tabfoundry_staged",
+            "stage": "nano_exact",
+            "stage_label": "registry_record_anchor",
+            "input_normalization": "train_zscore_clip",
+            "many_class_base": 2,
+            "tficl_n_heads": 4,
+            "tficl_n_layers": 2,
+            "head_hidden_dim": 128,
+        },
+    )
+    record_path = tmp_path / "training_surface_record.json"
+    record_path.write_text(
+        json.dumps({"model": {"build_spec": spec.to_dict()}}, indent=2),
+        encoding="utf-8",
+    )
+    registry_payload = {
+        "runs": {
+            "anchor_from_record": {
+                "artifacts": {
+                    "training_surface_record_path": str(record_path),
+                    "best_checkpoint_path": None,
+                }
+            }
+        }
+    }
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(graph_module, "load_benchmark_run_registry", lambda _path: registry_payload)
+    monkeypatch.setattr(graph_module, "resolve_registry_path_value", lambda value: Path(value))
+    try:
+        resolved_spec, metadata = graph_module.resolve_anchor_model_spec(
+            queue={"anchor_run_id": "anchor_from_record", "rows": []},
+            registry_path=tmp_path / "registry.json",
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert metadata["source"] == "training_surface_record"
+    assert resolved_spec.stage_label == "registry_record_anchor"
+
+
+def test_resolve_anchor_model_spec_falls_back_to_checkpoint(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "best.pt"
+    torch.save(
+        {
+            "config": {
+                "task": "classification",
+                "model": {
+                    "arch": "tabfoundry_staged",
+                    "stage": "nano_exact",
+                    "stage_label": "checkpoint_anchor",
+                    "input_normalization": "train_zscore_clip",
+                    "many_class_base": 2,
+                    "tficl_n_heads": 4,
+                    "tficl_n_layers": 2,
+                    "head_hidden_dim": 128,
+                },
+            },
+            "model": {},
+        },
+        checkpoint_path,
+    )
+    registry_payload = {
+        "runs": {
+            "anchor_from_checkpoint": {
+                "artifacts": {
+                    "training_surface_record_path": str(tmp_path / "missing_training_surface_record.json"),
+                    "best_checkpoint_path": str(checkpoint_path),
+                }
+            }
+        }
+    }
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(graph_module, "load_benchmark_run_registry", lambda _path: registry_payload)
+    monkeypatch.setattr(graph_module, "resolve_registry_path_value", lambda value: Path(value))
+    try:
+        resolved_spec, metadata = graph_module.resolve_anchor_model_spec(
+            queue={"anchor_run_id": "anchor_from_checkpoint", "rows": []},
+            registry_path=tmp_path / "registry.json",
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert metadata["source"] == "checkpoint"
+    assert resolved_spec.stage_label == "checkpoint_anchor"
+
+
+def test_resolve_anchor_model_spec_errors_when_all_sources_are_missing(tmp_path: Path) -> None:
+    registry_payload = {
+        "runs": {
+            "missing_anchor": {
+                "artifacts": {
+                    "training_surface_record_path": str(tmp_path / "missing.json"),
+                    "best_checkpoint_path": str(tmp_path / "missing.pt"),
+                }
+            }
+        }
+    }
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(graph_module, "load_benchmark_run_registry", lambda _path: registry_payload)
+    monkeypatch.setattr(graph_module, "resolve_registry_path_value", lambda value: Path(value))
+    try:
+        with pytest.raises(RuntimeError, match="unable to resolve anchor model spec"):
+            _ = graph_module.resolve_anchor_model_spec(
+                queue={"anchor_run_id": "missing_anchor", "rows": []},
+                registry_path=tmp_path / "registry.json",
+            )
+    finally:
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--anchor"], {"anchor": True, "all_rows": False, "orders": [], "delta_refs": []}),
+        (["--all-rows"], {"anchor": False, "all_rows": True, "orders": [], "delta_refs": []}),
+        (["--order", "7"], {"anchor": False, "all_rows": False, "orders": [7], "delta_refs": []}),
+        (
+            ["--delta-ref", "dpnb_input_norm_anchor_replay_batch64_sqrt"],
+            {
+                "anchor": False,
+                "all_rows": False,
+                "orders": [],
+                "delta_refs": ["dpnb_input_norm_anchor_replay_batch64_sqrt"],
+            },
+        ),
+    ],
+)
+def test_graph_main_parses_cli_selectors(
+    argv: list[str],
+    expected: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_render_sweep_graphs(**kwargs):
+        captured.update(kwargs)
+        return {"sweep_id": "cuda_stability_followup", "graphs": [], "index_path": str(tmp_path / "index.md")}
+
+    monkeypatch.setattr(graph_module, "render_sweep_graphs", _fake_render_sweep_graphs)
+
+    exit_code = graph_module.main([*argv, "--out-dir", str(tmp_path)])
+
+    assert exit_code == 0
+    assert captured["anchor"] == expected["anchor"]
+    assert captured["all_rows"] == expected["all_rows"]
+    assert captured["orders"] == expected["orders"]
+    assert captured["delta_refs"] == expected["delta_refs"]
+
+
+def test_render_sweep_graphs_rejects_invalid_selector_combinations(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="cannot combine --all-rows"):
+        _ = graph_module.render_sweep_graphs(
+            sweep_id="input_norm_followup",
+            all_rows=True,
+            orders=[7],
+            out_dir=tmp_path,
+        )
+
+
+def test_render_sweep_graphs_rejects_unknown_delta_ref(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="unknown sweep delta_ref"):
+        _ = graph_module.render_sweep_graphs(
+            sweep_id="input_norm_followup",
+            delta_refs=["missing_delta"],
+            out_dir=tmp_path,
+        )
+
+
+def test_render_sweep_graphs_writes_svg_and_index_without_mutating_sweep_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference_root, sweeps_root = _copy_reference_workspace(tmp_path)
+    sweep_yaml_path = sweeps_root / "input_norm_followup" / "sweep.yaml"
+    queue_yaml_path = sweeps_root / "input_norm_followup" / "queue.yaml"
+    sweep_before = sweep_yaml_path.read_text(encoding="utf-8")
+    queue_before = queue_yaml_path.read_text(encoding="utf-8")
+
+    class _FakeVisualGraph:
+        def pipe(self, *, format: str) -> bytes:
+            assert format == "svg"
+            return b"<svg><!-- fake graph --></svg>"
+
+    class _FakeGraph:
+        def __init__(self) -> None:
+            self.visual_graph = _FakeVisualGraph()
+
+    def _fake_draw_graph(*args, **kwargs):
+        assert args
+        return _FakeGraph()
+
+    monkeypatch.setattr(graph_module.shutil, "which", lambda name: "/usr/bin/dot" if name == "dot" else None)
+    monkeypatch.setitem(sys.modules, "torchview", SimpleNamespace(draw_graph=_fake_draw_graph))
+
+    out_dir = tmp_path / "graphs"
+    result = graph_module.render_sweep_graphs(
+        sweep_id="input_norm_followup",
+        anchor=True,
+        orders=[7],
+        out_dir=out_dir,
+        paths=GraphPaths(
+            index_path=sweeps_root / "index.yaml",
+            catalog_path=reference_root / "system_delta_catalog.yaml",
+            sweeps_root=sweeps_root,
+            registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+        ),
+    )
+
+    graph_paths = [Path(item["path"]) for item in result["graphs"]]
+    assert graph_paths
+    assert all(path.exists() for path in graph_paths)
+    assert all("<svg" in path.read_text(encoding="utf-8") for path in graph_paths)
+    index_path = Path(str(result["index_path"]))
+    assert index_path.exists()
+    index_text = index_path.read_text(encoding="utf-8")
+    assert "Sweep Architecture Graphs" in index_text
+    assert "Anchor" in index_text
+    assert "row:07:dpnb_input_norm_anchor_replay_batch64_sqrt" in index_text
+    assert sweep_yaml_path.read_text(encoding="utf-8") == sweep_before
+    assert queue_yaml_path.read_text(encoding="utf-8") == queue_before

--- a/tests/runtime/test_program_contract.py
+++ b/tests/runtime/test_program_contract.py
@@ -136,6 +136,8 @@ def test_workflows_runbook_reflects_system_delta_surface() -> None:
         "`cls_benchmark_linear_v2`",
         "`src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json`",
         "`training_surface_record.json`",
+        "`tab-foundry research sweep graph --anchor`",
+        "Graphviz `dot`",
     ]
     for statement in required_statements:
         assert statement in contents

--- a/uv.lock
+++ b/uv.lock
@@ -383,6 +383,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300 },
+]
+
+[[package]]
 name = "grimp"
 version = "3.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1614,10 +1623,11 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
+    { name = "graphviz" },
     { name = "hydra-core" },
     { name = "numpy" },
     { name = "omegaconf" },
@@ -1627,6 +1637,7 @@ dependencies = [
     { name = "safetensors" },
     { name = "schedulefree" },
     { name = "torch" },
+    { name = "torchview" },
     { name = "wandb" },
 ]
 
@@ -1668,6 +1679,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", specifier = ">=1.2" },
+    { name = "graphviz", specifier = ">=0.20" },
     { name = "h5py", marker = "extra == 'benchmark'", specifier = ">=3.12" },
     { name = "hydra-core", specifier = ">=1.3" },
     { name = "matplotlib", marker = "extra == 'benchmark'", specifier = ">=3.10" },
@@ -1683,6 +1695,7 @@ requires-dist = [
     { name = "schedulefree", specifier = ">=1.4" },
     { name = "scikit-learn", marker = "extra == 'benchmark'", specifier = ">=1.6" },
     { name = "torch", specifier = ">=2.8" },
+    { name = "torchview", specifier = ">=0.2.7" },
     { name = "wandb", specifier = ">=0.20" },
 ]
 provides-extras = ["benchmark", "muon"]
@@ -1770,6 +1783,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/d9/2b811d1c0812e9ef23e6cf2dbe022becbe6c5ab065e33fd80ee05c0cd996/torchinfo-1.8.0.tar.gz", hash = "sha256:72e94b0e9a3e64dc583a8e5b7940b8938a1ac0f033f795457f27e6f4e7afa2e9", size = 25880 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/25/973bd6128381951b23cdcd8a9870c6dcfc5606cb864df8eabd82e529f9c1/torchinfo-1.8.0-py3-none-any.whl", hash = "sha256:2e911c2918603f945c26ff21a3a838d12709223dc4ccf243407bce8b6e897b46", size = 23377 },
+]
+
+[[package]]
+name = "torchview"
+version = "0.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphviz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/45/f76ac5a2a49f3a5831ddde2e7e6b58fe423b434075e812559976a2122560/torchview-0.2.7.tar.gz", hash = "sha256:c5898fd03d256333c9827000c1f83e1052fbcfc1066032d86b30d429dd942f7c", size = 25697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/66/b87d835f664f0f99a0bf1e2e294c45d286545fed35b96f2c99e700915dd9/torchview-0.2.7-py3-none-any.whl", hash = "sha256:c7f3a9d16138c20b606900ecbf46d01489f2b8c77ed97e71293883bc606c2be0", size = 26103 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `tab-foundry research sweep graph` to render SVG architecture graphs for sweep anchors and selected rows
- resolve graph targets from sweep rows, training surface records, or checkpoint-backed model specs
- add docs, tests, and package/version updates for the new visualization workflow

## Testing
- `uv run pre-commit run --all-files`
- `./.venv/bin/python -m pytest`