### PR TITLE
Add explore experiment configs for staged classification benchmarks

### DIFF
--- a/configs/experiment/_shared/explore_runtime_prior.yaml
+++ b/configs/experiment/_shared/explore_runtime_prior.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+
+runtime:
+  trace_activations: false
+  eval_every: 250
+  checkpoint_every: 250

--- a/configs/experiment/_shared/explore_runtime_standard.yaml
+++ b/configs/experiment/_shared/explore_runtime_standard.yaml
@@ -1,0 +1,8 @@
+# @package _global_
+
+runtime:
+  num_workers: 2
+  trace_activations: false
+  eval_every: 100
+  checkpoint_every: null
+  val_batches: 8

--- a/configs/experiment/cls_benchmark_staged_explore.yaml
+++ b/configs/experiment/cls_benchmark_staged_explore.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_staged
+  - _shared/explore_runtime_standard
+  - _self_
+
+runtime:
+  output_dir: outputs/cls_benchmark_staged_explore
+
+logging:
+  run_name: cls-benchmark-staged-explore

--- a/configs/experiment/cls_benchmark_staged_prior_cuda_scale_explore.yaml
+++ b/configs/experiment/cls_benchmark_staged_prior_cuda_scale_explore.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_staged_prior_cuda_scale
+  - _shared/explore_runtime_prior
+  - _self_
+
+runtime:
+  output_dir: outputs/cls_benchmark_staged_prior_cuda_scale_explore
+
+logging:
+  run_name: dpnb_cuda_large_anchor_explore

--- a/configs/experiment/cls_benchmark_staged_prior_explore.yaml
+++ b/configs/experiment/cls_benchmark_staged_prior_explore.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_staged_prior
+  - _shared/explore_runtime_prior
+  - _self_
+
+runtime:
+  output_dir: outputs/cls_benchmark_staged_prior_explore
+
+logging:
+  run_name: dpnb_row_cls_cls2_linear_warmup_decay_explore

--- a/tests/config/test_experiment_resolution.py
+++ b/tests/config/test_experiment_resolution.py
@@ -111,6 +111,27 @@ def test_cls_benchmark_staged_resolution() -> None:
     assert str(cfg.logging.history_jsonl_path) == "outputs/cls_benchmark_staged/train_history.jsonl"
 
 
+def test_cls_benchmark_staged_explore_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_staged_explore")
+    assert str(cfg.task) == "classification"
+    assert str(cfg.model.arch) == "tabfoundry_staged"
+    assert str(cfg.model.stage) == "nano_exact"
+    assert int(cfg.model.d_icl) == 96
+    assert str(cfg.model.input_normalization) == "train_zscore_clip"
+    assert int(cfg.model.many_class_base) == 2
+    assert int(cfg.model.tficl_n_heads) == 4
+    assert int(cfg.model.tficl_n_layers) == 3
+    assert int(cfg.model.head_hidden_dim) == 192
+    assert int(cfg.runtime.num_workers) == 2
+    assert bool(cfg.runtime.trace_activations) is False
+    assert int(cfg.runtime.eval_every) == 100
+    assert cfg.runtime.checkpoint_every is None
+    assert int(cfg.runtime.val_batches) == 8
+    assert str(cfg.runtime.output_dir) == "outputs/cls_benchmark_staged_explore"
+    assert str(cfg.logging.run_name) == "cls-benchmark-staged-explore"
+    assert str(cfg.logging.history_jsonl_path) == "outputs/cls_benchmark_staged_explore/train_history.jsonl"
+
+
 def test_cls_benchmark_staged_prior_resolution() -> None:
     cfg = _compose("experiment=cls_benchmark_staged_prior")
     assert str(cfg.task) == "classification"
@@ -154,6 +175,55 @@ def test_cls_benchmark_staged_prior_resolution() -> None:
     assert float(stage["warmup_ratio"]) == 0.05
     assert str(cfg.logging.run_name) == "dpnb_row_cls_cls2_linear_warmup_decay"
     assert str(cfg.logging.history_jsonl_path) == "outputs/cls_benchmark_staged_prior/train_history.jsonl"
+
+
+def test_cls_benchmark_staged_prior_explore_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_staged_prior_explore")
+    assert str(cfg.task) == "classification"
+    assert str(cfg.model.arch) == "tabfoundry_staged"
+    assert str(cfg.model.stage) == "nano_exact"
+    assert str(cfg.model.stage_label) == "dpnb_row_cls_cls2_linear_warmup_decay"
+    assert cfg.model.module_overrides == {
+        "table_block_style": "prenorm",
+        "allow_test_self_attention": False,
+        "row_pool": "row_cls",
+    }
+    assert int(cfg.model.d_icl) == 96
+    assert str(cfg.model.input_normalization) == "train_zscore_clip"
+    assert int(cfg.model.many_class_base) == 2
+    assert int(cfg.model.tfrow_n_heads) == 8
+    assert int(cfg.model.tfrow_n_layers) == 3
+    assert int(cfg.model.tfrow_cls_tokens) == 2
+    assert str(cfg.model.tfrow_norm) == "layernorm"
+    assert int(cfg.runtime.max_steps) == 2500
+    assert int(cfg.runtime.eval_every) == 250
+    assert int(cfg.runtime.checkpoint_every) == 250
+    assert bool(cfg.runtime.trace_activations) is False
+    assert str(cfg.optimizer.name) == "schedulefree_adamw"
+    assert bool(cfg.optimizer.require_requested) is True
+    assert float(cfg.optimizer.weight_decay) == 0.0
+    assert list(cfg.optimizer.betas) == [0.9, 0.999]
+    assert float(cfg.optimizer.min_lr) == 4.0e-4
+    assert bool(cfg.optimizer.muon_per_parameter_lr) is False
+    assert str(cfg.model.norm_type) == "layernorm"
+    assert str(cfg.training.surface_label) == "prior_linear_warmup_decay"
+    assert bool(cfg.training.apply_schedule) is True
+    assert str(cfg.training.prior_dump_non_finite_policy) == "skip"
+    assert int(cfg.training.prior_dump_batch_size) == 32
+    assert str(cfg.training.prior_dump_lr_scale_rule) == "none"
+    assert int(cfg.training.prior_dump_batch_reference_size) == 32
+    stage = cfg.schedule.stages[0]
+    assert str(stage["name"]) == "prior_dump"
+    assert int(stage["steps"]) == 2500
+    assert float(stage["lr_max"]) == 4.0e-3
+    assert str(stage["lr_schedule"]) == "linear"
+    assert float(stage["warmup_ratio"]) == 0.05
+    assert str(cfg.logging.run_name) == "dpnb_row_cls_cls2_linear_warmup_decay_explore"
+    assert str(cfg.runtime.output_dir) == "outputs/cls_benchmark_staged_prior_explore"
+    assert (
+        str(cfg.logging.history_jsonl_path)
+        == "outputs/cls_benchmark_staged_prior_explore/train_history.jsonl"
+    )
 
 
 def test_cls_benchmark_staged_prior_cuda_scale_resolution() -> None:
@@ -204,4 +274,55 @@ def test_cls_benchmark_staged_prior_cuda_scale_resolution() -> None:
     assert (
         str(cfg.logging.history_jsonl_path)
         == "outputs/cls_benchmark_staged_prior_cuda_scale/train_history.jsonl"
+    )
+
+
+def test_cls_benchmark_staged_prior_cuda_scale_explore_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_staged_prior_cuda_scale_explore")
+    assert str(cfg.task) == "classification"
+    assert str(cfg.model.arch) == "tabfoundry_staged"
+    assert str(cfg.model.stage) == "nano_exact"
+    assert str(cfg.model.stage_label) == "dpnb_cuda_large_anchor"
+    assert cfg.model.module_overrides == {
+        "table_block_style": "prenorm",
+        "allow_test_self_attention": False,
+        "row_pool": "row_cls",
+    }
+    assert int(cfg.model.d_col) == 128
+    assert int(cfg.model.d_icl) == 512
+    assert str(cfg.model.input_normalization) == "train_zscore_clip"
+    assert int(cfg.model.tfrow_n_heads) == 8
+    assert int(cfg.model.tfrow_n_layers) == 3
+    assert int(cfg.model.tfrow_cls_tokens) == 2
+    assert str(cfg.model.tfrow_norm) == "layernorm"
+    assert int(cfg.model.tficl_n_heads) == 8
+    assert int(cfg.model.tficl_n_layers) == 12
+    assert int(cfg.model.head_hidden_dim) == 1024
+    assert int(cfg.runtime.max_steps) == 2500
+    assert int(cfg.runtime.eval_every) == 250
+    assert int(cfg.runtime.checkpoint_every) == 250
+    assert bool(cfg.runtime.trace_activations) is False
+    assert str(cfg.optimizer.name) == "schedulefree_adamw"
+    assert bool(cfg.optimizer.require_requested) is True
+    assert float(cfg.optimizer.weight_decay) == 0.0
+    assert list(cfg.optimizer.betas) == [0.9, 0.999]
+    assert float(cfg.optimizer.min_lr) == 4.0e-4
+    assert bool(cfg.optimizer.muon_per_parameter_lr) is False
+    assert str(cfg.training.surface_label) == "prior_linear_warmup_decay"
+    assert bool(cfg.training.apply_schedule) is True
+    assert str(cfg.training.prior_dump_non_finite_policy) == "skip"
+    assert int(cfg.training.prior_dump_batch_size) == 64
+    assert str(cfg.training.prior_dump_lr_scale_rule) == "sqrt"
+    assert int(cfg.training.prior_dump_batch_reference_size) == 32
+    stage = cfg.schedule.stages[0]
+    assert str(stage["name"]) == "prior_dump"
+    assert int(stage["steps"]) == 2500
+    assert float(stage["lr_max"]) == 4.0e-3
+    assert str(stage["lr_schedule"]) == "linear"
+    assert float(stage["warmup_ratio"]) == 0.05
+    assert str(cfg.logging.run_name) == "dpnb_cuda_large_anchor_explore"
+    assert str(cfg.runtime.output_dir) == "outputs/cls_benchmark_staged_prior_cuda_scale_explore"
+    assert (
+        str(cfg.logging.history_jsonl_path)
+        == "outputs/cls_benchmark_staged_prior_cuda_scale_explore/train_history.jsonl"
     )


### PR DESCRIPTION
## Summary
- add shared explore runtime presets for standard and prior staged benchmark runs
- add explore variants for `cls_benchmark_staged`, `cls_benchmark_staged_prior`, and `cls_benchmark_staged_prior_cuda_scale`
- extend experiment resolution coverage to verify the new output paths, run names, and runtime overrides

## Testing
- Not run (not requested)