### PR TITLE
Fix shared-surface bridge metadata consistency

### DIFF
--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -87,8 +87,8 @@ sweeps:
     control_baseline_id: cls_benchmark_linear_v2
   shared_surface_bridge_v1:
     parent_sweep_id: binary_md_v1
-    status: draft
-    anchor_run_id: 01_nano_exact_md_prior_parity_fix_binary_medium_v1
+    status: completed
+    anchor_run_id: sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1
     complexity_level: binary_md
     benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
     control_baseline_id: cls_benchmark_linear_v2

--- a/reference/system_delta_sweeps/shared_surface_bridge_v1/matrix.md
+++ b/reference/system_delta_sweeps/shared_surface_bridge_v1/matrix.md
@@ -5,20 +5,20 @@ This file is rendered from `reference/system_delta_sweeps/shared_surface_bridge_
 ## Sweep
 
 - Sweep id: `shared_surface_bridge_v1`
-- Sweep status: `draft`
+- Sweep status: `completed`
 - Parent sweep id: `binary_md_v1`
 - Complexity level: `binary_md`
 
 ## Locked Surface
 
-- Anchor run id: `01_nano_exact_md_prior_parity_fix_binary_medium_v1`
+- Anchor run id: `sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1`
 - Benchmark bundle: `src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json`
 - Control baseline id: `cls_benchmark_linear_v2`
 - Training experiment: `cls_benchmark_staged`
 - Training config profile: `cls_benchmark_staged`
 - Surface role: `architecture_screen`
 - Comparison policy: `anchor_only`
-- Anchor metrics: best ROC AUC `0.7615`, final ROC AUC `0.7599`, final training time `355.6s`
+- Anchor metrics: final log loss `0.6951`, final Brier score `0.5020`, best ROC AUC `0.4339`, final ROC AUC `0.4339`, final training time `87.3s`
 
 ## Anchor Comparison
 
@@ -34,26 +34,26 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | row readout | Target-column readout from the final cell tensor. | Same target-column row pool. | Readout remains on the direct upstream-style path. |
 | context encoder | None on the upstream direct path. | None on the anchor path. | Context encoding remains absent; later context rows will change both depth and label-flow semantics. |
 | prediction head | Direct binary logits head. | Direct binary logits head. | The prediction head remains on the narrow upstream-style binary path. |
-| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Benchmark bundle `nanotabpfn_openml_binary_medium` (10 tasks) with data surface label `registry surface label unavailable`. | Bundle and training-data changes are first-class sweep rows and should not be inherited from parent sweep prose. |
-| preprocessing | Notebook preprocessing inside the benchmark helper. | Benchmark preprocessing surface label `registry surface label unavailable`. | Preprocessing changes can alter the effective task definition and must be tracked explicitly. |
-| training recipe | No repo-local prior-dump training-surface contract. | Training surface label `prior_constant_lr`. | Optimizer and schedule changes are first-class sweep rows, not background recipe assumptions. |
+| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Benchmark bundle `nanotabpfn_openml_binary_medium` (10 tasks) with data surface label `anchor_manifest_default`. | Bundle and training-data changes are first-class sweep rows and should not be inherited from parent sweep prose. |
+| preprocessing | Notebook preprocessing inside the benchmark helper. | Benchmark preprocessing surface label `runtime_default`. | Preprocessing changes can alter the effective task definition and must be tracked explicitly. |
+| training recipe | No repo-local prior-dump training-surface contract. | Training surface label `training_default`. | Optimizer and schedule changes are first-class sweep rows, not background recipe assumptions. |
 
 ## Queue Summary
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_architecture_screen_nano_exact_replay` | baseline_replay | yes | ready | nano_exact | Replay the public `nano_exact` stage on `cls_benchmark_staged` before comparing the shared-surface bridge rows. | Run first to establish the architecture-screen replay baseline for the shared-surface bridge. |
-| 2 | `delta_architecture_screen_shared_norm` | feature_encoding | yes | ready | shared_norm | Evaluate the public `shared_norm` stage as the first stage-native step off the PFN-only encoder path on `cls_benchmark_staged`. | Compare directly against the architecture-screen `nano_exact` replay before moving deeper into the bridge. |
-| 3 | `delta_architecture_screen_prenorm_block` | table_block | yes | ready | prenorm_block | Evaluate the public `prenorm_block` stage as the first stage-native backbone change on the shared architecture-screen surface. | Compare against the shared-norm row before deciding whether the bridge should advance through the pre-norm block. |
-| 4 | `delta_architecture_screen_small_class_head` | head | yes | ready | small_class_head | Evaluate the public `small_class_head` stage as the first shared-surface bridge row with the small-class head contract enabled. | Compare directly against `prenorm_block` to decide whether the bridge should carry the small-class head forward. |
-| 5 | `delta_architecture_screen_test_self` | table_block | yes | ready | test_self | Evaluate the public `test_self` stage as the last shared-surface bridge row before grouped-token work. | Compare directly against `small_class_head` and lock only one grouped-token predecessor after the full bridge sweep. |
+| 1 | `delta_architecture_screen_nano_exact_replay` | baseline_replay | yes | completed | nano_exact | Replay the public `nano_exact` stage on `cls_benchmark_staged` before comparing the shared-surface bridge rows. | Run first to establish the architecture-screen replay baseline for the shared-surface bridge. |
+| 2 | `delta_architecture_screen_shared_norm` | feature_encoding | yes | completed | shared_norm | Evaluate the public `shared_norm` stage as the first stage-native step off the PFN-only encoder path on `cls_benchmark_staged`. | Compare directly against the architecture-screen `nano_exact` replay before moving deeper into the bridge. |
+| 3 | `delta_architecture_screen_prenorm_block` | table_block | yes | completed | prenorm_block | Evaluate the public `prenorm_block` stage as the first stage-native backbone change on the shared architecture-screen surface. | Lock as the grouped-token handoff row and treat later bridge rows as optional follow-ons, not new default predecessors. |
+| 4 | `delta_architecture_screen_small_class_head` | head | yes | completed | small_class_head | Evaluate the public `small_class_head` stage as the first shared-surface bridge row with the small-class head contract enabled. | Treat as a binary-lane no-op and keep `prenorm_block` as the grouped-token predecessor. |
+| 5 | `delta_architecture_screen_test_self` | table_block | yes | completed | test_self | Evaluate the public `test_self` stage as the last shared-surface bridge row before grouped-token work. | Do not carry forward by default; only revalidate if grouped-token work makes test-self attention explicitly valuable. |
 
 ## Detailed Rows
 
 ### 1. `delta_architecture_screen_nano_exact_replay`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `nano_exact`
 - Description: Replay the public `nano_exact` stage on `cls_benchmark_staged` before comparing the shared-surface bridge rows.
@@ -63,6 +63,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Keep the public `nano_exact` stage fixed and only move execution onto the benchmark-facing architecture-screen lane.
 - Expected effect: Establish a telemetry-complete local comparator for the stage-native bridge rows without changing the public model stage.
 - Effective labels: model=`delta_architecture_screen_nano_exact_replay`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`training_default`
+- Stage-local stability: column (grad `0.0000`, act delta `-0.0000`); row (grad `0.0000`, act delta `-0.0000`)
 - Training overrides: `{}`
 - Parameter adequacy plan:
   - Run this row first so the bridge sweep has a local `cls_benchmark_staged` comparator with `gradient_history.jsonl` and `telemetry.json`.
@@ -71,18 +72,20 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Keep data, preprocessing, and training surfaces fixed to the canonical architecture-screen contract.
   - Treat benchmark ROC as primary and use emitted telemetry only to confirm same-lane artifact parity.
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `keep`
 - Notes:
   - Treat the older `01_nano_exact_md_prior_parity_fix_binary_medium_v1` registry run as historical anchor evidence only until this replay lands locally.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1`.
+  - Established the architecture-screen nano_exact replay anchor for TF-RD-003 shared-surface bridge comparisons.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1` with final log loss `0.6951`, delta final log loss `+0.0000`, final Brier score `0.5020`, delta final Brier score `+0.0000`, best ROC AUC `0.4339`, final ROC AUC `0.4339`, final-minus-best `+0.0000`, delta final ROC AUC `+0.0000`, delta drift `+0.0000`, delta final training time `+0.0s`
 
 ### 2. `delta_architecture_screen_shared_norm`
 
 - Dimension family: `model`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `shared_norm`
 - Description: Evaluate the public `shared_norm` stage as the first stage-native step off the PFN-only encoder path on `cls_benchmark_staged`.
@@ -92,6 +95,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Starting from the architecture-screen `nano_exact` replay, switch only to the public `shared_norm` stage.
 - Expected effect: Move feature handling onto the shared staged surface while keeping scalar-per-feature tokenization and the post-norm table block fixed.
 - Effective labels: model=`delta_architecture_screen_shared_norm`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`training_default`
+- Stage-local stability: column (grad `0.0000`, act delta `+0.0001`); row (grad `0.0000`, act delta `+0.0001`)
 - Model overrides: `{'stage': 'shared_norm'}`
 - Parameter adequacy plan:
   - Treat this as the first mandatory shared-surface comparator, not as a tokenizer or row-pool experiment.
@@ -100,18 +104,20 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Compare directly against the architecture-screen `nano_exact` replay before attributing later bridge changes.
   - Use activation and gradient telemetry to confirm whether the shared encoder remains stable enough to serve as the first bridge step.
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Historical hybrid-diagnostic `delta_shared_feature_norm` evidence remains context only; this row is the stage-native benchmark-facing shared-surface read.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1`.
+  - Recorded the first stage-native shared-surface bridge read against the architecture-screen nano_exact replay anchor.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1` with final log loss `0.6680`, delta final log loss `-0.0271`, final Brier score `0.4750`, delta final Brier score `-0.0270`, best ROC AUC `0.4928`, final ROC AUC `0.4928`, final-minus-best `+0.0000`, delta final ROC AUC `+0.0589`, delta drift `+0.0000`, delta final training time `+19.5s`
 
 ### 3. `delta_architecture_screen_prenorm_block`
 
 - Dimension family: `model`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `prenorm_block`
 - Description: Evaluate the public `prenorm_block` stage as the first stage-native backbone change on the shared architecture-screen surface.
@@ -121,6 +127,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Starting from the stage-native `shared_norm` bridge row, switch only to the public `prenorm_block` stage.
 - Expected effect: Keep the shared encoder fixed while switching the main table block to the staged pre-norm implementation.
 - Effective labels: model=`delta_architecture_screen_prenorm_block`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`training_default`
+- Stage-local stability: column (grad `0.0000`, act delta `-0.0066`); row (grad `0.0000`, act delta `-0.0434`)
 - Model overrides: `{'stage': 'prenorm_block'}`
 - Parameter adequacy plan:
   - Treat this row as the first backbone change after the shared encoder is active.
@@ -129,18 +136,21 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Compare against both the architecture-screen `nano_exact` replay and the public `shared_norm` row.
   - Use final-vs-best benchmark behavior plus stage-local telemetry to separate outright regressions from bridge instability.
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `keep`
 - Notes:
   - Do not collapse this row back into the older `delta_prenorm_block` conclusion; this is the first benchmark-facing stage-native prenorm read.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Locked as the grouped-token handoff row because it delivered the first material bridge gain while preserving the strongest proper-score result among rows 3-5.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1` with final log loss `0.6538`, delta final log loss `-0.0413`, final Brier score `0.4610`, delta final Brier score `-0.0410`, best ROC AUC `0.5479`, final ROC AUC `0.5479`, final-minus-best `+0.0000`, delta final ROC AUC `+0.1140`, delta drift `+0.0000`, delta final training time `-8.1s`
 
 ### 4. `delta_architecture_screen_small_class_head`
 
 - Dimension family: `model`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `small_class_head`
 - Description: Evaluate the public `small_class_head` stage as the first shared-surface bridge row with the small-class head contract enabled.
@@ -150,6 +160,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Starting from the public `prenorm_block` bridge row, switch only to the public `small_class_head` stage.
 - Expected effect: Keep the shared encoder and pre-norm block fixed while promoting the head to the small-class contract that later grouped-token work should inherit from.
 - Effective labels: model=`delta_architecture_screen_small_class_head`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`training_default`
+- Stage-local stability: column (grad `0.0000`, act delta `-0.0066`); row (grad `0.0000`, act delta `-0.0434`)
 - Model overrides: `{'stage': 'small_class_head'}`
 - Parameter adequacy plan:
   - Treat this as a bridge row, not as a many-class promotion or tokenization change.
@@ -158,18 +169,21 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Compare against `prenorm_block` before attributing any effect to grouped-token readiness.
   - Watch whether head-contract changes are neutral, stabilizing, or clearly harmful on the fixed binary architecture-screen surface.
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - This row exists to make the grouped-token handoff explicit; do not interpret it as many-class promotion work.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Numerically matched `prenorm_block` on this binary architecture-screen lane and did not justify a distinct predecessor row.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1` with final log loss `0.6538`, delta final log loss `-0.0413`, final Brier score `0.4610`, delta final Brier score `-0.0410`, best ROC AUC `0.5479`, final ROC AUC `0.5479`, final-minus-best `+0.0000`, delta final ROC AUC `+0.1140`, delta drift `+0.0000`, delta final training time `-16.3s`
 
 ### 5. `delta_architecture_screen_test_self`
 
 - Dimension family: `model`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `test_self`
 - Description: Evaluate the public `test_self` stage as the last shared-surface bridge row before grouped-token work.
@@ -179,6 +193,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Starting from the public `small_class_head` bridge row, switch only to the public `test_self` stage.
 - Expected effect: Keep the shared bridge surface fixed while enabling the public test-self attention setting that later grouped-token work may inherit.
 - Effective labels: model=`delta_architecture_screen_test_self`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`training_default`
+- Stage-local stability: column (grad `0.0000`, act delta `-0.0075`); row (grad `0.0000`, act delta `-0.0461`)
 - Model overrides: `{'stage': 'test_self'}`
 - Parameter adequacy plan:
   - Treat this as the final shared-surface bridge candidate before grouped tokens, not as tokenizer work.
@@ -187,10 +202,13 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Compare against both `prenorm_block` and `small_class_head` before concluding that test-self attention should be the grouped-token predecessor.
   - Use stage-local telemetry to distinguish a local repair from a genuinely stronger bridge handoff row.
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Earlier hybrid-diagnostic `delta_test_self_attention` evidence is historical context only; the keep/defer decision here must come from the stage-native bridge.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Improved ROC AUC only marginally over `prenorm_block` while slightly worsening log loss and Brier score, so it was not selected as the default handoff row.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1` with final log loss `0.6545`, delta final log loss `-0.0406`, final Brier score `0.4617`, delta final Brier score `-0.0403`, best ROC AUC `0.5493`, final ROC AUC `0.5493`, final-minus-best `+0.0000`, delta final ROC AUC `+0.1154`, delta drift `+0.0000`, delta final training time `-18.1s`

--- a/reference/system_delta_sweeps/shared_surface_bridge_v1/queue.yaml
+++ b/reference/system_delta_sweeps/shared_surface_bridge_v1/queue.yaml
@@ -3,16 +3,15 @@ sweep_id: shared_surface_bridge_v1
 rows:
 - order: 1
   delta_ref: delta_architecture_screen_nano_exact_replay
-  status: ready
-  rationale: >-
-    Replay the public `nano_exact` stage on `cls_benchmark_staged` so the bridge sweep
-    has a same-lane local comparator before any shared-surface row is judged.
-  hypothesis: >-
-    The replay should recover the expected benchmark range while emitting the architecture-screen
-    telemetry artifacts missing from the older prior-lane anchor run.
-  anchor_delta: >-
-    Keep the public `nano_exact` stage fixed and only move execution onto the
-    benchmark-facing architecture-screen lane.
+  status: completed
+  rationale: Replay the public `nano_exact` stage on `cls_benchmark_staged` so the
+    bridge sweep has a same-lane local comparator before any shared-surface row is
+    judged.
+  hypothesis: The replay should recover the expected benchmark range while emitting
+    the architecture-screen telemetry artifacts missing from the older prior-lane
+    anchor run.
+  anchor_delta: Keep the public `nano_exact` stage fixed and only move execution onto
+    the benchmark-facing architecture-screen lane.
   model:
     stage: nano_exact
     stage_label: delta_architecture_screen_nano_exact_replay
@@ -28,27 +27,56 @@ rows:
     with `gradient_history.jsonl` and `telemetry.json`.
   - Compare later bridge rows against this replay rather than treating the older prior-lane
     anchor as artifact-complete.
-  run_id: null
+  run_id: sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: keep
+  interpretation_status: completed
   confounders: []
   next_action: Run first to establish the architecture-screen replay baseline for
     the shared-surface bridge.
   notes:
-  - Treat the older `01_nano_exact_md_prior_parity_fix_binary_medium_v1` registry run as historical anchor evidence only until this replay lands locally.
+  - Treat the older `01_nano_exact_md_prior_parity_fix_binary_medium_v1` registry
+    run as historical anchor evidence only until this replay lands locally.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1`.
+  - Established the architecture-screen nano_exact replay anchor for TF-RD-003 shared-surface
+    bridge comparisons.
+  benchmark_metrics:
+    best_step: 400
+    max_grad_norm: 2.7170772552490234
+    clipped_step_fraction: 0.625
+    best_log_loss: 0.6951108983991502
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.6951108983991502
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.5019782156493655
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.5019782156493655
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.43390183680083255
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.43390183680083255
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0
+    column_activation_early_to_final_mean_delta: -3.979976891976822e-05
+    column_activation_final_window_mean: 0.9999491270292318
+    row_activation_early_to_final_mean_delta: -2.8078761150851506e-05
+    row_activation_final_window_mean: 0.9999601237432885
 - order: 2
   delta_ref: delta_architecture_screen_shared_norm
-  status: ready
-  rationale: >-
-    Make `shared_norm` the first explicit step off the PFN-only encoder path on the
-    benchmark-facing architecture-screen surface.
-  hypothesis: >-
-    The public shared encoder should keep the bridge finite and interpretable enough to
-    serve as the first mandatory shared-surface comparator.
-  anchor_delta: >-
-    Starting from the architecture-screen `nano_exact` replay, switch only to the public
-    `shared_norm` stage.
+  status: completed
+  rationale: Make `shared_norm` the first explicit step off the PFN-only encoder path
+    on the benchmark-facing architecture-screen surface.
+  hypothesis: The public shared encoder should keep the bridge finite and interpretable
+    enough to serve as the first mandatory shared-surface comparator.
+  anchor_delta: Starting from the architecture-screen `nano_exact` replay, switch
+    only to the public `shared_norm` stage.
   model:
     stage: shared_norm
     stage_label: delta_architecture_screen_shared_norm
@@ -64,28 +92,60 @@ rows:
     or row-pool experiment.
   - If weak, keep the result as bridge evidence and do not skip straight to later
     shared-surface rows without recording the regression.
-  run_id: null
+  run_id: sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Compare directly against the architecture-screen `nano_exact` replay
     before moving deeper into the bridge.
   notes:
-  - Historical hybrid-diagnostic `delta_shared_feature_norm` evidence remains context only; this row is the stage-native benchmark-facing shared-surface read.
+  - Historical hybrid-diagnostic `delta_shared_feature_norm` evidence remains context
+    only; this row is the stage-native benchmark-facing shared-surface read.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1`.
+  - Recorded the first stage-native shared-surface bridge read against the architecture-screen
+    nano_exact replay anchor.
+  benchmark_metrics:
+    best_step: 400
+    max_grad_norm: 1.5973516702651978
+    clipped_step_fraction: 0.2225
+    best_log_loss: 0.6679828942145587
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.6679828942145587
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.47501199187574217
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.47501199187574217
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.49278212746697553
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.49278212746697553
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    delta_final_log_loss: -0.027128004184591492
+    delta_final_brier_score: -0.026966223773623343
+    delta_final_roc_auc: 0.058880290666142976
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0
+    column_activation_early_to_final_mean_delta: 6.0411556449202486e-05
+    column_activation_final_window_mean: 1.0000547312016599
+    row_activation_early_to_final_mean_delta: 0.00011093961685415543
+    row_activation_final_window_mean: 1.0001063022905283
 - order: 3
   delta_ref: delta_architecture_screen_prenorm_block
-  status: ready
-  rationale: >-
-    Test whether the public `prenorm_block` stage is the first viable shared-surface backbone
-    change once the bridge is already off the PFN-only encoder.
-  hypothesis: >-
-    The stage-native pre-norm block should be more informative than the earlier hybrid-diagnostic
-    prenorm evidence because it runs on the public shared surface rather than on `nano_exact`
-    with bounded overrides.
-  anchor_delta: >-
-    Starting from the stage-native `shared_norm` bridge row, switch only to the public
-    `prenorm_block` stage.
+  status: completed
+  rationale: Test whether the public `prenorm_block` stage is the first viable shared-surface
+    backbone change once the bridge is already off the PFN-only encoder.
+  hypothesis: The stage-native pre-norm block should be more informative than the
+    earlier hybrid-diagnostic prenorm evidence because it runs on the public shared
+    surface rather than on `nano_exact` with bounded overrides.
+  anchor_delta: Starting from the stage-native `shared_norm` bridge row, switch only
+    to the public `prenorm_block` stage.
   model:
     stage: prenorm_block
     stage_label: delta_architecture_screen_prenorm_block
@@ -100,27 +160,61 @@ rows:
   - Treat this row as the first backbone change after the shared encoder is active.
   - If mixed, preserve it as explicit bridge evidence rather than collapsing the result
     into the older hybrid-diagnostic prenorm evidence.
-  run_id: null
+  run_id: sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: keep
+  interpretation_status: completed
   confounders: []
-  next_action: Compare against the shared-norm row before deciding whether the bridge
-    should advance through the pre-norm block.
+  next_action: Lock as the grouped-token handoff row and treat later bridge rows as
+    optional follow-ons, not new default predecessors.
   notes:
-  - Do not collapse this row back into the older `delta_prenorm_block` conclusion; this is the first benchmark-facing stage-native prenorm read.
+  - Do not collapse this row back into the older `delta_prenorm_block` conclusion;
+    this is the first benchmark-facing stage-native prenorm read.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Locked as the grouped-token handoff row because it delivered the first material
+    bridge gain while preserving the strongest proper-score result among rows 3-5.
+  benchmark_metrics:
+    best_step: 400
+    max_grad_norm: 1.6202101707458496
+    clipped_step_fraction: 0.4075
+    best_log_loss: 0.6537925368843912
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.6537925368843912
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.46099584343509575
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.46099584343509575
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.547923887879494
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.547923887879494
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    delta_final_log_loss: -0.04131836151475898
+    delta_final_brier_score: -0.04098237221426976
+    delta_final_roc_auc: 0.11402205107866142
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0
+    column_activation_early_to_final_mean_delta: -0.006562832898615145
+    column_activation_final_window_mean: 0.9034304734859377
+    row_activation_early_to_final_mean_delta: -0.043416923657441986
+    row_activation_final_window_mean: 1.0767038653624084
 - order: 4
   delta_ref: delta_architecture_screen_small_class_head
-  status: ready
-  rationale: >-
-    Evaluate whether `small_class_head` should become the first explicit grouped-token
-    predecessor row on the public shared-surface bridge.
-  hypothesis: >-
-    The small-class head may improve bridge coherence enough that later grouped-token work
-    should inherit it instead of stopping at the pre-norm block.
-  anchor_delta: >-
-    Starting from the public `prenorm_block` bridge row, switch only to the public
-    `small_class_head` stage.
+  status: completed
+  rationale: Evaluate whether `small_class_head` should become the first explicit
+    grouped-token predecessor row on the public shared-surface bridge.
+  hypothesis: The small-class head may improve bridge coherence enough that later
+    grouped-token work should inherit it instead of stopping at the pre-norm block.
+  anchor_delta: Starting from the public `prenorm_block` bridge row, switch only to
+    the public `small_class_head` stage.
   model:
     stage: small_class_head
     stage_label: delta_architecture_screen_small_class_head
@@ -135,27 +229,62 @@ rows:
   - Treat this as a bridge row, not as a many-class promotion or tokenization change.
   - Use it to decide whether later grouped-token work should inherit the small-class
     head rather than stopping at the pre-norm block.
-  run_id: null
+  run_id: sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Compare directly against `prenorm_block` to decide whether the bridge
-    should carry the small-class head forward.
+  next_action: Treat as a binary-lane no-op and keep `prenorm_block` as the grouped-token
+    predecessor.
   notes:
-  - This row exists to make the grouped-token handoff explicit; do not interpret it as many-class promotion work.
+  - This row exists to make the grouped-token handoff explicit; do not interpret it
+    as many-class promotion work.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Numerically matched `prenorm_block` on this binary architecture-screen lane and
+    did not justify a distinct predecessor row.
+  benchmark_metrics:
+    best_step: 400
+    max_grad_norm: 1.6202101707458496
+    clipped_step_fraction: 0.4075
+    best_log_loss: 0.6537925376495098
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.6537925376495098
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.460995844183887
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.460995844183887
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.547923887879494
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.547923887879494
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    delta_final_log_loss: -0.04131836074964035
+    delta_final_brier_score: -0.040982371465478507
+    delta_final_roc_auc: 0.11402205107866142
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0
+    column_activation_early_to_final_mean_delta: -0.006562832898615145
+    column_activation_final_window_mean: 0.9034304734859377
+    row_activation_early_to_final_mean_delta: -0.043416923657441986
+    row_activation_final_window_mean: 1.0767038653624084
 - order: 5
   delta_ref: delta_architecture_screen_test_self
-  status: ready
-  rationale: >-
-    Evaluate whether `test_self` should displace `small_class_head` as the single grouped-token
-    predecessor on the public shared-surface bridge.
-  hypothesis: >-
-    Test-self attention may repair the late bridge rows enough to justify locking `test_self`
-    as the grouped-token handoff row, but the effect may remain only locally beneficial.
-  anchor_delta: >-
-    Starting from the public `small_class_head` bridge row, switch only to the public
-    `test_self` stage.
+  status: completed
+  rationale: Evaluate whether `test_self` should displace `small_class_head` as the
+    single grouped-token predecessor on the public shared-surface bridge.
+  hypothesis: Test-self attention may repair the late bridge rows enough to justify
+    locking `test_self` as the grouped-token handoff row, but the effect may remain
+    only locally beneficial.
+  anchor_delta: Starting from the public `small_class_head` bridge row, switch only
+    to the public `test_self` stage.
   model:
     stage: test_self
     stage_label: delta_architecture_screen_test_self
@@ -171,12 +300,49 @@ rows:
     not as tokenizer work.
   - Pick between `small_class_head` and `test_self` only after the full five-row bridge
     sweep is visible together.
-  run_id: null
+  run_id: sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Compare directly against `small_class_head` and lock only one grouped-token
-    predecessor after the full bridge sweep.
+  next_action: Do not carry forward by default; only revalidate if grouped-token work
+    makes test-self attention explicitly valuable.
   notes:
-  - Earlier hybrid-diagnostic `delta_test_self_attention` evidence is historical context only; the keep/defer decision here must come from the stage-native bridge.
+  - Earlier hybrid-diagnostic `delta_test_self_attention` evidence is historical context
+    only; the keep/defer decision here must come from the stage-native bridge.
+  - Canonical rerun registered as `sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Improved ROC AUC only marginally over `prenorm_block` while slightly worsening
+    log loss and Brier score, so it was not selected as the default handoff row.
+  benchmark_metrics:
+    best_step: 400
+    max_grad_norm: 1.604324460029602
+    clipped_step_fraction: 0.3825
+    best_log_loss: 0.6544766663723528
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.6544766663723528
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.46166381185560346
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.46166381185560346
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.5493476180578807
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.5493476180578807
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    delta_final_log_loss: -0.04063423202679739
+    delta_final_brier_score: -0.040314403793762055
+    delta_final_roc_auc: 0.11544578125704813
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0
+    column_activation_early_to_final_mean_delta: -0.007459636209227294
+    column_activation_final_window_mean: 0.901507613493251
+    row_activation_early_to_final_mean_delta: -0.046072893887601385
+    row_activation_final_window_mean: 1.0698463719490163

--- a/reference/system_delta_sweeps/shared_surface_bridge_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/shared_surface_bridge_v1/sweep.yaml
@@ -1,9 +1,9 @@
 schema: tab-foundry-system-delta-sweep-v1
 sweep_id: shared_surface_bridge_v1
 parent_sweep_id: binary_md_v1
-status: draft
+status: completed
 complexity_level: binary_md
-anchor_run_id: 01_nano_exact_md_prior_parity_fix_binary_medium_v1
+anchor_run_id: sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1
 benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
 control_baseline_id: cls_benchmark_linear_v2
 training_experiment: cls_benchmark_staged
@@ -15,17 +15,17 @@ upstream_reference:
   model_source: https://github.com/automl/nanoTabPFN/blob/main/model.py
 anchor_surface:
   notes:
-  - The locked anchor is benchmark registry run `01_nano_exact_md_prior_parity_fix_binary_medium_v1`
+  - The locked anchor is benchmark registry run `sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1`
     on bundle `nanotabpfn_openml_binary_medium` (10 tasks).
-  - This sweep is the first benchmark-facing, stage-native shared-surface bridge
-    on `cls_benchmark_staged`; it does not reuse the hybrid-diagnostic lane as its
-    execution surface.
+  - This sweep is the first benchmark-facing, stage-native shared-surface bridge on
+    `cls_benchmark_staged`; it does not reuse the hybrid-diagnostic lane as its execution
+    surface.
   - Earlier hybrid-diagnostic results for `delta_shared_feature_norm`, `delta_prenorm_block`,
     and `delta_test_self_attention` remain historical input only and do not close
     TF-RD-003 by themselves.
-  - The local registry anchor does not include `gradient_history.jsonl` or `telemetry.json`,
-    so row 1 replays `nano_exact` on the architecture-screen lane before the shared-surface
-    bridge rows are compared.
+  - Treat the older `01_nano_exact_md_prior_parity_fix_binary_medium_v1` registry run
+    as historical anchor evidence only; row 1 established the same-lane replay anchor
+    with the missing telemetry artifacts.
   - Data and preprocessing remain part of the comparison surface and must stay fixed
     unless the queue row declares that exact dimension.
   dimension_table:
@@ -70,39 +70,43 @@ anchor_surface:
     upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training
       manifest contract.
     anchor: Benchmark bundle `nanotabpfn_openml_binary_medium` (10 tasks) with data
-      surface label `registry surface label unavailable`.
+      surface label `anchor_manifest_default`.
     interpretation: Bundle and training-data changes are first-class sweep rows and
       should not be inherited from parent sweep prose.
   - dimension: preprocessing
     upstream: Notebook preprocessing inside the benchmark helper.
-    anchor: Benchmark preprocessing surface label `registry surface label unavailable`.
+    anchor: Benchmark preprocessing surface label `runtime_default`.
     interpretation: Preprocessing changes can alter the effective task definition
       and must be tracked explicitly.
   - dimension: training recipe
     upstream: No repo-local prior-dump training-surface contract.
-    anchor: Training surface label `prior_constant_lr`.
+    anchor: Training surface label `training_default`.
     interpretation: Optimizer and schedule changes are first-class sweep rows, not
       background recipe assumptions.
 anchor_context:
-  run_id: 01_nano_exact_md_prior_parity_fix_binary_medium_v1
-  experiment: cls_benchmark_staged_prior
-  config_profile: cls_benchmark_staged_prior
+  run_id: sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1
+  experiment: cls_benchmark_staged
+  config_profile: cls_benchmark_staged
   model:
     arch: tabfoundry_staged
-    benchmark_profile: nano_exact
+    benchmark_profile: delta_architecture_screen_nano_exact_replay
     stage: nano_exact
-    stage_label: null
+    stage_label: delta_architecture_screen_nano_exact_replay
     module_selection:
+      allow_test_self_attention: false
+      column_encoder: none
+      context_encoder: none
       feature_encoder: nano
+      head: binary_direct
       post_encoder_norm: none
       post_stack_norm: none
+      row_pool: target_column
+      table_block_residual_scale: none
+      table_block_style: nano_postnorm
       target_conditioner: mean_padded_linear
       tokenizer: scalar_per_feature
-      column_encoder: none
-      row_pool: target_column
-      context_encoder: none
-      head: binary_direct
-      table_block_style: nano_postnorm
-      table_block_residual_scale: none
-      allow_test_self_attention: false
-  surface_labels: null
+  surface_labels:
+    data: anchor_manifest_default
+    model: delta_architecture_screen_nano_exact_replay
+    preprocessing: runtime_default
+    training: training_default

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -7661,6 +7661,929 @@
         "train_elapsed_seconds": 258.1572148539126,
         "wall_elapsed_seconds": 272.201015740633
       }
+    },
+    "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/train/checkpoints/step_000400.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": null,
+        "vs_parent": null
+      },
+      "conclusion": "Established the architecture-screen nano_exact replay anchor for TF-RD-003 shared-surface bridge comparisons.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "keep",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": null,
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": null
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_nano_exact_replay",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": false,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "nano_postnorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": false,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "nano",
+          "head": "binary_direct",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "nano_postnorm",
+          "target_conditioner": "mean_padded_linear",
+          "tokenizer": "scalar_per_feature"
+        },
+        "stage": "nano_exact",
+        "stage_label": "delta_architecture_screen_nano_exact_replay",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356066,
+        "trainable_params": 356066
+      },
+      "registered_at_utc": "2026-03-19T23:36:35Z",
+      "run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_nano_exact_replay",
+        "preprocessing": "runtime_default",
+        "training": "training_default"
+      },
+      "sweep": {
+        "delta_id": "delta_architecture_screen_nano_exact_replay",
+        "parent_sweep_id": "binary_md_v1",
+        "queue_order": 1,
+        "run_kind": "primary",
+        "sweep_id": "shared_surface_bridge_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.5019782156493655,
+        "best_crps": null,
+        "best_log_loss": 0.6951108983991502,
+        "best_picp_90": null,
+        "best_roc_auc": 0.43390183680083255,
+        "best_step": 400.0,
+        "best_training_time": 87.31229317294492,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.5019782156493655,
+        "final_crps": null,
+        "final_log_loss": 0.6951108983991502,
+        "final_picp_90": null,
+        "final_roc_auc": 0.43390183680083255,
+        "final_step": 400.0,
+        "final_training_time": 87.31229317294492
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 1.067495346069336,
+        "final_val_loss": null,
+        "max_grad_norm": 2.7170772552490234,
+        "mean_grad_norm": 1.1755298732221127,
+        "post_warmup_train_loss_var": 0.0008439976894508583,
+        "train_elapsed_seconds": 87.31229317294492,
+        "wall_elapsed_seconds": 88.95210891599709
+      }
+    },
+    "sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/train/checkpoints/step_000400.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_shared_norm/sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.058880290666142976,
+          "best_training_time_delta": 19.474670571216848,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.026966223773623343,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.027128004184591492,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.058880290666142976,
+          "final_training_time_delta": 19.474670571216848,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.058880290666142976,
+          "best_training_time_delta": 19.474670571216848,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.026966223773623343,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.027128004184591492,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.058880290666142976,
+          "final_training_time_delta": 19.474670571216848,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        }
+      },
+      "conclusion": "Recorded the first stage-native shared-surface bridge read against the architecture-screen nano_exact replay anchor.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_shared_norm",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": false,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "nano_postnorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": false,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "shared",
+          "head": "binary_direct",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "nano_postnorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "scalar_per_feature"
+        },
+        "stage": "shared_norm",
+        "stage_label": "delta_architecture_screen_shared_norm",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356066,
+        "trainable_params": 356066
+      },
+      "registered_at_utc": "2026-03-19T23:51:20Z",
+      "run_id": "sd_shared_surface_bridge_v1_02_delta_architecture_screen_shared_norm_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_shared_norm",
+        "preprocessing": "runtime_default",
+        "training": "training_default"
+      },
+      "sweep": {
+        "delta_id": "delta_architecture_screen_shared_norm",
+        "parent_sweep_id": "binary_md_v1",
+        "queue_order": 2,
+        "run_kind": "primary",
+        "sweep_id": "shared_surface_bridge_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.47501199187574217,
+        "best_crps": null,
+        "best_log_loss": 0.6679828942145587,
+        "best_picp_90": null,
+        "best_roc_auc": 0.49278212746697553,
+        "best_step": 400.0,
+        "best_training_time": 106.78696374416177,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.47501199187574217,
+        "final_crps": null,
+        "final_log_loss": 0.6679828942145587,
+        "final_picp_90": null,
+        "final_roc_auc": 0.49278212746697553,
+        "final_step": 400.0,
+        "final_training_time": 106.78696374416177
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.84682697057724,
+        "final_val_loss": null,
+        "max_grad_norm": 1.5973516702651978,
+        "mean_grad_norm": 0.8779342906177043,
+        "post_warmup_train_loss_var": 0.0003077550160368561,
+        "train_elapsed_seconds": 106.78696374416177,
+        "wall_elapsed_seconds": 111.54881300000125
+      }
+    },
+    "sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/train/checkpoints/step_000400.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_prenorm_block/sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.11402205107866142,
+          "best_training_time_delta": -8.059707135820645,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.04098237221426976,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04131836151475898,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11402205107866142,
+          "final_training_time_delta": -8.059707135820645,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.11402205107866142,
+          "best_training_time_delta": -8.059707135820645,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.04098237221426976,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04131836151475898,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11402205107866142,
+          "final_training_time_delta": -8.059707135820645,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        }
+      },
+      "conclusion": "Locked as the grouped-token handoff row because it delivered the first material bridge gain while preserving the strongest proper-score result among rows 3-5.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "keep",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_prenorm_block",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": false,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": false,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "shared",
+          "head": "binary_direct",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "scalar_per_feature"
+        },
+        "stage": "prenorm_block",
+        "stage_label": "delta_architecture_screen_prenorm_block",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356066,
+        "trainable_params": 356066
+      },
+      "registered_at_utc": "2026-03-20T00:17:09Z",
+      "run_id": "sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_prenorm_block",
+        "preprocessing": "runtime_default",
+        "training": "training_default"
+      },
+      "sweep": {
+        "delta_id": "delta_architecture_screen_prenorm_block",
+        "parent_sweep_id": "binary_md_v1",
+        "queue_order": 3,
+        "run_kind": "primary",
+        "sweep_id": "shared_surface_bridge_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.46099584343509575,
+        "best_crps": null,
+        "best_log_loss": 0.6537925368843912,
+        "best_picp_90": null,
+        "best_roc_auc": 0.547923887879494,
+        "best_step": 400.0,
+        "best_training_time": 79.25258603712427,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.46099584343509575,
+        "final_crps": null,
+        "final_log_loss": 0.6537925368843912,
+        "final_picp_90": null,
+        "final_roc_auc": 0.547923887879494,
+        "final_step": 400.0,
+        "final_training_time": 79.25258603712427
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.9135237336158752,
+        "final_val_loss": null,
+        "max_grad_norm": 1.6202101707458496,
+        "mean_grad_norm": 0.9687842106819153,
+        "post_warmup_train_loss_var": 0.0006517943747977265,
+        "train_elapsed_seconds": 79.25258603712427,
+        "wall_elapsed_seconds": 83.94683670900122
+      }
+    },
+    "sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/train/checkpoints/step_000400.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_small_class_head/sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.11402205107866142,
+          "best_training_time_delta": -16.33345454695518,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.040982371465478507,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04131836074964035,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11402205107866142,
+          "final_training_time_delta": -16.33345454695518,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.11402205107866142,
+          "best_training_time_delta": -16.33345454695518,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.040982371465478507,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04131836074964035,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11402205107866142,
+          "final_training_time_delta": -16.33345454695518,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_small_class_head",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": false,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": false,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "scalar_per_feature"
+        },
+        "stage": "small_class_head",
+        "stage_label": "delta_architecture_screen_small_class_head",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356066,
+        "trainable_params": 356066
+      },
+      "registered_at_utc": "2026-03-20T00:29:50Z",
+      "run_id": "sd_shared_surface_bridge_v1_04_delta_architecture_screen_small_class_head_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_small_class_head",
+        "preprocessing": "runtime_default",
+        "training": "training_default"
+      },
+      "sweep": {
+        "delta_id": "delta_architecture_screen_small_class_head",
+        "parent_sweep_id": "binary_md_v1",
+        "queue_order": 4,
+        "run_kind": "primary",
+        "sweep_id": "shared_surface_bridge_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.460995844183887,
+        "best_crps": null,
+        "best_log_loss": 0.6537925376495098,
+        "best_picp_90": null,
+        "best_roc_auc": 0.547923887879494,
+        "best_step": 400.0,
+        "best_training_time": 70.97883862598974,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.460995844183887,
+        "final_crps": null,
+        "final_log_loss": 0.6537925376495098,
+        "final_picp_90": null,
+        "final_roc_auc": 0.547923887879494,
+        "final_step": 400.0,
+        "final_training_time": 70.97883862598974
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.9135237336158752,
+        "final_val_loss": null,
+        "max_grad_norm": 1.6202101707458496,
+        "mean_grad_norm": 0.9687842105329036,
+        "post_warmup_train_loss_var": 0.0006517943876760072,
+        "train_elapsed_seconds": 70.97883862598974,
+        "wall_elapsed_seconds": 73.52852741599781
+      }
+    },
+    "sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/train/checkpoints/step_000400.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_test_self/sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.11544578125704813,
+          "best_training_time_delta": -18.13481637799123,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.040314403793762055,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04063423202679739,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11544578125704813,
+          "final_training_time_delta": -18.13481637799123,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.11544578125704813,
+          "best_training_time_delta": -18.13481637799123,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.040314403793762055,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.04063423202679739,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.11544578125704813,
+          "final_training_time_delta": -18.13481637799123,
+          "reference_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1"
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_test_self",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "scalar_per_feature"
+        },
+        "stage": "test_self",
+        "stage_label": "delta_architecture_screen_test_self",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356066,
+        "trainable_params": 356066
+      },
+      "registered_at_utc": "2026-03-20T00:42:09Z",
+      "run_id": "sd_shared_surface_bridge_v1_05_delta_architecture_screen_test_self_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_test_self",
+        "preprocessing": "runtime_default",
+        "training": "training_default"
+      },
+      "sweep": {
+        "delta_id": "delta_architecture_screen_test_self",
+        "parent_sweep_id": "binary_md_v1",
+        "queue_order": 5,
+        "run_kind": "primary",
+        "sweep_id": "shared_surface_bridge_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.46166381185560346,
+        "best_crps": null,
+        "best_log_loss": 0.6544766663723528,
+        "best_picp_90": null,
+        "best_roc_auc": 0.5493476180578807,
+        "best_step": 400.0,
+        "best_training_time": 69.17747679495369,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.46166381185560346,
+        "final_crps": null,
+        "final_log_loss": 0.6544766663723528,
+        "final_picp_90": null,
+        "final_roc_auc": 0.5493476180578807,
+        "final_step": 400.0,
+        "final_training_time": 69.17747679495369
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.9085001945495605,
+        "final_val_loss": null,
+        "max_grad_norm": 1.604324460029602,
+        "mean_grad_norm": 0.9515412475168705,
+        "post_warmup_train_loss_var": 0.000621943721489645,
+        "train_elapsed_seconds": 69.17747679495369,
+        "wall_elapsed_seconds": 72.07819995799218
+      }
     }
   },
   "schema": "tab-foundry-benchmark-runs-v1",

--- a/tests/research/test_shared_surface_bridge_v1.py
+++ b/tests/research/test_shared_surface_bridge_v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -68,7 +69,11 @@ def test_shared_surface_bridge_v1_uses_architecture_screen_lane_and_stage_native
         "stage-native shared-surface bridge" in note for note in sweep["anchor_surface"]["notes"]
     )
     assert any(
-        "row 1 replays `nano_exact` on the architecture-screen lane" in note
+        "same-lane replay anchor" in note
+        for note in sweep["anchor_surface"]["notes"]
+    )
+    assert any(
+        "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1" in note
         for note in sweep["anchor_surface"]["notes"]
     )
 
@@ -103,3 +108,26 @@ def test_shared_surface_bridge_v1_matrix_records_the_stage_native_bridge_rows() 
     assert "delta_architecture_screen_small_class_head" in matrix
     assert "delta_architecture_screen_test_self" in matrix
     assert "Treat the older `01_nano_exact_md_prior_parity_fix_binary_medium_v1` registry run as historical anchor evidence only" in matrix
+    assert "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1" in matrix
+    assert "data surface label `anchor_manifest_default`" in matrix
+    assert "Benchmark preprocessing surface label `runtime_default`" in matrix
+    assert "Training surface label `training_default`" in matrix
+    assert "prior_constant_lr" not in matrix
+    assert "registry surface label unavailable" not in matrix
+    assert "Lock as the grouped-token handoff row and treat later bridge rows as optional follow-ons" in matrix
+
+
+def test_shared_surface_bridge_v1_registry_records_prenorm_block_as_locked_handoff() -> None:
+    registry = json.loads(
+        (REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    run = registry["runs"]["sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1"]
+
+    assert run["decision"] == "keep"
+    assert (
+        run["conclusion"]
+        == "Locked as the grouped-token handoff row because it delivered the first material bridge gain while preserving the strongest proper-score result among rows 3-5."
+    )


### PR DESCRIPTION
## Summary
- align `shared_surface_bridge_v1` on the replay run as the locked anchor across the sweep index, queue, sweep metadata, matrix, and benchmark registry
- record `prenorm_block` as the canonical grouped-token handoff row in the checked-in research metadata
- refresh the rendered shared-surface matrix so the anchor comparison and final row actions match the canonical sources

## Issues
Closes #60
Closes #61
Refs #45
Refs #46

## Testing
- `./.venv/bin/pytest tests/research/test_shared_surface_bridge_v1.py`
- `./scripts/dev verify paths reference/system_delta_sweeps/shared_surface_bridge_v1 src/tab_foundry/bench/benchmark_run_registry_v1.json tests/research/test_shared_surface_bridge_v1.py`