### PR TITLE
Add TF-RD-013 data source contract sweep definitions

### DIFF
--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -2247,6 +2247,42 @@ deltas:
     default_next_action: Run only after the matrix explicitly records the anchor-versus-iris manifest characteristics.
     applicability_guards: []
 
+  delta_data_manifest_curated_realdata_comparator:
+    dimension_family: data
+    family: source
+    binary_applicable: true
+    description: Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations.
+    upstream_delta: Not applicable; this is a repo-local comparator contract layered on top of the benchmark-native OpenML baseline.
+    expected_effect: A real-data comparator lane that is explicit enough to compare against current-corpus and dagzoo candidates without reopening loader boundaries.
+    adequacy_knobs:
+      - Approved ledger rows for every dataset referenced by the comparator manifest family.
+      - OpenML baseline versus approved external augmentation coverage notes.
+      - Manifest lineage and regime-coverage notes attached before any benchmark read is interpreted.
+    parameter_adequacy_policy:
+      default_plan:
+        - Keep the OpenML baseline canonical and treat manifest-backed external datasets as approved augmentations rather than a replacement path.
+        - Do not schedule the comparator until the referenced datasets are approved in the review ledger and the manifest lineage is attached.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_artifacts
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model:
+        stage_label: anchor_model
+      data:
+        surface_label: tf_rd_013_curated_realdata_comparator
+        surface_overrides:
+          source: manifest
+          manifest_path: outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Materialize the approved OpenML-baseline comparator manifest and cite any approved external augmentations before scheduling this row.
+    applicability_guards: []
+
   delta_preproc_impute_missing_off:
     dimension_family: preprocessing
     family: missing_values

--- a/reference/system_delta_sweeps/binary_md_v1/matrix.md
+++ b/reference/system_delta_sweeps/binary_md_v1/matrix.md
@@ -5,7 +5,7 @@ This file is rendered from `reference/system_delta_sweeps/binary_md_v1/queue.yam
 ## Sweep
 
 - Sweep id: `binary_md_v1`
-- Sweep status: `active`
+- Sweep status: `completed`
 - Parent sweep id: `None`
 - Complexity level: `binary_md`
 
@@ -14,6 +14,9 @@ This file is rendered from `reference/system_delta_sweeps/binary_md_v1/queue.yam
 - Anchor run id: `01_nano_exact_md_prior_parity_fix_binary_medium_v1`
 - Benchmark bundle: `src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json`
 - Control baseline id: `cls_benchmark_linear_v2`
+- Training experiment: `cls_benchmark_staged_prior`
+- Training config profile: `cls_benchmark_staged_prior`
+- Surface role: `hybrid_diagnostic`
 - Comparison policy: `anchor_only`
 - Anchor metrics: best ROC AUC `0.7615`, final ROC AUC `0.7599`, final training time `355.6s`
 
@@ -50,7 +53,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 | 11 | `delta_training_linear_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but replace the exact-prior constant LR with single-stage linear decay. | Keep this as completed negative evidence for plain linear decay on the anchor surface, then move to delta_training_linear_warmup_decay to separate warmup from decay itself. |
 | 12 | `delta_training_linear_warmup_decay` | schedule | yes | completed | none | Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup. | Keep this as completed evidence that warmup partly improves the decay recipe but still does not justify replacing the constant-LR anchor, then move to delta_data_manifest_source_binary_iris. |
 | 13 | `delta_data_filter_policy_accepted_only` | provenance | yes | blocked_on_artifacts | none | Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor. | Materialize the accepted-only manifest and attach its provenance before scheduling training. |
-| 14 | `delta_data_manifest_root_curated_dagzoo` | provenance | yes | blocked_on_artifacts | none | Point training at a curated dagzoo manifest root with explicit dagzoo command provenance. | Capture the dagzoo generation/filter lineage first. |
+| 14 | `delta_data_manifest_root_curated_dagzoo` | provenance | yes | superseded | none | Point training at a curated dagzoo manifest root with explicit dagzoo command provenance. | Do not run on `binary_md_v1`; use `tf_rd_013_data_source_contract_v1` as the promoted-anchor TF-RD-013 contract surface instead. |
 | 15 | `delta_data_manifest_source_binary_iris` | source | yes | ready | none | Swap the training manifest to the small binary iris support surface while keeping the model and preprocessing anchored. | Run only after the matrix explicitly records the anchor-versus-iris manifest characteristics. |
 | 16 | `delta_preproc_impute_missing_off` | missing_values | yes | deferred_separate_workstream | none | Disable runtime mean imputation while keeping the fitted label-remap path intact. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
 | 17 | `delta_preproc_all_nan_fill_nonzero` | missing_values | yes | deferred_separate_workstream | none | Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0. | Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs. |
@@ -78,6 +81,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Adequacy knobs to dimension explicitly:
   - many_class_base should stay at 2 on the locked binary surface.
   - Negative evidence should be checked for calibration drift before rejection.
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -104,7 +108,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Upstream delta: Upstream nanoTabPFN keeps its own internal feature normalization/encoding path.
 - Anchor delta: Changes only feature_encoder from nano to shared; tokenizer, target conditioning, table block, row pooling, data, and preprocessing remain fixed.
 - Expected effect: Better transfer across heterogeneous columns, with risk that the shared path simply mismatches the compact binary anchor scale.
-- Effective labels: model=`delta_shared_feature_norm`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`prior_constant_lr`
+- Effective labels: model=`delta_shared_feature_norm`, data=`anchor_manifest_default`, preprocessing=`runtime_default`, training=`prior_constant_lr_trace_activations`
 - Model overrides: `{'module_overrides': {'feature_encoder': 'shared'}}`
 - Parameter adequacy plan:
   - Keep optimizer and row/context structure fixed for the first pass.
@@ -112,6 +116,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Adequacy knobs to dimension explicitly:
   - input_normalization remains train_zscore_clip on the anchor unless the queue row explicitly changes preprocessing.
   - If performance drops, note whether the harm appears early or only after longer training.
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -146,6 +151,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Adequacy knobs to dimension explicitly:
   - The relevant knobs are still tficl_n_heads, tficl_n_layers, and head_hidden_dim.
   - A weak result is ambiguous unless late-curve stability clearly worsens despite similar best-step performance.
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -178,6 +184,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Compare directly against both the anchor and the pre-norm-only row in the written interpretation.
 - Adequacy knobs to dimension explicitly:
   - Interpretation depends on the paired pre-norm-only result; a weak result may just indicate the block style itself remains unsettled.
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -211,6 +218,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Do not run while tokenizer changes are bypassed by the active feature encoder.
 - Adequacy knobs to dimension explicitly:
   - Revisit only after the comparison surface switches to a non-nano feature encoder.
+- Execution policy: `benchmark_full`
 - Interpretation status: `blocked`
 - Decision: `None`
 - Confounders:
@@ -241,6 +249,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - tfrow_n_heads
   - tfrow_n_layers
   - tfrow_cls_tokens
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -279,6 +288,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - tfrow_n_heads
   - tfrow_n_layers
   - tfrow_cls_tokens
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -314,6 +324,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - tfcol_n_heads
   - tfcol_n_layers
   - tfcol_n_inducing
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -349,6 +360,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - tficl_n_heads
   - tficl_n_layers
   - tficl_ff_expansion
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -384,6 +396,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Adequacy knobs to dimension explicitly:
   - model.norm_type
   - model.tfrow_norm
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -420,6 +433,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - schedule.stages[0].lr_max
   - optimizer.min_lr
   - schedule.stages[0].warmup_ratio
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -456,6 +470,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - schedule.stages[0].lr_max
   - optimizer.min_lr
   - schedule.stages[0].warmup_ratio
+- Execution policy: `benchmark_full`
 - Interpretation status: `interpreted`
 - Decision: `defer`
 - Confounders:
@@ -490,6 +505,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - If weaker, discuss whether coverage loss or provenance tightening is the likely cause.
 - Adequacy knobs to dimension explicitly:
   - Must report dataset-count and feature/class distribution shifts versus the anchor manifest.
+- Execution policy: `benchmark_full`
 - Interpretation status: `pending`
 - Decision: `None`
 - Confounders:
@@ -501,7 +517,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 ### 14. `delta_data_manifest_root_curated_dagzoo`
 
 - Dimension family: `data`
-- Status: `blocked_on_artifacts`
+- Status: `superseded`
 - Binary applicable: `True`
 - Recipe alias: `none`
 - Description: Point training at a curated dagzoo manifest root with explicit dagzoo command provenance.
@@ -518,10 +534,13 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - dagzoo generate/filter commands
   - curated root lineage
   - dataset count and split distribution deltas
-- Interpretation status: `pending`
-- Decision: `None`
+- Execution policy: `benchmark_full`
+- Interpretation status: `blocked`
+- Decision: `defer`
 - Confounders:
   - Requires a materialized curated dagzoo manifest and provenance references.
+- Notes:
+  - This row is historical precursor evidence only and no longer defines the active dagzoo closure path.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/binary_md_v1/delta_data_manifest_root_curated_dagzoo/result_card.md`
 - Benchmark metrics: pending
@@ -544,6 +563,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Treat any weakness primarily as evidence about training-surface coverage unless metrics collapse unambiguously.
 - Adequacy knobs to dimension explicitly:
   - Compare manifest row/feature/class distributions to the anchor before training.
+- Execution policy: `benchmark_full`
 - Interpretation status: `pending`
 - Decision: `None`
 - Confounders:
@@ -570,6 +590,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - If the result is weak, note whether the benchmark tasks actually contain meaningful missingness on the support side.
 - Adequacy knobs to dimension explicitly:
   - Interpret against manifest missingness prevalence where available.
+- Execution policy: `benchmark_full`
 - Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
@@ -594,6 +615,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Interpret near-zero movement as expected if the surface rarely exercises this branch.
 - Adequacy knobs to dimension explicitly:
   - Report whether all-NaN columns are actually present in the compared manifests.
+- Execution policy: `benchmark_full`
 - Interpretation status: `blocked`
 - Decision: `None`
 - Follow-up run ids: `[]`
@@ -618,6 +640,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - Do not run until a real alternative policy exists.
 - Adequacy knobs to dimension explicitly:
   - Must record how unseen test labels are handled and whether the effective task definition changes.
+- Execution policy: `benchmark_full`
 - Interpretation status: `blocked`
 - Decision: `None`
 - Confounders:

--- a/reference/system_delta_sweeps/binary_md_v1/queue.yaml
+++ b/reference/system_delta_sweeps/binary_md_v1/queue.yaml
@@ -431,7 +431,7 @@ rows:
 
   - order: 14
     delta_ref: delta_data_manifest_root_curated_dagzoo
-    status: blocked_on_artifacts
+    status: superseded
     rationale: The queue must be able to compare not only model structure but also the exact dagzoo call set that defined the training corpus.
     hypothesis: A more curated dagzoo root may improve signal quality, but any change must be interpreted through manifest lineage and dataset-characteristic shifts.
     anchor_delta: Changes only the manifest root and its documented dagzoo provenance.
@@ -452,12 +452,13 @@ rows:
       - Do not run until the dagzoo provenance payload is filled in and the manifest characteristics are attached.
     run_id: null
     followup_run_ids: []
-    decision: null
-    interpretation_status: pending
+    decision: defer
+    interpretation_status: blocked
     confounders:
       - Requires a materialized curated dagzoo manifest and provenance references.
-    next_action: Capture the dagzoo generation/filter lineage first.
-    notes: []
+    next_action: Do not run on `binary_md_v1`; use `tf_rd_013_data_source_contract_v1` as the promoted-anchor TF-RD-013 contract surface instead.
+    notes:
+      - This row is historical precursor evidence only and no longer defines the active dagzoo closure path.
 
   - order: 15
     delta_ref: delta_data_manifest_source_binary_iris

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -148,6 +148,13 @@ sweeps:
     complexity_level: binary_md
     benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
     control_baseline_id: cls_benchmark_linear_v2
+  tf_rd_013_data_source_contract_v1:
+    parent_sweep_id: qass_tfcol_large_missing_validation_v1
+    status: draft
+    anchor_run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+    complexity_level: binary_md
+    benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
+    control_baseline_id: cls_benchmark_linear_v2
   row_first_training_adequacy_v1:
     parent_sweep_id: qass_tfcol_large_missing_validation_v1
     status: draft

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/matrix.md
@@ -1,0 +1,137 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/queue.yaml` plus `reference/system_delta_catalog.yaml` and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_013_data_source_contract_v1`
+- Sweep status: `draft`
+- Parent sweep id: `qass_tfcol_large_missing_validation_v1`
+- Complexity level: `binary_md`
+
+## Locked Surface
+
+- Anchor run id: `sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1`
+- Benchmark bundle: `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`
+- Control baseline id: `cls_benchmark_linear_v2`
+- Training experiment: `cls_benchmark_staged`
+- Training config profile: `cls_benchmark_staged`
+- Surface role: `architecture_screen`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final log loss `0.4215`, final Brier score `0.2644`, best ROC AUC `0.6702`, final ROC AUC `0.6702`, final training time `2550.1s`
+
+## Anchor Comparison
+
+Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob/main/model.py`.
+
+| Dimension | Upstream nanoTabPFN | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+| model anchor | Upstream nanoTabPFN has no repo-local row-first promoted-anchor contract. | The settled promoted row-first benchmark anchor `row_cls + qass + no tfcol`. | TF-RD-013 changes only the training-data comparison surface, not the promoted model surface. |
+| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Current manifest-backed prior-training corpus with data surface label `anchor_manifest_default`. | The current corpus is the baseline comparator; TF-RD-013 rows define explicit dagzoo and curated real-data alternatives against it. |
+| dagzoo provenance contract | Not applicable. | No dagzoo provenance is attached to the current-corpus anchor surface. | Dagzoo candidate rows must carry one explicit `dagzoo_provenance` payload with fixed keys before the sweep becomes runnable. |
+| real-data comparator policy | Not applicable. | Benchmark bundle `nanotabpfn_openml_binary_large` remains the benchmark-facing evaluation surface. | Curated real-data ladders are comparator evidence and must keep one OpenML baseline plus approved manifest-backed augmentations rather than introducing a new loader path. |
+| training recipe | No repo-local prior-dump training-surface contract. | Training surface label `prior_linear_warmup_decay`. | TF-RD-013 contract work should not mix optimizer or schedule changes into the data-source decision. |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_data_filter_policy_accepted_only` | provenance | yes | blocked_on_artifacts | none | Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor. | Materialize the accepted-only manifest and fill the dagzoo command lineage under issue 120 before scheduling any comparison run. |
+| 2 | `delta_data_manifest_root_curated_dagzoo` | provenance | yes | blocked_on_artifacts | none | Point training at a curated dagzoo manifest root with explicit dagzoo command provenance. | Materialize the curated dagzoo root lineage and support artifacts under issue 120, then wire the promoted-anchor comparison row under issue 121. |
+| 3 | `delta_data_manifest_curated_realdata_comparator` | source | yes | blocked_on_artifacts | none | Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations. | Materialize the approved OpenML-baseline comparator manifest and cite any approved manifest-backed augmentations before scheduling this row. |
+
+## Detailed Rows
+
+### 1. `delta_data_filter_policy_accepted_only`
+
+- Dimension family: `data`
+- Status: `blocked_on_artifacts`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor.
+- Rationale: Define the first canonical dagzoo candidate surface by tightening filtering while keeping the promoted row-first anchor otherwise fixed.
+- Hypothesis: An accepted-only dagzoo candidate may improve signal quality, but its value is only interpretable once manifest lineage and corpus-shape deltas are explicit.
+- Upstream delta: Not applicable; this is a repo-local manifest/provenance decision.
+- Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but replace the current corpus with a TF-RD-013 accepted-only dagzoo candidate manifest that carries the canonical dagzoo provenance payload.
+- Expected effect: Cleaner data quality with a possible diversity-versus-quality tradeoff.
+- Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_accepted_only`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Data overrides: `{'source': 'manifest', 'manifest_path': 'outputs/staged_ladder_support/tf_rd_013/dagzoo_accepted_only/manifest.parquet', 'filter_policy': 'accepted_only', 'dagzoo_provenance': {'corpus_variant': 'dagzoo_accepted_only', 'comparator_role': 'promoted_anchor_candidate', 'commands': [], 'config_refs': ['configs/default.yaml'], 'curated_root_lineage': [], 'materialization_issue': 120}}`
+- Parameter adequacy plan:
+  - Compare manifest characteristics against the current-corpus anchor before reading any benchmark outcome.
+  - Treat the empty `commands` list as a contract placeholder only; issue 120 is responsible for filling the actual command lineage.
+- Adequacy knobs to dimension explicitly:
+  - Must report dataset-count and feature/class distribution shifts versus the anchor manifest.
+- Execution policy: `benchmark_full`
+- Interpretation status: `pending`
+- Decision: `None`
+- Confounders:
+  - This row is contract-only until the accepted-only manifest and lineage are materialized.
+- Notes:
+  - This row defines the canonical top-level dagzoo provenance keys expected on TF-RD-013 promoted-anchor comparison surfaces.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_filter_policy_accepted_only/result_card.md`
+- Benchmark metrics: pending
+
+### 2. `delta_data_manifest_root_curated_dagzoo`
+
+- Dimension family: `data`
+- Status: `blocked_on_artifacts`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Point training at a curated dagzoo manifest root with explicit dagzoo command provenance.
+- Rationale: Define the promoted-anchor curated dagzoo root as a second canonical dagzoo candidate surface rather than leaving it as an old binary-md precursor row.
+- Hypothesis: A curated dagzoo root may better match intended post-008 use than the current corpus, but it must be read through explicit lineage from the accepted-only candidate rather than as an opaque manifest swap.
+- Upstream delta: Not applicable; this is a repo-local dataset-generation axis.
+- Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but point training at the curated dagzoo root contract while preserving the same canonical dagzoo provenance payload shape.
+- Expected effect: Potentially cleaner training data with a materially different corpus composition.
+- Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_curated_dagzoo_root`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Data overrides: `{'source': 'manifest', 'manifest_path': 'outputs/staged_ladder_support/tf_rd_013/curated_dagzoo/manifest.parquet', 'dagzoo_provenance': {'corpus_variant': 'dagzoo_curated_root', 'comparator_role': 'promoted_anchor_candidate', 'commands': [], 'config_refs': ['configs/default.yaml'], 'curated_root_lineage': ['dagzoo_accepted_only', 'curated_root_selection'], 'materialization_issue': 120}}`
+- Parameter adequacy plan:
+  - Compare this row first against the accepted-only dagzoo candidate, then against the current-corpus anchor.
+  - Treat `curated_root_lineage` as required contract metadata, not as optional commentary.
+- Adequacy knobs to dimension explicitly:
+  - dagzoo generate/filter commands
+  - curated root lineage
+  - dataset count and split distribution deltas
+- Execution policy: `benchmark_full`
+- Interpretation status: `pending`
+- Decision: `None`
+- Confounders:
+  - This row remains a contract placeholder until issue 120 materializes the curated root manifest and lineage.
+- Notes:
+  - This row supersedes the old `binary_md_v1` `delta_data_manifest_root_curated_dagzoo` precursor as the TF-RD-013 dagzoo-root contract surface.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_curated_dagzoo/result_card.md`
+- Benchmark metrics: pending
+
+### 3. `delta_data_manifest_curated_realdata_comparator`
+
+- Dimension family: `data`
+- Status: `blocked_on_artifacts`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations.
+- Rationale: Make the curated real-data comparator contract explicit so TF-RD-013 reads dagzoo against a defined comparator lane instead of a vague future workstream.
+- Hypothesis: The first comparator should stay anchored on one canonical OpenML baseline and only add approved manifest-backed external augmentations when they cover regimes OpenML misses.
+- Upstream delta: Not applicable; this is a repo-local comparator contract layered on top of the benchmark-native OpenML baseline.
+- Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but define the curated real-data comparator manifest family as a separate contract surface from both the current corpus and dagzoo candidates.
+- Expected effect: A real-data comparator lane that is explicit enough to compare against current-corpus and dagzoo candidates without reopening loader boundaries.
+- Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_curated_realdata_comparator`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Data overrides: `{'source': 'manifest', 'manifest_path': 'outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet'}`
+- Parameter adequacy plan:
+  - Keep the OpenML baseline canonical and cite approved external augmentations only after issue 114 license approval rows exist.
+  - Interpret this row as comparator-surface contract work, not as a new ingestion pathway.
+- Adequacy knobs to dimension explicitly:
+  - Approved ledger rows for every dataset referenced by the comparator manifest family.
+  - OpenML baseline versus approved external augmentation coverage notes.
+  - Manifest lineage and regime-coverage notes attached before any benchmark read is interpreted.
+- Execution policy: `benchmark_full`
+- Interpretation status: `pending`
+- Decision: `None`
+- Confounders:
+  - The comparator surface depends on later curation and license backfill work under issues 97, 106, and 114.
+- Notes:
+  - This row defines comparator policy only; it does not authorize any dataset outside the review ledger.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/queue.yaml
@@ -1,0 +1,121 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_013_data_source_contract_v1
+rows:
+- order: 1
+  delta_ref: delta_data_filter_policy_accepted_only
+  status: blocked_on_artifacts
+  rationale: Define the first canonical dagzoo candidate surface by tightening filtering while keeping the promoted row-first anchor otherwise fixed.
+  hypothesis: An accepted-only dagzoo candidate may improve signal quality, but its value is only interpretable once manifest lineage and corpus-shape deltas are explicit.
+  anchor_delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but replace the current corpus with a TF-RD-013 accepted-only dagzoo candidate manifest that carries the canonical dagzoo provenance payload.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_accepted_only
+    surface_overrides:
+      source: manifest
+      manifest_path: outputs/staged_ladder_support/tf_rd_013/dagzoo_accepted_only/manifest.parquet
+      filter_policy: accepted_only
+      dagzoo_provenance:
+        corpus_variant: dagzoo_accepted_only
+        comparator_role: promoted_anchor_candidate
+        commands: []
+        config_refs:
+        - configs/default.yaml
+        curated_root_lineage: []
+        materialization_issue: 120
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+  parameter_adequacy_plan:
+  - Compare manifest characteristics against the current-corpus anchor before reading any benchmark outcome.
+  - Treat the empty `commands` list as a contract placeholder only; issue 120 is responsible for filling the actual command lineage.
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders:
+  - This row is contract-only until the accepted-only manifest and lineage are materialized.
+  next_action: Materialize the accepted-only manifest and fill the dagzoo command lineage under issue 120 before scheduling any comparison run.
+  notes:
+  - This row defines the canonical top-level dagzoo provenance keys expected on TF-RD-013 promoted-anchor comparison surfaces.
+
+- order: 2
+  delta_ref: delta_data_manifest_root_curated_dagzoo
+  status: blocked_on_artifacts
+  parent_delta_ref: delta_data_filter_policy_accepted_only
+  rationale: Define the promoted-anchor curated dagzoo root as a second canonical dagzoo candidate surface rather than leaving it as an old binary-md precursor row.
+  hypothesis: A curated dagzoo root may better match intended post-008 use than the current corpus, but it must be read through explicit lineage from the accepted-only candidate rather than as an opaque manifest swap.
+  anchor_delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but point training at the curated dagzoo root contract while preserving the same canonical dagzoo provenance payload shape.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_curated_dagzoo_root
+    surface_overrides:
+      source: manifest
+      manifest_path: outputs/staged_ladder_support/tf_rd_013/curated_dagzoo/manifest.parquet
+      dagzoo_provenance:
+        corpus_variant: dagzoo_curated_root
+        comparator_role: promoted_anchor_candidate
+        commands: []
+        config_refs:
+        - configs/default.yaml
+        curated_root_lineage:
+        - dagzoo_accepted_only
+        - curated_root_selection
+        materialization_issue: 120
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+  parameter_adequacy_plan:
+  - Compare this row first against the accepted-only dagzoo candidate, then against the current-corpus anchor.
+  - Treat `curated_root_lineage` as required contract metadata, not as optional commentary.
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders:
+  - This row remains a contract placeholder until issue 120 materializes the curated root manifest and lineage.
+  next_action: Materialize the curated dagzoo root lineage and support artifacts under issue 120, then wire the promoted-anchor comparison row under issue 121.
+  notes:
+  - This row supersedes the old `binary_md_v1` `delta_data_manifest_root_curated_dagzoo` precursor as the TF-RD-013 dagzoo-root contract surface.
+
+- order: 3
+  delta_ref: delta_data_manifest_curated_realdata_comparator
+  status: blocked_on_artifacts
+  rationale: Make the curated real-data comparator contract explicit so TF-RD-013 reads dagzoo against a defined comparator lane instead of a vague future workstream.
+  hypothesis: The first comparator should stay anchored on one canonical OpenML baseline and only add approved manifest-backed external augmentations when they cover regimes OpenML misses.
+  anchor_delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but define the curated real-data comparator manifest family as a separate contract surface from both the current corpus and dagzoo candidates.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_curated_realdata_comparator
+    surface_overrides:
+      source: manifest
+      manifest_path: outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+  parameter_adequacy_plan:
+  - Keep the OpenML baseline canonical and cite approved external augmentations only after issue 114 license approval rows exist.
+  - Interpret this row as comparator-surface contract work, not as a new ingestion pathway.
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders:
+  - The comparator surface depends on later curation and license backfill work under issues 97, 106, and 114.
+  next_action: Materialize the approved OpenML-baseline comparator manifest and cite any approved manifest-backed augmentations before scheduling this row.
+  notes:
+  - This row defines comparator policy only; it does not authorize any dataset outside the review ledger.

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/sweep.yaml
@@ -1,0 +1,70 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_013_data_source_contract_v1
+parent_sweep_id: qass_tfcol_large_missing_validation_v1
+status: draft
+complexity_level: binary_md
+anchor_run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
+control_baseline_id: cls_benchmark_linear_v2
+comparison_policy: anchor_only
+training_experiment: cls_benchmark_staged
+training_config_profile: cls_benchmark_staged
+surface_role: architecture_screen
+upstream_reference:
+  name: nanoTabPFN
+  model_source: https://github.com/automl/nanoTabPFN/blob/main/model.py
+anchor_surface:
+  notes:
+  - This draft sweep is the TF-RD-013 contract layer for the promoted `row_cls + qass + no tfcol` anchor.
+  - The locked current-corpus surface remains the anchor until later TF-RD-013 child issues materialize and execute comparison artifacts.
+  - The old `binary_md_v1` `delta_data_manifest_root_curated_dagzoo` row is historical precursor evidence only and should not be treated as the closure path.
+  - Reuse the existing `dagzoo_provenance` mapping on data surfaces; do not introduce a parallel dagzoo metadata channel.
+  - Keep one canonical OpenML real-data baseline and treat approved manifest-backed external datasets as augmentation evidence only after the license ledger is satisfied.
+  dimension_table:
+  - dimension: model anchor
+    upstream: Upstream nanoTabPFN has no repo-local row-first promoted-anchor contract.
+    anchor: The settled promoted row-first benchmark anchor `row_cls + qass + no tfcol`.
+    interpretation: TF-RD-013 changes only the training-data comparison surface, not the promoted model surface.
+  - dimension: training data surface
+    upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract.
+    anchor: Current manifest-backed prior-training corpus with data surface label `anchor_manifest_default`.
+    interpretation: The current corpus is the baseline comparator; TF-RD-013 rows define explicit dagzoo and curated real-data alternatives against it.
+  - dimension: dagzoo provenance contract
+    upstream: Not applicable.
+    anchor: No dagzoo provenance is attached to the current-corpus anchor surface.
+    interpretation: Dagzoo candidate rows must carry one explicit `dagzoo_provenance` payload with fixed keys before the sweep becomes runnable.
+  - dimension: real-data comparator policy
+    upstream: Not applicable.
+    anchor: Benchmark bundle `nanotabpfn_openml_binary_large` remains the benchmark-facing evaluation surface.
+    interpretation: Curated real-data ladders are comparator evidence and must keep one OpenML baseline plus approved manifest-backed augmentations rather than introducing a new loader path.
+  - dimension: training recipe
+    upstream: No repo-local prior-dump training-surface contract.
+    anchor: Training surface label `prior_linear_warmup_decay`.
+    interpretation: TF-RD-013 contract work should not mix optimizer or schedule changes into the data-source decision.
+anchor_context:
+  run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+  experiment: cls_benchmark_staged
+  config_profile: cls_benchmark_staged
+  model:
+    arch: tabfoundry_staged
+    benchmark_profile: delta_qass_no_column_v3
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_selection:
+      allow_test_self_attention: true
+      column_encoder: none
+      context_encoder: qass
+      feature_encoder: shared
+      head: small_class
+      post_encoder_norm: none
+      post_stack_norm: none
+      row_pool: row_cls
+      table_block_residual_scale: none
+      table_block_style: prenorm
+      target_conditioner: label_token
+      tokenizer: shifted_grouped
+  surface_labels:
+    data: anchor_manifest_default
+    model: delta_qass_no_column_v3
+    preprocessing: runtime_default
+    training: prior_linear_warmup_decay

--- a/tests/research/test_tf_rd_013_data_source_contract_v1.py
+++ b/tests/research/test_tf_rd_013_data_source_contract_v1.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+import tab_foundry.research.sweep.diff as diff_module
+import tab_foundry.research.sweep.inspect as inspect_module
+from tab_foundry.research.system_delta import load_system_delta_queue
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEP_ID = "tf_rd_013_data_source_contract_v1"
+ANCHOR_RUN_ID = "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+EXPECTED_ROWS = [
+    "delta_data_filter_policy_accepted_only",
+    "delta_data_manifest_root_curated_dagzoo",
+    "delta_data_manifest_curated_realdata_comparator",
+]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _row_by_ref(queue: dict[str, Any], delta_ref: str) -> dict[str, Any]:
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    return next(row for row in rows if row["delta_ref"] == delta_ref)
+
+
+def test_tf_rd_013_data_source_contract_is_registered_but_not_active() -> None:
+    index = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml")
+
+    assert index["active_sweep_id"] == "cuda_stack_scale_followup"
+
+    sweeps = index["sweeps"]
+    assert isinstance(sweeps, dict)
+    assert sweeps[SWEEP_ID] == {
+        "parent_sweep_id": "qass_tfcol_large_missing_validation_v1",
+        "status": "draft",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "binary_md",
+        "benchmark_bundle_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+    }
+
+
+def test_tf_rd_013_data_source_contract_metadata_and_rows_match_issue_100_contract() -> None:
+    sweep_root = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+
+    assert sweep["sweep_id"] == SWEEP_ID
+    assert sweep["parent_sweep_id"] == "qass_tfcol_large_missing_validation_v1"
+    assert sweep["status"] == "draft"
+    assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
+    assert sweep["anchor_context"]["run_id"] == ANCHOR_RUN_ID
+    assert sweep["anchor_context"]["model"]["stage"] == "qass_context"
+    assert sweep["anchor_context"]["surface_labels"]["data"] == "anchor_manifest_default"
+    assert sweep["anchor_context"]["surface_labels"]["training"] == "prior_linear_warmup_decay"
+    notes = sweep["anchor_surface"]["notes"]
+    assert isinstance(notes, list)
+    assert any("TF-RD-013 contract layer" in note for note in notes)
+    assert any("historical precursor evidence" in note for note in notes)
+    assert any("dagzoo_provenance" in note for note in notes)
+
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
+    assert [row["status"] for row in rows] == ["blocked_on_artifacts"] * 3
+
+    accepted_only_row = _row_by_ref(queue, "delta_data_filter_policy_accepted_only")
+    assert accepted_only_row["data"]["surface_label"] == "tf_rd_013_dagzoo_accepted_only"
+    accepted_overrides = accepted_only_row["data"]["surface_overrides"]
+    assert accepted_overrides["manifest_path"] == "outputs/staged_ladder_support/tf_rd_013/dagzoo_accepted_only/manifest.parquet"
+    assert accepted_overrides["filter_policy"] == "accepted_only"
+    assert accepted_overrides["dagzoo_provenance"] == {
+        "corpus_variant": "dagzoo_accepted_only",
+        "comparator_role": "promoted_anchor_candidate",
+        "commands": [],
+        "config_refs": ["configs/default.yaml"],
+        "curated_root_lineage": [],
+        "materialization_issue": 120,
+    }
+
+    curated_dagzoo_row = _row_by_ref(queue, "delta_data_manifest_root_curated_dagzoo")
+    assert curated_dagzoo_row["parent_delta_ref"] == "delta_data_filter_policy_accepted_only"
+    assert curated_dagzoo_row["data"]["surface_label"] == "tf_rd_013_curated_dagzoo_root"
+    assert curated_dagzoo_row["data"]["surface_overrides"]["dagzoo_provenance"]["curated_root_lineage"] == [
+        "dagzoo_accepted_only",
+        "curated_root_selection",
+    ]
+    assert any("supersedes the old `binary_md_v1`" in note for note in curated_dagzoo_row["notes"])
+
+    realdata_row = _row_by_ref(queue, "delta_data_manifest_curated_realdata_comparator")
+    assert realdata_row["data"]["surface_label"] == "tf_rd_013_curated_realdata_comparator"
+    assert realdata_row["data"]["surface_overrides"]["manifest_path"] == (
+        "outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet"
+    )
+    assert all("license" not in key for key in realdata_row["data"]["surface_overrides"].keys())
+
+    materialized = load_system_delta_queue(
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+    materialized_rows = materialized["rows"]
+    assert [row["delta_id"] for row in materialized_rows] == EXPECTED_ROWS
+    assert all(row["status"] == "blocked_on_artifacts" for row in materialized_rows)
+
+
+def test_tf_rd_013_data_source_contract_inspect_and_diff_resolve_explicit_data_surfaces() -> None:
+    inspect_payload = inspect_module.inspect_sweep_row(
+        order=2,
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+        sweeps_root=REPO_ROOT / "reference" / "system_delta_sweeps",
+        registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+    )
+
+    resolved_data = inspect_payload["target"]["resolved"]["data"]
+    assert resolved_data["surface_label"] == "tf_rd_013_curated_dagzoo_root"
+    assert resolved_data["source"] == "manifest"
+    assert resolved_data["dagzoo_provenance"]["corpus_variant"] == "dagzoo_curated_root"
+    assert resolved_data["dagzoo_provenance"]["materialization_issue"] == 120
+    assert resolved_data["overrides"]["manifest_path"].endswith(
+        "outputs/staged_ladder_support/tf_rd_013/curated_dagzoo/manifest.parquet"
+    )
+
+    diff_payload = diff_module.diff_sweep_row(
+        order=2,
+        sweep_id=SWEEP_ID,
+        against="anchor",
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+        sweeps_root=REPO_ROOT / "reference" / "system_delta_sweeps",
+        registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+    )
+
+    assert diff_payload["difference_count"] > 0
+    differences = diff_payload["differences"]
+    assert differences["resolved.data.surface_label"] == {
+        "target": "tf_rd_013_curated_dagzoo_root",
+        "against": "anchor_manifest_default",
+    }
+    assert differences["resolved.data.dagzoo_provenance"]["target"]["corpus_variant"] == "dagzoo_curated_root"
+    assert differences["resolved.data.dagzoo_provenance"]["against"] is None
+
+
+def test_binary_md_v1_curated_dagzoo_row_is_now_marked_as_historical_precursor() -> None:
+    queue = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "binary_md_v1" / "queue.yaml")
+    row = _row_by_ref(queue, "delta_data_manifest_root_curated_dagzoo")
+
+    assert row["status"] == "superseded"
+    assert row["decision"] == "defer"
+    assert row["interpretation_status"] == "blocked"
+    assert "tf_rd_013_data_source_contract_v1" in row["next_action"]
+    assert any("historical precursor evidence only" in note for note in row["notes"])


### PR DESCRIPTION
## Summary
- add the draft `tf_rd_013_data_source_contract_v1` sweep and queue for the promoted row-first anchor
- define canonical TF-RD-013 dagzoo and curated real-data comparator surfaces, including the expected `dagzoo_provenance` contract
- mark the old `binary_md_v1` curated dagzoo row as superseded historical precursor evidence
- add targeted research tests covering registration, queue materialization, inspect/diff resolution, and precursor supersession
- Closes #100

## Testing
- `.venv/bin/tab-foundry research sweep render --sweep-id tf_rd_013_data_source_contract_v1`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_013_data_source_contract_v1 --order 2 --json`
- `.venv/bin/tab-foundry research sweep diff --sweep-id tf_rd_013_data_source_contract_v1 --order 2 --against anchor --json`
- `.venv/bin/python -m pytest -q tests/research/test_tf_rd_013_data_source_contract_v1.py tests/research/test_system_delta.py tests/research/test_sweep_inspect.py tests/research/test_missingness_followup.py`
- `./scripts/dev verify paths reference/system_delta_catalog.yaml reference/system_delta_sweeps/index.yaml reference/system_delta_sweeps/binary_md_v1/queue.yaml reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1 tests/research/test_tf_rd_013_data_source_contract_v1.py`