### PR TITLE
[TF-RD-004] Land grouped-token warmup-decay replay

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -91,7 +91,7 @@ retained for traceability.
 | 1 | TF-RD-001 | Control freeze and experiment trust | implemented | Implemented |
 | 2 | TF-RD-002 | Measurement surfaces for architecture migration | implemented | Implemented |
 | 3 | TF-RD-003 | Shared-surface unlock | implemented | Implemented |
-| 4 | TF-RD-004 | Tokenization migration | partial | Now |
+| 4 | TF-RD-004 | Tokenization migration | completed | Now |
 | 5 | TF-RD-005 | Row-embedding unlock | planned | Now |
 | 6 | TF-RD-006 | Column-set integration | planned | Now |
 | 7 | TF-RD-007 | Row-level context and QASS attribution | planned | Now |
@@ -154,7 +154,7 @@ Critical path: **003 → 004 → 005 → 006 → 007 → 008**. 000, 001, 002, 0
 | Objective / Claim | Current State | Evidence In Repo | Current Gap | Roadmap IDs |
 | --- | --- | --- | --- | --- |
 | Frozen PFN-style control exists | `implemented` | `tabfoundry_simple`, `stage=nano_exact`, benchmark comparison tooling, and prior-trained PFN-facing lanes already exist | The current large-anchor hybrid line is still easy to confuse with the intended destination | `TF-RD-001` |
-| Coherent row-first migration ladder exists in code | `partial` | The staged recipe ladder already encodes `shared_norm -> prenorm_block -> small_class_head -> test_self -> grouped_tokens -> row_cls_pool -> column_set -> qass_context -> many_class`, `shared_surface_bridge_v1` locks `prenorm_block` as the grouped-token handoff, and `grouped_token_stability_probe_v1` resolves the grouped-token adequacy question in favor of `prior_linear_warmup_decay` | One benchmark-facing grouped-token replay on the winning warmup-decay surface still needs to be registered before later row-first rows should rely on grouped tokens as the working token surface | `TF-RD-003`, `TF-RD-004`, `TF-RD-005`, `TF-RD-006`, `TF-RD-007` |
+| Coherent row-first migration ladder exists in code | `partial` | The staged recipe ladder already encodes `shared_norm -> prenorm_block -> small_class_head -> test_self -> grouped_tokens -> row_cls_pool -> column_set -> qass_context -> many_class`, `shared_surface_bridge_v1` locks `prenorm_block` as the grouped-token handoff, `grouped_token_stability_probe_v1` resolves the adequacy question in favor of `prior_linear_warmup_decay`, and benchmark-facing replay `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` now carries grouped tokens on the architecture-screen lane | Later row-first rows still need their own attributable evaluations, but TF-RD-005, TF-RD-006, and TF-RD-007 should inherit grouped tokens from `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` rather than from `prenorm_block` or the older scalar-token path | `TF-RD-003`, `TF-RD-004`, `TF-RD-005`, `TF-RD-006`, `TF-RD-007` |
 | Architecture comparisons are attributable | `partial` | Isolated row-CLS, TFCol, and QASS evidence exists on compact surfaces | Negative evidence is easy to overgeneralize because stage-local telemetry and matched controls are still incomplete | `TF-RD-002`, `TF-RD-005`, `TF-RD-006`, `TF-RD-007` |
 | One promoted row-first classification anchor exists | `planned` | The ingredients exist in `tabfoundry_staged`, but no coherent row-first anchor has been promoted | The active architecture target is still split across compact-ladder evidence and the current large hybrid line | `TF-RD-008` |
 | Scaling-law work targets the right architecture | `partial` | Tuning and benchmark-adjacent tooling already exist | There is no canonical scaling artifact path on a promoted row-first anchor yet | `TF-RD-009` |
@@ -276,8 +276,8 @@ This roadmap assumes the following repo truths:
 
 ### TF-RD-004: Tokenization Migration
 
-- Status: `partial`
-- Milestone: `Now`
+- Status: `completed`
+- Milestone: `Implemented`
 - Goal: evaluate grouped tokenization as the first true row-first preparation
   step on the shared surface
 - Current state:
@@ -304,16 +304,18 @@ This roadmap assumes the following repo truths:
   - TF-RD-004 now has an explicit keep decision: grouped tokens stay on the
     migration path, with `prior_linear_warmup_decay` as the preferred adequacy
     surface for the benchmark-facing replay
-- Required work:
-  - register one benchmark-facing grouped-token replay on the winning
-    `prior_linear_warmup_decay` surface without trace-only overhead so the
-    grouped-token handoff is benchmark-facing rather than probe-only
-  - keep `prenorm_block` as the canonical architecture-screen handoff until that
-    replay is registered, even though the grouped-token keep/defer decision is
-    now resolved
-  - use the replayed warmup-decay grouped-token surface, not the old
-    scalar-per-feature token path, as the predecessor for TF-RD-005, TF-RD-006,
-    and TF-RD-007
+  - the benchmark-facing grouped-token replay
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    is now registered on the architecture-screen lane and lands the probe's
+    no-trace warmup-decay surface as the canonical grouped-token predecessor
+- Implemented contract:
+  - keep `prenorm_block` as the locked TF-RD-004 anchor for attributable
+    comparisons, but carry later row-first work forward from
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+  - treat the warmup-decay grouped-token replay, not the old scalar-per-feature
+    token path, as the predecessor for TF-RD-005, TF-RD-006, and TF-RD-007
+  - preserve the adequacy probe as supporting evidence rather than the
+    benchmark-facing handoff itself
 - Exit criteria:
   - the grouped-token keep decision is recorded from the mixed
     `tokenization_migration_v1` result plus the warmup-decay stability follow-up
@@ -333,8 +335,9 @@ This roadmap assumes the following repo truths:
   - that evidence is entangled with the old PFN-adjacent surface and should not
     be generalized too far
 - Required work:
-  - evaluate `row_cls_pool` only after the grouped-token warmup-decay replay
-    from TF-RD-004 is registered
+  - evaluate `row_cls_pool` starting from grouped-token replay
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`,
+    not from `prenorm_block` or the older scalar-token path
   - keep adequacy checks bounded to row-encoder capacity knobs after the main
     row-first surface is established
   - interpret old row-CLS negative evidence as compact-surface evidence, not as
@@ -354,8 +357,8 @@ This roadmap assumes the following repo truths:
   - old compact-surface TFCol evidence was near-neutral, stable, and expensive
   - the old row pool and compact surface limited how much that result could say
 - Required work:
-  - evaluate `column_set` only after the grouped-token warmup-decay replay is
-    registered and row embeddings are viable
+  - evaluate `column_set` only after row embeddings are viable on grouped-token
+    replay `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
   - keep inducing-count and depth adequacy follow-ups bounded and explicit
   - interpret TFCol as part of the row-first bundle, not as a bolt-on to the PFN
     anchor
@@ -376,8 +379,9 @@ This roadmap assumes the following repo truths:
     not cleanly separate context value from added depth
 - Required work:
   - compare row-level `plain` context against row-level `qass` context only
-    after the grouped-token warmup-decay replay and the row-embedding /
-    column-set predecessors are registered
+    after grouped-token replay
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    and the row-embedding / column-set predecessors are registered
   - pair each QASS row with a matched non-QASS added-depth control
   - keep QASS optional by construction
 - Exit criteria:

--- a/reference/system_delta_sweeps/grouped_token_stability_probe_v1/matrix.md
+++ b/reference/system_delta_sweeps/grouped_token_stability_probe_v1/matrix.md
@@ -5,7 +5,7 @@ This file is rendered from `reference/system_delta_sweeps/grouped_token_stabilit
 ## Sweep
 
 - Sweep id: `grouped_token_stability_probe_v1`
-- Sweep status: `draft`
+- Sweep status: `completed`
 - Parent sweep id: `tokenization_migration_v1`
 - Complexity level: `binary_md`
 
@@ -44,7 +44,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | `delta_anchor_activation_trace_baseline` | diagnostics | yes | completed | none | Keep the locked anchor model surface fixed but rerun prior training with activation tracing enabled so forward-pass norm dynamics are captured in `gradient_history.jsonl` and `telemetry.json`. | Use this traced row as the telemetry anchor only; the benchmark-facing grouped-token replay should follow the row-3 no-trace warmup-decay surface rather than this traced run. |
 | 2 | `delta_training_linear_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but replace the exact-prior constant LR with single-stage linear decay. | Keep this row as a ROC-oriented tradeoff reference only; prefer the warmup-decay grouped-token surface before any benchmark-facing replay or later row-first architecture work. |
-| 3 | `delta_training_linear_warmup_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup. | Run one benchmark-facing grouped-token replay on this no-trace warmup-decay surface, then let TF-RD-005, TF-RD-006, and TF-RD-007 inherit grouped tokens from that replay rather than from `prenorm_block`. |
+| 3 | `delta_training_linear_warmup_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup. | Use `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` as the canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and TF-RD-007; keep this row as the adequacy probe that selected the replay surface rather than as the benchmark-facing handoff itself. |
 
 ## Detailed Rows
 
@@ -145,6 +145,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
   - Warmup+decay without tracing reproduced row 1 almost exactly: final log loss `0.4002`, final Brier `0.2618`, final ROC AUC `0.7414`, clipped-step fraction `0.0012`, and zero drift.
   - Treat this as the preferred grouped-token adequacy surface: it preserves the strong row-1 quality/stability read without the trace-only overhead and clearly dominates the no-warmup decay tradeoff on loss, Brier, and gradient stability.
+  - Benchmark-facing replay `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` landed on the architecture-screen lane, so TF-RD-005, TF-RD-006, and TF-RD-007 should inherit grouped tokens from that run rather than from `prenorm_block`.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/grouped_token_stability_probe_v1/delta_training_linear_warmup_decay/result_card.md`
 - Registered run: `sd_grouped_token_stability_probe_v1_03_delta_training_linear_warmup_decay_v1` with final log loss `0.4002`, delta final log loss `-0.2370`, final Brier score `0.2618`, delta final Brier score `-0.1833`, best ROC AUC `0.7414`, final ROC AUC `0.7414`, final-minus-best `+0.0000`, delta final ROC AUC `+0.2184`, delta drift `+0.0000`, delta final training time `+382.1s`

--- a/reference/system_delta_sweeps/grouped_token_stability_probe_v1/queue.yaml
+++ b/reference/system_delta_sweeps/grouped_token_stability_probe_v1/queue.yaml
@@ -233,15 +233,17 @@ rows:
   decision: keep
   interpretation_status: completed
   confounders: []
-  next_action: Run one benchmark-facing grouped-token replay on this no-trace warmup-decay
-    surface, then let TF-RD-005, TF-RD-006, and TF-RD-007 inherit grouped tokens
-    from that replay rather than from `prenorm_block`.
+  next_action: Use `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    as the canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and TF-RD-007;
+    keep this row as the adequacy probe that selected the replay surface rather than
+    as the benchmark-facing handoff itself.
   notes:
   - Canonical rerun registered as `sd_grouped_token_stability_probe_v1_03_delta_training_linear_warmup_decay_v1`.
   - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
     this row in the full sweep context.
   - "Warmup+decay without tracing reproduced row 1 almost exactly: final log loss `0.4002`, final Brier `0.2618`, final ROC AUC `0.7414`, clipped-step fraction `0.0012`, and zero drift."
   - "Treat this as the preferred grouped-token adequacy surface: it preserves the strong row-1 quality/stability read without the trace-only overhead and clearly dominates the no-warmup decay tradeoff on loss, Brier, and gradient stability."
+  - "Benchmark-facing replay `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` landed on the architecture-screen lane, so TF-RD-005, TF-RD-006, and TF-RD-007 should inherit grouped tokens from that run rather than from `prenorm_block`."
   benchmark_metrics:
     best_step: 2500
     max_grad_norm: 1.2678043842315674

--- a/reference/system_delta_sweeps/grouped_token_stability_probe_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/grouped_token_stability_probe_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
 sweep_id: grouped_token_stability_probe_v1
 parent_sweep_id: tokenization_migration_v1
-status: draft
+status: completed
 complexity_level: binary_md
 anchor_run_id: sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2
 benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
@@ -22,9 +22,12 @@ anchor_surface:
   - Data and preprocessing remain part of the comparison surface and must stay fixed
     unless the queue row declares that exact dimension.
   - >-
-    `prenorm_block` remains the current canonical architecture-screen handoff;
-    `grouped_tokens` stays mixed benchmark evidence until this bounded
-    hybrid-diagnostic probe resolves.
+    This bounded hybrid-diagnostic probe resolved the grouped-token adequacy
+    question, and benchmark-facing replay
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    now carries grouped tokens on the architecture-screen lane while
+    `prenorm_block` remains the locked TF-RD-004 anchor for attributable
+    comparisons.
   - >-
     This sweep keeps the grouped-token model, data, and preprocessing surfaces
     fixed and asks only whether training adequacy explains the weaker ROC read.
@@ -32,8 +35,9 @@ anchor_surface:
     Do not interpret this sweep as evidence about row-CLS, TFCol, QASS, or
     later tokenizer-dependent architecture work.
   - >-
-    TF-RD-005, TF-RD-006, and TF-RD-007 remain blocked on the outcome of this
-    grouped-token adequacy probe.
+    TF-RD-005, TF-RD-006, and TF-RD-007 should inherit grouped tokens from
+    `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`,
+    not from `prenorm_block` or the older scalar-token path.
   dimension_table:
   - dimension: feature encoder
     upstream: Scalar feature linear encoder with internal train/test z-score+clip

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -94,14 +94,14 @@ sweeps:
     control_baseline_id: cls_benchmark_linear_v2
   tokenization_migration_v1:
     parent_sweep_id: shared_surface_bridge_v1
-    status: draft
+    status: completed
     anchor_run_id: sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1
     complexity_level: binary_md
     benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
     control_baseline_id: cls_benchmark_linear_v2
   grouped_token_stability_probe_v1:
     parent_sweep_id: tokenization_migration_v1
-    status: draft
+    status: completed
     anchor_run_id: sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2
     complexity_level: binary_md
     benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json

--- a/reference/system_delta_sweeps/tokenization_migration_v1/matrix.md
+++ b/reference/system_delta_sweeps/tokenization_migration_v1/matrix.md
@@ -5,7 +5,7 @@ This file is rendered from `reference/system_delta_sweeps/tokenization_migration
 ## Sweep
 
 - Sweep id: `tokenization_migration_v1`
-- Sweep status: `draft`
+- Sweep status: `completed`
 - Parent sweep id: `shared_surface_bridge_v1`
 - Complexity level: `binary_md`
 
@@ -43,6 +43,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | `delta_architecture_screen_grouped_tokens` | tokenization | yes | completed | grouped_tokens | Replace scalar-per-feature tokenization with the public grouped-token staged recipe on the locked shared-surface handoff. | Run the first stage-native grouped-token benchmark row on top of the locked `prenorm_block` handoff, then create `grouped_token_stability_probe_v1` only if this row registers successfully. |
+| 2 | `delta_training_linear_warmup_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup. | Use `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` as the canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and TF-RD-007; do not reopen the tokenization handoff unless a later benchmark-facing replay supersedes it. |
 
 ## Detailed Rows
 
@@ -79,3 +80,35 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tokenization_migration_v1/delta_architecture_screen_grouped_tokens/result_card.md`
 - Registered run: `sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2` with final log loss `0.6372`, delta final log loss `-0.0166`, final Brier score `0.4451`, delta final Brier score `-0.0159`, best ROC AUC `0.5229`, final ROC AUC `0.5229`, final-minus-best `+0.0000`, delta final ROC AUC `-0.0250`, delta drift `+0.0000`, delta final training time `+2.4s`
+
+### 2. `delta_training_linear_warmup_decay`
+
+- Dimension family: `training`
+- Status: `completed`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup.
+- Rationale: Replay the grouped-token row on the benchmark-facing architecture-screen lane with the no-trace warmup-decay training contract selected by the grouped-token adequacy probe.
+- Hypothesis: The benchmark-facing grouped-token replay should recover the probe's stable warmup-decay quality while keeping the architecture-screen lane, making the grouped-token handoff canonical for TF-RD-005, TF-RD-006, and TF-RD-007.
+- Upstream delta: Not applicable; this is a repo-local exact-prior training recipe change.
+- Anchor delta: Keep the stage-native grouped-token model, data, and preprocessing surfaces fixed on `cls_benchmark_staged`, then replace `training_default` with the preferred no-trace `prior_linear_warmup_decay` contract selected by `grouped_token_stability_probe_v1`.
+- Expected effect: Reduced early instability versus constant LR or plain linear decay, with uncertain final quality impact.
+- Effective labels: model=`delta_architecture_screen_grouped_tokens`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.0000`)
+- Training overrides: `{'apply_schedule': True, 'optimizer': {'name': 'schedulefree_adamw', 'require_requested': True, 'weight_decay': 0.0, 'betas': [0.9, 0.999], 'min_lr': 0.0004, 'muon_per_parameter_lr': False}, 'runtime': {'max_steps': 2500, 'eval_every': 25, 'checkpoint_every': 25, 'trace_activations': False}, 'schedule': {'stages': [{'name': 'stage1', 'steps': 2500, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.05}]}}`
+- Parameter adequacy plan:
+  - Compare directly against both the mixed architecture-screen grouped-token row and the warmup-decay probe result.
+  - Treat this as the benchmark-facing canonical replay for later row-first rows, not as a reopened tokenizer adequacy screen.
+- Adequacy knobs to dimension explicitly:
+  - schedule.stages[0].lr_max
+  - optimizer.min_lr
+  - schedule.stages[0].warmup_ratio
+- Execution policy: `benchmark_full`
+- Interpretation status: `completed`
+- Decision: `keep`
+- Notes:
+  - Canonical rerun registered as `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`.
+  - Registered the benchmark-facing grouped-token warmup-decay replay; TF-RD-005, TF-RD-006, and TF-RD-007 should anchor on this run.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/result_card.md`
+- Registered run: `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` with final log loss `0.4002`, delta final log loss `-0.2536`, final Brier score `0.2618`, delta final Brier score `-0.1992`, best ROC AUC `0.7413`, final ROC AUC `0.7413`, final-minus-best `+0.0000`, delta final ROC AUC `+0.1934`, delta drift `+0.0000`, delta final training time `+342.7s`

--- a/reference/system_delta_sweeps/tokenization_migration_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tokenization_migration_v1/queue.yaml
@@ -73,3 +73,107 @@ rows:
     column_activation_final_window_mean: 0.9297528803925204
     row_activation_early_to_final_mean_delta: -0.044995769230150584
     row_activation_final_window_mean: 1.0675786989251688
+- order: 2
+  delta_ref: delta_training_linear_warmup_decay
+  parent_delta_ref: delta_architecture_screen_grouped_tokens
+  status: completed
+  rationale: Replay the grouped-token row on the benchmark-facing architecture-screen
+    lane with the no-trace warmup-decay training contract selected by the grouped-token
+    adequacy probe.
+  hypothesis: The benchmark-facing grouped-token replay should recover the probe's
+    stable warmup-decay quality while keeping the architecture-screen lane, making
+    the grouped-token handoff canonical for TF-RD-005, TF-RD-006, and TF-RD-007.
+  anchor_delta: Keep the stage-native grouped-token model, data, and preprocessing
+    surfaces fixed on `cls_benchmark_staged`, then replace `training_default` with
+    the preferred no-trace `prior_linear_warmup_decay` contract selected by `grouped_token_stability_probe_v1`.
+  model:
+    stage: grouped_tokens
+    stage_label: delta_architecture_screen_grouped_tokens
+    module_overrides:
+      allow_test_self_attention: true
+      column_encoder: none
+      context_encoder: none
+      feature_encoder: shared
+      head: small_class
+      post_encoder_norm: none
+      post_stack_norm: none
+      row_pool: target_column
+      table_block_residual_scale: none
+      table_block_style: prenorm
+      target_conditioner: label_token
+      tokenizer: shifted_grouped
+  data:
+    surface_label: anchor_manifest_default
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+    prior_dump_non_finite_policy: skip
+    overrides:
+      apply_schedule: true
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      runtime:
+        max_steps: 2500
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Compare directly against both the mixed architecture-screen grouped-token row
+    and the warmup-decay probe result.
+  - Treat this as the benchmark-facing canonical replay for later row-first rows,
+    not as a reopened tokenizer adequacy screen.
+  run_id: sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1
+  followup_run_ids: []
+  decision: keep
+  interpretation_status: completed
+  confounders: []
+  next_action: Use `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    as the canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and TF-RD-007;
+    do not reopen the tokenization handoff unless a later benchmark-facing replay
+    supersedes it.
+  notes:
+  - Canonical rerun registered as `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`.
+  - Registered the benchmark-facing grouped-token warmup-decay replay; TF-RD-005,
+    TF-RD-006, and TF-RD-007 should anchor on this run.
+  benchmark_metrics:
+    best_step: 2500
+    max_grad_norm: 1.2678042650222778
+    clipped_step_fraction: 0.0012
+    best_log_loss: 0.40016941460067895
+    nanotabpfn_best_log_loss: 0.44081483626958085
+    final_log_loss: 0.40016941460067895
+    nanotabpfn_final_log_loss: 0.44079963988830684
+    best_brier_score: 0.26181315535215954
+    nanotabpfn_best_brier_score: 0.2858710473067903
+    final_brier_score: 0.26181315535215954
+    nanotabpfn_final_brier_score: 0.28493892770426144
+    best_roc_auc: 0.7413025086332128
+    nanotabpfn_best_roc_auc: 0.7579204425720094
+    final_roc_auc: 0.7413025086332128
+    nanotabpfn_final_roc_auc: 0.7613018118078175
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    nanotabpfn_best: 0.7579204425720094
+    nanotabpfn_final: 0.7613018118078175
+    delta_final_log_loss: -0.25362312228371225
+    delta_final_brier_score: -0.1991826880829362
+    delta_final_roc_auc: 0.1933786207537188
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.0

--- a/reference/system_delta_sweeps/tokenization_migration_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tokenization_migration_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
 sweep_id: tokenization_migration_v1
 parent_sweep_id: shared_surface_bridge_v1
-status: draft
+status: completed
 complexity_level: binary_md
 anchor_run_id: sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1
 benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
@@ -29,8 +29,11 @@ anchor_surface:
     were not selected as the canonical grouped-token predecessor on the shared-surface
     bridge.
   - >-
-    If the grouped-token benchmark row registers successfully, follow immediately
-    with the bounded hybrid-diagnostic stability probe `grouped_token_stability_probe_v1`.
+    `grouped_token_stability_probe_v1` resolved the grouped-token adequacy question
+    in favor of the no-trace `prior_linear_warmup_decay` contract, and benchmark-facing
+    replay `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
+    is now the canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and
+    TF-RD-007.
   dimension_table:
   - dimension: feature encoder
     upstream: Scalar feature linear encoder with internal train/test z-score+clip

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -9529,6 +9529,195 @@
         "train_elapsed_seconds": 81.62507329627988,
         "wall_elapsed_seconds": 85.26196875001187
       }
+    },
+    "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/train/checkpoints/step_002500.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.1933786207537188,
+          "best_training_time_delta": 342.69477453868603,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.1991826880829362,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.25362312228371225,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.1933786207537188,
+          "final_training_time_delta": 342.69477453868603,
+          "reference_run_id": "sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.21835785081655945,
+          "best_training_time_delta": 340.3222872795304,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": -0.18329155725923213,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.23700765066821233,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.21835785081655945,
+          "final_training_time_delta": 340.3222872795304,
+          "reference_run_id": "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2"
+        }
+      },
+      "conclusion": "Registered the benchmark-facing grouped-token warmup-decay replay; TF-RD-005, TF-RD-006, and TF-RD-007 should anchor on this run.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "keep",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2"
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_architecture_screen_grouped_tokens",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": null,
+            "ff_expansion": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null,
+            "use_qass": null
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": null,
+            "n_heads": null,
+            "n_layers": null,
+            "name": "target_column",
+            "norm_type": null
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "none",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "target_column",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "shifted_grouped"
+        },
+        "stage": "grouped_tokens",
+        "stage_label": "delta_architecture_screen_grouped_tokens",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 356258,
+        "trainable_params": 356258
+      },
+      "registered_at_utc": "2026-03-20T06:38:23Z",
+      "run_id": "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "anchor_manifest_default",
+        "model": "delta_architecture_screen_grouped_tokens",
+        "preprocessing": "runtime_default",
+        "training": "prior_linear_warmup_decay"
+      },
+      "sweep": {
+        "delta_id": "delta_training_linear_warmup_decay",
+        "parent_sweep_id": "shared_surface_bridge_v1",
+        "queue_order": 2,
+        "run_kind": "primary",
+        "sweep_id": "tokenization_migration_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.26181315535215954,
+        "best_crps": null,
+        "best_log_loss": 0.40016941460067895,
+        "best_picp_90": null,
+        "best_roc_auc": 0.7413025086332128,
+        "best_step": 2500.0,
+        "best_training_time": 421.9473605758103,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.26181315535215954,
+        "final_crps": null,
+        "final_log_loss": 0.40016941460067895,
+        "final_picp_90": null,
+        "final_roc_auc": 0.7413025086332128,
+        "final_step": 2500.0,
+        "final_training_time": 421.9473605758103
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.2333899289369583,
+        "final_val_loss": null,
+        "max_grad_norm": 1.2678042650222778,
+        "mean_grad_norm": 0.1965236706867814,
+        "post_warmup_train_loss_var": 0.0017719368785092202,
+        "train_elapsed_seconds": 421.9473605758103,
+        "wall_elapsed_seconds": 431.8746543750167
+      }
     }
   },
   "schema": "tab-foundry-benchmark-runs-v1",

--- a/tests/research/test_grouped_token_stability_probe_v1.py
+++ b/tests/research/test_grouped_token_stability_probe_v1.py
@@ -54,7 +54,7 @@ def test_grouped_token_stability_probe_v1_is_registered_but_not_active() -> None
     assert isinstance(sweeps, dict)
     assert sweeps[SWEEP_ID] == {
         "parent_sweep_id": "tokenization_migration_v1",
-        "status": "draft",
+        "status": "completed",
         "anchor_run_id": ANCHOR_RUN_ID,
         "complexity_level": "binary_md",
         "benchmark_bundle_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
@@ -69,7 +69,7 @@ def test_grouped_token_stability_probe_v1_metadata_and_rows_match_the_grouped_to
 
     assert sweep["sweep_id"] == SWEEP_ID
     assert sweep["parent_sweep_id"] == "tokenization_migration_v1"
-    assert sweep["status"] == "draft"
+    assert sweep["status"] == "completed"
     assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
     assert sweep["training_experiment"] == "cls_benchmark_staged_prior"
     assert sweep["training_config_profile"] == "cls_benchmark_staged_prior"
@@ -86,7 +86,11 @@ def test_grouped_token_stability_probe_v1_metadata_and_rows_match_the_grouped_to
         "training": "training_default",
     }
     assert any("bounded hybrid-diagnostic probe" in note for note in sweep["anchor_surface"]["notes"])
-    assert any("TF-RD-005, TF-RD-006, and TF-RD-007 remain blocked" in note for note in sweep["anchor_surface"]["notes"])
+    assert any(
+        "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1"
+        in note
+        for note in sweep["anchor_surface"]["notes"]
+    )
 
     rows = queue["rows"]
     assert isinstance(rows, list)
@@ -151,9 +155,14 @@ def test_grouped_token_stability_probe_v1_metadata_and_rows_match_the_grouped_to
         }
     ]
     assert "grouped-token model" in warmup_row["anchor_delta"]
-    assert "benchmark-facing grouped-token replay" in warmup_row["next_action"]
+    assert "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1" in warmup_row["next_action"]
     assert warmup_row["decision"] == "keep"
     assert any("preferred grouped-token adequacy surface" in note for note in warmup_row["notes"])
+    assert any(
+        "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1"
+        in note
+        for note in warmup_row["notes"]
+    )
 
     materialized = load_system_delta_queue(
         sweep_id=SWEEP_ID,
@@ -204,3 +213,4 @@ def test_grouped_token_stability_probe_v1_matrix_records_the_grouped_token_probe
     assert "Shifted grouped tokenizer" in matrix
     assert "warmup-decay grouped-token surface" in matrix
     assert "preferred grouped-token adequacy surface" in matrix
+    assert "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1" in matrix

--- a/tests/research/test_tokenization_migration_v1.py
+++ b/tests/research/test_tokenization_migration_v1.py
@@ -6,13 +6,32 @@ from typing import Any
 from omegaconf import OmegaConf
 
 from tab_foundry.research.system_delta import load_system_delta_queue
+from tab_foundry.research.system_delta_execute import _compose_cfg
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ANCHOR_RUN_ID = "sd_shared_surface_bridge_v1_03_delta_architecture_screen_prenorm_block_v1"
-EXPECTED_ROWS = ["delta_architecture_screen_grouped_tokens"]
+EXPECTED_ROWS = [
+    "delta_architecture_screen_grouped_tokens",
+    "delta_training_linear_warmup_decay",
+]
 HISTORICAL_RUN_ID = "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v1"
-RUN_ID = "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2"
+GROUPED_RUN_ID = "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v2"
+REPLAY_RUN_ID = "sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1"
+EXPECTED_MODULE_OVERRIDES = {
+    "allow_test_self_attention": True,
+    "column_encoder": "none",
+    "context_encoder": "none",
+    "feature_encoder": "shared",
+    "head": "small_class",
+    "post_encoder_norm": "none",
+    "post_stack_norm": "none",
+    "row_pool": "target_column",
+    "table_block_residual_scale": "none",
+    "table_block_style": "prenorm",
+    "target_conditioner": "label_token",
+    "tokenizer": "shifted_grouped",
+}
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -36,7 +55,7 @@ def test_tokenization_migration_v1_is_registered_but_not_active() -> None:
     assert isinstance(sweeps, dict)
     assert sweeps["tokenization_migration_v1"] == {
         "parent_sweep_id": "shared_surface_bridge_v1",
-        "status": "draft",
+        "status": "completed",
         "anchor_run_id": ANCHOR_RUN_ID,
         "complexity_level": "binary_md",
         "benchmark_bundle_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
@@ -51,7 +70,7 @@ def test_tokenization_migration_v1_metadata_and_rows_match_the_grouped_token_pla
 
     assert sweep["sweep_id"] == "tokenization_migration_v1"
     assert sweep["parent_sweep_id"] == "shared_surface_bridge_v1"
-    assert sweep["status"] == "draft"
+    assert sweep["status"] == "completed"
     assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
     assert sweep["training_experiment"] == "cls_benchmark_staged"
     assert sweep["training_config_profile"] == "cls_benchmark_staged"
@@ -66,8 +85,8 @@ def test_tokenization_migration_v1_metadata_and_rows_match_the_grouped_token_pla
     rows = queue["rows"]
     assert isinstance(rows, list)
     assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
-    assert [row["status"] for row in rows] == ["completed"]
-    assert [row["interpretation_status"] for row in rows] == ["completed"]
+    assert [row["status"] for row in rows] == ["completed", "completed"]
+    assert [row["interpretation_status"] for row in rows] == ["completed", "completed"]
 
     grouped_row = _row_by_ref(queue, "delta_architecture_screen_grouped_tokens")
     assert grouped_row["model"] == {
@@ -80,13 +99,59 @@ def test_tokenization_migration_v1_metadata_and_rows_match_the_grouped_token_pla
         "surface_label": "training_default",
         "overrides": {},
     }
-    assert grouped_row["run_id"] == RUN_ID
+    assert grouped_row["run_id"] == GROUPED_RUN_ID
     assert "locked `prenorm_block` bridge row" in grouped_row["anchor_delta"]
     assert "grouped_token_stability_probe_v1" in grouped_row["next_action"]
     assert grouped_row["decision"] == "defer"
     assert grouped_row["benchmark_metrics"]["best_step"] == 400
     assert grouped_row["notes"][0] == f"Canonical rerun registered as `{HISTORICAL_RUN_ID}`."
-    assert grouped_row["notes"][-1] == f"Canonical rerun registered as `{RUN_ID}`."
+    assert grouped_row["notes"][-1] == f"Canonical rerun registered as `{GROUPED_RUN_ID}`."
+
+    replay_row = _row_by_ref(queue, "delta_training_linear_warmup_decay")
+    assert replay_row["model"] == {
+        "stage": "grouped_tokens",
+        "stage_label": "delta_architecture_screen_grouped_tokens",
+        "module_overrides": EXPECTED_MODULE_OVERRIDES,
+    }
+    assert replay_row["data"] == {"surface_label": "anchor_manifest_default"}
+    assert replay_row["preprocessing"] == {"surface_label": "runtime_default"}
+    assert replay_row["training"] == {
+        "surface_label": "prior_linear_warmup_decay",
+        "prior_dump_non_finite_policy": "skip",
+        "overrides": {
+            "apply_schedule": True,
+            "optimizer": {
+                "name": "schedulefree_adamw",
+                "require_requested": True,
+                "weight_decay": 0.0,
+                "betas": [0.9, 0.999],
+                "min_lr": 0.0004,
+                "muon_per_parameter_lr": False,
+            },
+            "runtime": {
+                "max_steps": 2500,
+                "eval_every": 25,
+                "checkpoint_every": 25,
+                "trace_activations": False,
+            },
+            "schedule": {
+                "stages": [
+                    {
+                        "name": "stage1",
+                        "steps": 2500,
+                        "lr_max": 0.004,
+                        "lr_schedule": "linear",
+                        "warmup_ratio": 0.05,
+                    }
+                ]
+            },
+        },
+    }
+    assert replay_row["run_id"] == REPLAY_RUN_ID
+    assert replay_row["decision"] == "keep"
+    assert REPLAY_RUN_ID in replay_row["next_action"]
+    assert any(note == f"Canonical rerun registered as `{REPLAY_RUN_ID}`." for note in replay_row["notes"])
+    assert any("benchmark-facing grouped-token warmup-decay replay" in note for note in replay_row["notes"])
 
     materialized = load_system_delta_queue(
         sweep_id="tokenization_migration_v1",
@@ -111,6 +176,44 @@ def test_tokenization_migration_v1_matrix_records_the_grouped_token_handoff_row(
     assert "Training experiment: `cls_benchmark_staged`" in matrix
     assert "Surface role: `architecture_screen`" in matrix
     assert "delta_architecture_screen_grouped_tokens" in matrix
+    assert "delta_training_linear_warmup_decay" in matrix
     assert "grouped_tokens" in matrix
-    assert "grouped_token_stability_probe_v1" in matrix
+    assert REPLAY_RUN_ID in matrix
+    assert "canonical grouped-token predecessor for TF-RD-005, TF-RD-006, and TF-RD-007" in matrix
     assert "first stage-native tokenizer change on the shared-surface handoff" in matrix
+
+
+def test_tokenization_migration_v1_compose_cfg_resolves_architecture_screen_warmup_decay_replay(
+    tmp_path: Path,
+) -> None:
+    queue = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "tokenization_migration_v1" / "queue.yaml")
+    replay_row = _row_by_ref(queue, "delta_training_linear_warmup_decay")
+
+    cfg = _compose_cfg(
+        row=replay_row,
+        run_dir=tmp_path / "train",
+        device="cpu",
+        training_experiment="cls_benchmark_staged",
+    )
+
+    assert str(cfg.model.stage) == "grouped_tokens"
+    assert str(cfg.model.stage_label) == "delta_architecture_screen_grouped_tokens"
+    assert OmegaConf.to_container(cfg.model.module_overrides, resolve=True) == EXPECTED_MODULE_OVERRIDES
+    assert str(cfg.training.surface_label) == "prior_linear_warmup_decay"
+    assert str(cfg.training.prior_dump_non_finite_policy) == "skip"
+    assert bool(cfg.training.apply_schedule) is True
+    assert str(cfg.optimizer.name) == "schedulefree_adamw"
+    assert float(cfg.optimizer.min_lr) == 0.0004
+    assert int(cfg.runtime.max_steps) == 2500
+    assert int(cfg.runtime.eval_every) == 25
+    assert int(cfg.runtime.checkpoint_every) == 25
+    assert bool(cfg.runtime.trace_activations) is False
+    assert OmegaConf.to_container(cfg.schedule.stages, resolve=True) == [
+        {
+            "name": "stage1",
+            "steps": 2500,
+            "lr_max": 0.004,
+            "lr_schedule": "linear",
+            "warmup_ratio": 0.05,
+        }
+    ]


### PR DESCRIPTION
Closes #93

## Summary
- add the benchmark-facing `delta_training_linear_warmup_decay` replay row to `tokenization_migration_v1`
- register `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1` as the canonical grouped-token predecessor for TF-RD-005/006/007
- mark `tokenization_migration_v1` and `grouped_token_stability_probe_v1` completed and update the roadmap/tracker prose
- update registry and rendered matrices to reflect the landed replay

## Replay
- run id: `sd_tokenization_migration_v1_02_delta_training_linear_warmup_decay_v1`
- final log loss: `0.4002`
- final Brier: `0.2618`
- final ROC AUC: `0.7413`

## Verification
- `.venv/bin/python -m pytest tests/research/test_tokenization_migration_v1.py tests/research/test_grouped_token_stability_probe_v1.py tests/research/test_system_delta.py tests/research/test_system_delta_execute.py`
- `.venv/bin/python -m tab_foundry research sweep render --sweep-id tokenization_migration_v1`
- `.venv/bin/python -m tab_foundry research sweep validate --sweep-id tokenization_migration_v1`
- `.venv/bin/python -m tab_foundry research sweep render --sweep-id grouped_token_stability_probe_v1`
- `.venv/bin/python -m tab_foundry research sweep validate --sweep-id grouped_token_stability_probe_v1`
- `./scripts/dev verify paths reference tests src/tab_foundry configs`

## Artifact pointers
- matrix: `reference/system_delta_sweeps/tokenization_migration_v1/matrix.md`
- registry entry: `src/tab_foundry/bench/benchmark_run_registry_v1.json`
- local result card: `outputs/staged_ladder/research/tokenization_migration_v1/delta_training_linear_warmup_decay/result_card.md`