### PR TITLE
Correct dagzoo sweeps

### DIFF
--- a/configs/data/default.yaml
+++ b/configs/data/default.yaml
@@ -4,6 +4,7 @@ surface_label: manifest_default
 surface_overrides: {}
 filter_policy: null
 dagzoo_provenance: null
+allow_missing_values: false
 roots:
   - ${oc.env:DAGZOO_DATA_ROOT,${oc.env:HOME}/dev/dagzoo/data}
 train_row_cap: null

--- a/configs/experiment/_shared/compact_binary_prior.yaml
+++ b/configs/experiment/_shared/compact_binary_prior.yaml
@@ -1,6 +1,10 @@
 # @package _global_
 
 task: classification
+data:
+  source: prior_dump
+  surface_label: prior_dump
+  manifest_path: null
 model:
   d_icl: 96
   input_normalization: train_zscore_clip

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -654,8 +654,8 @@ This roadmap assumes the following repo truths:
 
 ### TF-RD-013: Dagzoo Synthetic-Data Efficacy On The Promoted Anchor
 
-- Status: `partial`
-- Milestone: `Now`
+- Status: `completed`
+- Milestone: `Implemented`
 - Goal: decide before training-surface adequacy work whether dagzoo-generated
   corpora better match the intended post-008 training data surface than the
   current corpus, and whether they materially improve training difficulty,
@@ -664,8 +664,9 @@ This roadmap assumes the following repo truths:
 - Current state:
   - the dagzoo handoff boundary is complete through closed TF-RD-011 work
   - dagzoo smoke and manifest identity are no longer the main blocker
-  - issue `#122` executed the first promoted-anchor comparison against one unfiltered
-    dagzoo surface and one OpenML-only curated comparator
+  - issue [#122](https://github.com/bensonlee5/tab-foundry/issues/122) executed
+    the first promoted-anchor comparison against one unfiltered dagzoo surface
+    and one OpenML-only curated comparator
   - that TF-RD-013 evidence remains a historical nanoTabPFN-era comparison package
     and does not define the forward benchmark policy for new sweeps, which now
     defaults to TabICLv2
@@ -678,26 +679,36 @@ This roadmap assumes the following repo truths:
     `--allow-missing-values`
   - dagzoo is the synthetic-data generation lane, not an external real-data
     ingestion surface
-  - issue `#120` now records the first runnable unfiltered dagzoo generated-
-    source surface and its support artifacts for the promoted anchor
-  - issue `#127` now tracks the immediate follow-up on multi-invocation, shape-aware
-    dagzoo coverage because the first read did not separate the candidate surfaces
-  - issue `#107` remains blocked until TF-RD-013 reruns against that broader dagzoo
-    surface and records a representative-data decision
-- Required work:
-  - expand dagzoo support beyond one default-config generate run so TF-RD-013 can
-    test a multi-invocation, shape-aware synthetic corpus under issue `#127`
-  - rerun the promoted-anchor current-vs-dagzoo-vs-curated comparison once that
-    broader dagzoo surface exists
-  - keep the curated real-data lane OpenML-first and evidence-only unless later
-    approved augmentations are needed to cover regimes OpenML misses
-  - use TF-RD-019 and issue `#124` only if the broader dagzoo read later shows a
-    predictability or corpus-selection problem that actually requires filtering policy
-  - record whether dagzoo becomes the representative post-008 training-data
-    surface, complements the benchmark ladders, or stays auxiliary
+  - issue [#120](https://github.com/bensonlee5/tab-foundry/issues/120) records
+    the first runnable unfiltered dagzoo generated-source surface and its support
+    artifacts for the promoted anchor
+  - issue [#127](https://github.com/bensonlee5/tab-foundry/issues/127) completed
+    the multi-invocation, shape-aware dagzoo follow-up and kept dagzoo deferred
+    on the promoted anchor
+  - issue [#107](https://github.com/bensonlee5/tab-foundry/issues/107) is no
+    longer blocked on TF-RD-013; the representative-data handoff is to keep the
+    current corpus and treat dagzoo as auxiliary synthetic-data evidence rather
+    than the default post-008 training surface
+- Completed evidence:
+  - the corrected manifest-backed reruns preserved the first read: the unfiltered
+    dagzoo generated-source surface remained close to, but still worse than, the
+    current-corpus anchor on final large-bundle log loss and Brier
+  - the broader shape-aware follow-up under issue [#127](https://github.com/bensonlee5/tab-foundry/issues/127)
+    did not change that outcome: the multi-invocation dagzoo surface still underperformed
+    the anchor on final large-bundle log loss and Brier
+  - the OpenML-first curated comparator remained materially worse than the anchor
+    on final large-bundle log loss and Brier in both TF-RD-013 sweeps, so it stays
+    evidence-only rather than becoming the representative training surface
+  - issue [#124](https://github.com/bensonlee5/tab-foundry/issues/124) remains
+    later filtering-policy work only if a future corpus-selection or predictability
+    problem appears
+  - the repo now has an explicit defer decision on dagzoo for the promoted anchor:
+    keep the current corpus as the representative post-008 training-data surface,
+    and treat dagzoo as an auxiliary synthetic-data lane rather than the default
 - Exit criteria:
-  - the repo has an explicit keep/defer decision on dagzoo as a post-008
-    training-data source before TF-RD-018 defines the default training surface
+  - satisfied: the repo now has an explicit keep/defer decision on dagzoo as a
+    post-008 training-data source before TF-RD-018 defines the default training
+    surface
 
 ### TF-RD-014: Missingness Robustness On The Promoted Anchor
 

--- a/docs/research-contributors.md
+++ b/docs/research-contributors.md
@@ -153,7 +153,7 @@ Read in this order:
 
 1. [docs/development/dataset-curation.md](development/dataset-curation.md)
 1. [docs/development/roadmap.md](development/roadmap.md)
-1. [reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/README.md](../reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/README.md)
+1. [reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md](../reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md)
 1. [docs/workflows.md](workflows.md)
 
 Key rule:
@@ -173,7 +173,7 @@ Inspect-first commands:
   --override data.manifest_path=data/manifests/default.parquet
 .venv/bin/tab-foundry dev resolve-config experiment=cls_benchmark_staged
 .venv/bin/tab-foundry research sweep inspect \
-  --sweep-id tf_rd_013_data_source_contract_v1 \
+  --sweep-id tf_rd_013_shape_aware_dagzoo_v1 \
   --order 1
 ```
 

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -2182,6 +2182,47 @@ deltas:
     default_next_action: Run the current-versus-generated-source comparison before any later filtering-policy follow-up.
     applicability_guards: []
 
+  delta_data_manifest_root_dagzoo_shape_aware_multi_invocation:
+    dimension_family: data
+    family: provenance
+    binary_applicable: true
+    description: Point training at the multi-invocation, shape-aware dagzoo manifest with explicit per-invocation provenance.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data generation axis.
+    expected_effect: Broader synthetic training coverage across small, anchor-scale, and large-shape dagzoo regimes while keeping provenance reviewable.
+    adequacy_knobs:
+      - explicit config ladder coverage across the selected dagzoo shape regimes
+      - per-invocation dataset counts and combined split distribution
+      - manifest-contract deltas versus the anchor and curated comparator
+    parameter_adequacy_policy:
+      default_plan:
+        - Compare manifest characteristics before training and name which config-backed regimes are represented in the combined surface.
+        - If weaker, discuss whether the broader surface still fails to match intended representative data rather than jumping straight to filtering policy.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model:
+        stage_label: anchor_model
+      data:
+        surface_label: tf_rd_013_dagzoo_shape_aware_multi_invocation
+        surface_overrides:
+          source: manifest
+          manifest_path: outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet
+          dagzoo_provenance:
+            commands: []
+            config_refs: []
+            curated_root_lineage: []
+            invocations: []
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Materialize the broader multi-invocation dagzoo surface, rerun TF-RD-013, and decide whether dagzoo now changes the representative post-008 training-data read.
+    applicability_guards: []
+
   delta_data_filter_policy_accepted_only:
       dimension_family: data
       family: provenance
@@ -2318,6 +2359,7 @@ deltas:
         surface_overrides:
           source: manifest
           manifest_path: outputs/staged_ladder_support/curated_realdata/openml_baseline/manifest.parquet
+        allow_missing_values: true
       preprocessing:
         surface_label: runtime_default
     default_next_action: Materialize the approved OpenML-baseline comparator manifest and cite any approved external augmentations before scheduling this row.

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -155,6 +155,13 @@ sweeps:
     complexity_level: binary_md
     benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
     control_baseline_id: cls_benchmark_linear_v2
+  tf_rd_013_shape_aware_dagzoo_v1:
+    parent_sweep_id: tf_rd_013_data_source_contract_v1
+    status: completed
+    anchor_run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+    complexity_level: binary_md
+    benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
+    control_baseline_id: cls_benchmark_linear_v2
   row_first_training_adequacy_v1:
     parent_sweep_id: qass_tfcol_large_missing_validation_v1
     status: draft

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/matrix.md
@@ -14,6 +14,7 @@ This file is rendered from `reference/system_delta_sweeps/tf_rd_013_data_source_
 - Anchor run id: `sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1`
 - Benchmark bundle: `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`
 - Control baseline id: `cls_benchmark_linear_v2`
+- External benchmarks: `nanotabpfn`
 - Training experiment: `cls_benchmark_staged`
 - Training config profile: `cls_benchmark_staged`
 - Surface role: `architecture_screen`
@@ -36,8 +37,8 @@ Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_data_manifest_root_dagzoo_generated_source` | provenance | yes | completed | none | Point training at the unfiltered dagzoo generated-source manifest with explicit dagzoo generate provenance. | Implement issue 127 to broaden dagzoo into a multi-invocation, shape-aware support surface, then rerun TF-RD-013 before handing representative-data decisions into issue 107; keep issue 124 reserved for later filtering policy unless the broader dagzoo read exposes a predictability problem. |
-| 2 | `delta_data_manifest_curated_realdata_comparator` | source | yes | completed | none | Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations. | Keep this OpenML-only comparator as evidence-only and keep issue 107 blocked until issue 127 reruns TF-RD-013 with broader dagzoo coverage; do not treat this row as the representative post-008 handoff surface. |
+| 1 | `delta_data_manifest_root_dagzoo_generated_source` | provenance | yes | completed | none | Point training at the unfiltered dagzoo generated-source manifest with explicit dagzoo generate provenance. | Use the completed issue 127 follow-up to keep the current corpus as the representative post-008 training-data surface for issue 107; leave issue 124 as later filtering-policy work only if a future corpus-selection problem appears. |
+| 2 | `delta_data_manifest_curated_realdata_comparator` | source | yes | completed | none | Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations. | Keep this OpenML-only lane evidence-only; use the completed issue 127 follow-up to support the representative-data handoff into issue 107. |
 
 ## Detailed Rows
 
@@ -54,7 +55,7 @@ Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
 - Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but replace the current corpus with a TF-RD-013 unfiltered dagzoo generated-source manifest that carries the canonical dagzoo provenance payload.
 - Expected effect: Higher-throughput synthetic training data with no post-generation filtering and explicit provenance.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_generated_source`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
-- Stage-local stability: column (grad `0.0000`); row (grad `0.0266`); context (grad `0.0475`)
+- Stage-local stability: column (grad `0.0000`); row (grad `0.0083`); context (grad `0.0398`)
 - Data overrides: `{}`
 - Parameter adequacy plan:
   - Compare manifest characteristics against the current-corpus anchor before reading any benchmark outcome.
@@ -67,18 +68,19 @@ Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
 - Interpretation status: `completed`
 - Decision: `defer`
 - Confounders:
-  - The first dagzoo candidate is still one default-config generate invocation, so a neutral benchmark read does not rule out a broader multi-invocation dagzoo surface.
-  - The nanoTabPFN helper failed on benchmark dataset `Fitness_Club` with non-finite probabilities even though this benchmark bundle allows missing values, so the direct control-lane comparison remains partially confounded until that helper path is fixed.
+  - Direct nanoTabPFN helper comparison remains partially confounded: the missing-value helper run failed (`helper_failed_on_missing_bundle`), and the historical failure mode was tied to `Fitness_Club` non-finite probabilities.
 - Notes:
   - This row defines the canonical top-level `dagzoo_provenance` keys expected on TF-RD-013 promoted-anchor comparison surfaces.
   - Reference-only support bundle: `reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/materialization_summary.json` and `reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/manifest_characteristics_summary.json`.
   - Issue 124 is subsequent policy work on whether any filtered dagzoo variants should exist after the initial unfiltered read.
-  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1`.
+  - Historical execution `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1` was invalid because manifest-backed training ran through the prior-dump backend.
   - The first promoted-anchor read was neutral: the unfiltered dagzoo surface matched the anchor and the OpenML-only comparator on the recorded large-bundle metrics while remaining materially different at the manifest-contract layer.
-  - The immediate blocker is issue 127 on broader dagzoo coverage rather than issue 124 filtering policy.
+  - The completed issue 127 follow-up kept dagzoo deferred: the broader multi-invocation surface remained worse than the anchor on final large-bundle log loss and Brier, so TF-RD-013 keeps the current corpus as the representative post-008 training-data surface.
+  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/result_card.md`
-- Registered run: `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1` with final log loss `0.4215`, delta final log loss `-0.0000`, final Brier score `0.2644`, delta final Brier score `-0.0000`, best ROC AUC `0.6702`, final ROC AUC `0.6702`, final-minus-best `+0.0000`, delta final ROC AUC `-0.0001`, delta drift `+0.0000`, delta final training time `-26.6s`
+- Registered run: `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2` with final log loss `0.4671`, delta final log loss `+0.0456`, final Brier score `0.2986`, delta final Brier score `+0.0342`, best ROC AUC `0.4546`, final ROC AUC `0.4737`, final-minus-best `+0.0191`, delta final ROC AUC `-0.1965`, delta drift `+0.0191`, delta final training time `-2221.9s`
 
 ### 2. `delta_data_manifest_curated_realdata_comparator`
 
@@ -93,7 +95,7 @@ Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
 - Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but define the curated real-data comparator manifest family as a separate contract surface from both the current corpus and the unfiltered dagzoo candidate.
 - Expected effect: A real-data comparator lane that is explicit enough to compare against current-corpus and dagzoo candidates without reopening loader boundaries.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_curated_realdata_comparator`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
-- Stage-local stability: column (grad `0.0000`); row (grad `0.0266`); context (grad `0.0475`)
+- Stage-local stability: column (grad `0.0000`); row (grad `3.5372`); context (grad `0.9408`)
 - Data overrides: `{}`
 - Parameter adequacy plan:
   - Keep the OpenML baseline canonical and cite approved external augmentations only after issue 114 license approval rows exist.
@@ -106,12 +108,14 @@ Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
 - Interpretation status: `completed`
 - Decision: `defer`
 - Confounders:
-  - The nanoTabPFN helper failed on benchmark dataset `Fitness_Club` with non-finite probabilities even though this benchmark bundle allows missing values, so the direct control-lane comparison remains partially confounded until that helper path is fixed.
+  - Direct nanoTabPFN helper comparison remains partially confounded: the missing-value helper run failed (`helper_failed_on_missing_bundle`), and the historical failure mode was tied to `Fitness_Club` non-finite probabilities.
 - Notes:
   - This row defines comparator policy only; it does not authorize any dataset outside the review ledger.
-  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1`.
-  - OpenML-only curated comparator recorded as evidence-only for the first promoted-anchor TF-RD-013 read.
-  - The OpenML-only comparator matched the anchor and the unfiltered dagzoo row on the recorded benchmark bundle, so it remains evidence-only rather than a replacement handoff surface.
+  - Historical execution `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1` was invalid because manifest-backed training ran through the prior-dump backend.
+  - The completed issue 127 follow-up did not change comparator policy; this OpenML-only lane remains evidence-only and materially worse than the anchor on final large-bundle log loss and Brier.
+  - Supersedes historical queue run `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1`; that invalid run id is preserved in queue notes only.
+  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/result_card.md`
-- Registered run: `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1` with final log loss `0.4215`, delta final log loss `-0.0000`, final Brier score `0.2644`, delta final Brier score `-0.0000`, best ROC AUC `0.6702`, final ROC AUC `0.6702`, final-minus-best `+0.0000`, delta final ROC AUC `-0.0001`, delta drift `+0.0000`, delta final training time `+12.3s`
+- Registered run: `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2` with final log loss `2.1071`, delta final log loss `+1.6856`, final Brier score `0.4933`, delta final Brier score `+0.2289`, best ROC AUC `0.5614`, final ROC AUC `0.5828`, final-minus-best `+0.0214`, delta final ROC AUC `-0.0874`, delta drift `+0.0214`, delta final training time `-2223.1s`

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/queue.yaml
@@ -69,22 +69,20 @@ rows:
     any benchmark outcome.
   - Treat `filter_status_counts.not_run` as a deliberate property of the initial unfiltered
     sweep, not as a hidden data-contract bug.
-  run_id: sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1
+  run_id: sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2
   followup_run_ids: []
   decision: defer
   interpretation_status: completed
   confounders:
-  - The first dagzoo candidate is still one default-config generate invocation, so
-    a neutral benchmark read does not rule out a broader multi-invocation dagzoo
-    surface.
-  - The nanoTabPFN helper failed on benchmark dataset `Fitness_Club` with non-finite
-    probabilities even though this benchmark bundle allows missing values, so the
-    direct control-lane comparison remains partially confounded until that helper
-    path is fixed.
-  next_action: Implement issue 127 to broaden dagzoo into a multi-invocation, shape-aware
-    support surface, then rerun TF-RD-013 before handing representative-data decisions
-    into issue 107; keep issue 124 reserved for later filtering policy unless the
-    broader dagzoo read exposes a predictability problem.
+    - >-
+      Direct nanoTabPFN helper comparison remains partially confounded: the
+      missing-value helper run failed (`helper_failed_on_missing_bundle`), and
+      the historical failure mode was tied to `Fitness_Club` non-finite
+      probabilities.
+  next_action: Use the completed issue 127 follow-up to keep the current corpus
+    as the representative post-008 training-data surface for issue 107; leave issue
+    124 as later filtering-policy work only if a future corpus-selection problem
+    appears.
   notes:
   - This row defines the canonical top-level `dagzoo_provenance` keys expected on
     TF-RD-013 promoted-anchor comparison surfaces.
@@ -92,32 +90,39 @@ rows:
     and `reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/manifest_characteristics_summary.json`.'
   - Issue 124 is subsequent policy work on whether any filtered dagzoo variants should
     exist after the initial unfiltered read.
-  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1`.
+  - Historical execution `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1`
+    was invalid because manifest-backed training ran through the prior-dump backend.
   - 'The first promoted-anchor read was neutral: the unfiltered dagzoo surface matched
     the anchor and the OpenML-only comparator on the recorded large-bundle metrics
     while remaining materially different at the manifest-contract layer.'
-  - The immediate blocker is issue 127 on broader dagzoo coverage rather than issue
-    124 filtering policy.
+  - >-
+    The completed issue 127 follow-up kept dagzoo deferred: the broader
+    multi-invocation surface remained worse than the anchor on final
+    large-bundle log loss and Brier, so TF-RD-013 keeps the current corpus as
+    the representative post-008 training-data surface.
+  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   benchmark_metrics:
-    best_step: 2500
-    max_grad_norm: 5.782161712646484
-    clipped_step_fraction: 0.0072
-    best_log_loss: 0.42151055964690004
-    final_log_loss: 0.42151055964690004
-    best_brier_score: 0.26437640199935597
-    final_brier_score: 0.26437640199935597
-    best_roc_auc: 0.6701728307468436
-    final_roc_auc: 0.6701728307468436
-    final_minus_best_log_loss: 0.0
-    final_minus_best_brier_score: 0.0
-    final_minus_best_roc_auc: 0.0
-    drift: 0.0
-    delta_final_log_loss: -3.3296791435155626e-09
-    delta_final_brier_score: -3.026016270890608e-09
-    delta_final_roc_auc: -5.139802631570767e-05
+    best_step: 250
+    max_grad_norm: 8.983333587646484
+    clipped_step_fraction: 0.06858710562414266
+    best_log_loss: 0.46516748233892263
+    final_log_loss: 0.4671030293897789
+    best_brier_score: 0.29789851264214673
+    final_brier_score: 0.29861690039648475
+    best_roc_auc: 0.45458055038882045
+    final_roc_auc: 0.4736863453411519
+    final_minus_best_log_loss: 0.0019355470508562456
+    final_minus_best_brier_score: 0.0007183877543380235
+    final_minus_best_roc_auc: 0.019105794952331445
+    drift: 0.019105794952331445
+    delta_final_log_loss: 0.045592466413199695
+    delta_final_brier_score: 0.03424049537111251
+    delta_final_roc_auc: -0.19653788343200745
     column_encoder_final_window_mean_grad_norm: 0.0
-    row_pool_final_window_mean_grad_norm: 0.026585699878925527
-    context_encoder_final_window_mean_grad_norm: 0.047535554359473646
+    row_pool_final_window_mean_grad_norm: 0.008279819644761073
+    context_encoder_final_window_mean_grad_norm: 0.03979169685603427
 - order: 2
   delta_ref: delta_data_manifest_curated_realdata_comparator
   status: completed
@@ -139,6 +144,7 @@ rows:
     surface_label: tf_rd_013_curated_realdata_comparator
     source: manifest
     manifest_path: outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet
+    allow_missing_values: true
   preprocessing:
     surface_label: runtime_default
   training:
@@ -151,6 +157,7 @@ rows:
         eval_every: 25
         checkpoint_every: 25
         trace_activations: false
+        val_batches: 0
       optimizer:
         name: schedulefree_adamw
         require_requested: true
@@ -172,44 +179,48 @@ rows:
     after issue 114 license approval rows exist.
   - Interpret this row as comparator-surface contract work, not as a new ingestion
     pathway.
-  run_id: sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1
+  run_id: sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2
   followup_run_ids: []
   decision: defer
   interpretation_status: completed
   confounders:
-  - The nanoTabPFN helper failed on benchmark dataset `Fitness_Club` with non-finite
-    probabilities even though this benchmark bundle allows missing values, so the
-    direct control-lane comparison remains partially confounded until that helper
-    path is fixed.
-  next_action: Keep this OpenML-only comparator as evidence-only and keep issue 107
-    blocked until issue 127 reruns TF-RD-013 with broader dagzoo coverage; do not
-    treat this row as the representative post-008 handoff surface.
+    - >-
+      Direct nanoTabPFN helper comparison remains partially confounded: the
+      missing-value helper run failed (`helper_failed_on_missing_bundle`), and
+      the historical failure mode was tied to `Fitness_Club` non-finite
+      probabilities.
+  next_action: Keep this OpenML-only lane evidence-only; use the completed issue
+    127 follow-up to support the representative-data handoff into issue 107.
   notes:
   - This row defines comparator policy only; it does not authorize any dataset outside
     the review ledger.
-  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1`.
-  - OpenML-only curated comparator recorded as evidence-only for the first promoted-anchor
-    TF-RD-013 read.
-  - The OpenML-only comparator matched the anchor and the unfiltered dagzoo row on
-    the recorded benchmark bundle, so it remains evidence-only rather than a replacement
-    handoff surface.
+  - Historical execution `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1`
+    was invalid because manifest-backed training ran through the prior-dump backend.
+  - The completed issue 127 follow-up did not change comparator policy; this OpenML-only
+    lane remains evidence-only and materially worse than the anchor on final large-bundle
+    log loss and Brier.
+  - Supersedes historical queue run `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1`;
+    that invalid run id is preserved in queue notes only.
+  - Canonical rerun registered as `sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   benchmark_metrics:
-    best_step: 2500
-    max_grad_norm: 5.782161712646484
-    clipped_step_fraction: 0.0072
-    best_log_loss: 0.42151055964690004
-    final_log_loss: 0.42151055964690004
-    best_brier_score: 0.26437640199935597
-    final_brier_score: 0.26437640199935597
-    best_roc_auc: 0.6701728307468436
-    final_roc_auc: 0.6701728307468436
-    final_minus_best_log_loss: 0.0
-    final_minus_best_brier_score: 0.0
-    final_minus_best_roc_auc: 0.0
-    drift: 0.0
-    delta_final_log_loss: -3.3296791435155626e-09
-    delta_final_brier_score: -3.026016270890608e-09
-    delta_final_roc_auc: -5.139802631570767e-05
+    best_step: 325
+    max_grad_norm: 711.2716674804688
+    clipped_step_fraction: 0.6169275929549902
+    best_log_loss: 0.4613900827138487
+    final_log_loss: 2.1070736899301186
+    best_brier_score: 0.29308872328473784
+    final_brier_score: 0.49332305775491814
+    best_roc_auc: 0.5614038112865214
+    final_roc_auc: 0.5827764017871021
+    final_minus_best_log_loss: 1.64568360721627
+    final_minus_best_brier_score: 0.2002343344701803
+    final_minus_best_roc_auc: 0.021372590500580713
+    drift: 0.021372590500580713
+    delta_final_log_loss: 1.6855631269535394
+    delta_final_brier_score: 0.2289466527295459
+    delta_final_roc_auc: -0.08744782698605724
     column_encoder_final_window_mean_grad_norm: 0.0
-    row_pool_final_window_mean_grad_norm: 0.026585699878925527
-    context_encoder_final_window_mean_grad_norm: 0.047535554359473646
+    row_pool_final_window_mean_grad_norm: 3.537151723691786
+    context_encoder_final_window_mean_grad_norm: 0.9407556727893515

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/matrix.md
@@ -1,0 +1,120 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/queue.yaml` plus `reference/system_delta_catalog.yaml` and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_013_shape_aware_dagzoo_v1`
+- Sweep status: `completed`
+- Parent sweep id: `tf_rd_013_data_source_contract_v1`
+- Complexity level: `binary_md`
+
+## Locked Surface
+
+- Anchor run id: `sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1`
+- Benchmark bundle: `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`
+- Control baseline id: `cls_benchmark_linear_v2`
+- External benchmarks: `nanotabpfn`
+- Training experiment: `cls_benchmark_staged`
+- Training config profile: `cls_benchmark_staged`
+- Surface role: `architecture_screen`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final log loss `0.4215`, final Brier score `0.2644`, best ROC AUC `0.6702`, final ROC AUC `0.6702`, final training time `2550.1s`
+
+## Anchor Comparison
+
+Upstream reference: `TabICLv2` from `https://arxiv.org/abs/2602.11139`.
+
+| Dimension | Upstream TabICLv2 | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+| model anchor | TabICLv2 is the primary row-first architectural reference, but it does not define this exact repo-local promoted-anchor contract. | The settled promoted row-first benchmark anchor `row_cls + qass + no tfcol`. | TF-RD-013 changes only the training-data comparison surface, not the promoted model surface. |
+| training data surface | TabICLv2 motivates synthetic pretraining at scale but does not define this repo-local manifest contract. | Current manifest-backed prior-training corpus with data surface label `anchor_manifest_default`. | The broader TF-RD-013 follow-up keeps the current corpus as baseline while testing one explicit multi-invocation dagzoo alternative plus the curated real-data comparator lane. |
+| dagzoo provenance contract | Not applicable. | No dagzoo provenance is attached to the current-corpus anchor surface. | The broader dagzoo candidate row should keep one top-level `dagzoo_provenance` payload and make each generate invocation explicit inside `dagzoo_provenance.invocations`. |
+| benchmark and control context | TabICLv2 is the architectural reference, while nanoTabPFN remains the current benchmark/control bundle family used by this repo. | Benchmark bundle `nanotabpfn_openml_binary_large` remains the benchmark-facing evaluation surface. | TF-RD-013 should keep benchmark/control context stable while it reads the training-data surface change. |
+| training recipe | TabICLv2 informs the row-first staged recipe direction, but there is no repo-local shared prior-dump training-surface contract to copy literally. | Training surface label `prior_linear_warmup_decay`. | The issue 127 follow-up should not mix optimizer or schedule changes into the data-source decision. |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_data_manifest_root_dagzoo_shape_aware_multi_invocation` | provenance | yes | completed | none | Point training at the multi-invocation, shape-aware dagzoo manifest with explicit per-invocation provenance. | Use this completed issue 127 follow-up to close issue 127, keep dagzoo deferred for issue 96, and record in issue 107 that the current corpus remains the representative post-008 training-data surface. |
+| 2 | `delta_data_manifest_curated_realdata_comparator` | source | yes | completed | none | Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations. | Keep this comparator evidence-only while closing issue 127 and recording the TF-RD-013 defer decision in issues 96 and 107. |
+
+## Detailed Rows
+
+### 1. `delta_data_manifest_root_dagzoo_shape_aware_multi_invocation`
+
+- Dimension family: `data`
+- Status: `completed`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Point training at the multi-invocation, shape-aware dagzoo manifest with explicit per-invocation provenance.
+- Rationale: Replace the first single-invocation dagzoo candidate with an explicit shape-aware config ladder so TF-RD-013 can test a broader synthetic-data contract before touching filtering policy.
+- Hypothesis: A broader dagzoo surface that mixes smaller, anchor-scale, and larger-shape generated corpora may better approximate the intended long-term synthetic-data lane and produce a more decisive promoted-anchor read than the first default-config-only comparison.
+- Upstream delta: Not applicable; this is a repo-local synthetic-data generation axis.
+- Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but replace the current corpus with a TF-RD-013 multi-invocation dagzoo manifest assembled from three explicit config-backed generate runs and one merged manifest.
+- Expected effect: Broader synthetic training coverage across small, anchor-scale, and large-shape dagzoo regimes while keeping provenance reviewable.
+- Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_shape_aware_multi_invocation`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.0074`); context (grad `0.0457`)
+- Data overrides: `{}`
+- Parameter adequacy plan:
+  - Compare manifest characteristics against the current-corpus anchor before reading any benchmark outcome.
+  - Name which config-backed dagzoo regimes are present in the merged surface before deciding whether the broader synthetic lane is representative.
+- Adequacy knobs to dimension explicitly:
+  - explicit config ladder coverage across the selected dagzoo shape regimes
+  - per-invocation dataset counts and combined split distribution
+  - manifest-contract deltas versus the anchor and curated comparator
+- Execution policy: `benchmark_full`
+- Interpretation status: `completed`
+- Decision: `defer`
+- Confounders:
+  - Direct nanoTabPFN helper comparison remains partially confounded: the missing-value helper run failed (`helper_failed_on_missing_bundle`), and the historical failure mode was tied to `Fitness_Club` non-finite probabilities.
+- Notes:
+  - Reference-only support bundle: `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/materialization_summary.json` and `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/manifest_characteristics_summary.json`.
+  - Issue 124 remains the later filtering-policy question rather than part of this broader shape-aware follow-up.
+  - Historical execution `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v1` was invalid because manifest-backed training ran through the prior-dump backend.
+  - The completed rerun kept dagzoo deferred: the broader multi-invocation surface still underperformed the anchor on final large-bundle log loss and Brier, so issue 127 does not change the representative-data decision.
+  - Runtime row caps (`train_row_cap=512`, `test_row_cap=256`) keep the larger-shape dagzoo shards inside the current row-attention budget while preserving the broader feature-shape mix in the support bundle.
+  - Supersedes historical queue run `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v1`; that invalid run id is preserved in queue notes only.
+  - Canonical rerun registered as `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/result_card.md`
+- Registered run: `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2` with final log loss `0.4658`, delta final log loss `+0.0443`, final Brier score `0.2979`, delta final Brier score `+0.0335`, best ROC AUC `0.5055`, final ROC AUC `0.5111`, final-minus-best `+0.0056`, delta final ROC AUC `-0.1591`, delta drift `+0.0056`, delta final training time `-2222.5s`
+
+### 2. `delta_data_manifest_curated_realdata_comparator`
+
+- Dimension family: `data`
+- Status: `completed`
+- Binary applicable: `True`
+- Recipe alias: `none`
+- Description: Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations.
+- Rationale: Rerun the curated real-data comparator inside the issue 127 follow-up sweep so the broader dagzoo result is interpreted against a self-contained current-vs-dagzoo-vs-curated comparison package.
+- Hypothesis: The curated comparator should stay OpenML-first and evidence-only, but rerunning it inside the follow-up sweep keeps the broader dagzoo read comparable without reopening any data-loader boundary.
+- Upstream delta: Not applicable; this is a repo-local comparator contract layered on top of the benchmark-native OpenML baseline.
+- Anchor delta: Keep the promoted anchor model, preprocessing, and training recipe fixed, but rerun the curated real-data comparator manifest family as the explicit evidence-only lane beside the broader shape-aware dagzoo candidate.
+- Expected effect: A real-data comparator lane that is explicit enough to compare against current-corpus and dagzoo candidates without reopening loader boundaries.
+- Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_curated_realdata_comparator`, preprocessing=`runtime_default`, training=`prior_linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `1.7357`); context (grad `0.4873`)
+- Data overrides: `{}`
+- Parameter adequacy plan:
+  - Keep the OpenML baseline canonical and cite approved external augmentations only after issue 114 license approval rows exist.
+  - Interpret this row as comparator-surface contract work, not as a new ingestion pathway.
+- Adequacy knobs to dimension explicitly:
+  - Approved ledger rows for every dataset referenced by the comparator manifest family.
+  - OpenML baseline versus approved external augmentation coverage notes.
+  - Manifest lineage and regime-coverage notes attached before any benchmark read is interpreted.
+- Execution policy: `benchmark_full`
+- Interpretation status: `completed`
+- Decision: `defer`
+- Confounders:
+  - Direct nanoTabPFN helper comparison remains partially confounded: the missing-value helper run failed (`helper_failed_on_missing_bundle`), and the historical failure mode was tied to `Fitness_Club` non-finite probabilities.
+- Notes:
+  - This row defines comparator policy only; it does not authorize any dataset outside the review ledger.
+  - The issue 127 follow-up reruns the same OpenML-first comparator lane for same-sweep evidence consistency.
+  - The completed same-sweep comparator remained evidence-only and materially worse than the anchor on final large-bundle log loss and Brier.
+  - Canonical rerun registered as `sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/result_card.md`
+- Registered run: `sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1` with final log loss `2.0849`, delta final log loss `+1.6634`, final Brier score `0.4740`, delta final Brier score `+0.2096`, best ROC AUC `0.5718`, final ROC AUC `0.6002`, final-minus-best `+0.0284`, delta final ROC AUC `-0.0700`, delta drift `+0.0284`, delta final training time `-2221.7s`

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/queue.yaml
@@ -1,0 +1,245 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_013_shape_aware_dagzoo_v1
+rows:
+- order: 1
+  delta_ref: delta_data_manifest_root_dagzoo_shape_aware_multi_invocation
+  status: completed
+  rationale: Replace the first single-invocation dagzoo candidate with an explicit
+    shape-aware config ladder so TF-RD-013 can test a broader synthetic-data contract
+    before touching filtering policy.
+  hypothesis: A broader dagzoo surface that mixes smaller, anchor-scale, and larger-shape
+    generated corpora may better approximate the intended long-term synthetic-data
+    lane and produce a more decisive promoted-anchor read than the first default-config-only
+    comparison.
+  anchor_delta: Keep the promoted anchor model, preprocessing, and training recipe
+    fixed, but replace the current corpus with a TF-RD-013 multi-invocation dagzoo
+    manifest assembled from three explicit config-backed generate runs and one merged
+    manifest.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_shape_aware_multi_invocation
+    source: manifest
+    manifest_path: outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet
+    train_row_cap: 512
+    test_row_cap: 256
+    dagzoo_provenance:
+      corpus_variant: dagzoo_shape_aware_multi_invocation
+      comparator_role: promoted_anchor_candidate
+      commands:
+      - cd "$DAGZOO_ROOT" && uv run dagzoo generate --config configs/benchmark_cpu.yaml
+        --handoff-root "$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu"
+        --num-datasets 2048 --seed 1 --device cpu --hardware-policy none
+      - cd "$DAGZOO_ROOT" && uv run dagzoo generate --config configs/default.yaml
+        --handoff-root "$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium"
+        --num-datasets 4096 --seed 1 --device cpu --hardware-policy none
+      - cd "$DAGZOO_ROOT" && uv run dagzoo generate --config configs/benchmark_cuda_h100_large_shape.yaml
+        --handoff-root "$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape"
+        --num-datasets 128 --seed 1 --device cpu --hardware-policy none
+      - build_manifest(data_roots=[outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated,
+        outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated,
+        outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated],
+        out_path=outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet)
+      config_refs:
+      - configs/benchmark_cpu.yaml
+      - configs/default.yaml
+      - configs/benchmark_cuda_h100_large_shape.yaml
+      curated_root_lineage: []
+      materialization_issue: 127
+      invocations:
+      - invocation_id: benchmark_cpu
+        config_ref: configs/benchmark_cpu.yaml
+        num_datasets: 2048
+      - invocation_id: default_medium
+        config_ref: configs/default.yaml
+        num_datasets: 4096
+      - invocation_id: large_shape
+        config_ref: configs/benchmark_cuda_h100_large_shape.yaml
+        num_datasets: 128
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+    prior_dump_non_finite_policy: skip
+    overrides:
+      apply_schedule: true
+      runtime:
+        max_steps: 2500
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Compare manifest characteristics against the current-corpus anchor before reading
+    any benchmark outcome.
+  - Name which config-backed dagzoo regimes are present in the merged surface before
+    deciding whether the broader synthetic lane is representative.
+  run_id: sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2
+  followup_run_ids: []
+  decision: defer
+  interpretation_status: completed
+  confounders:
+    - >-
+      Direct nanoTabPFN helper comparison remains partially confounded: the
+      missing-value helper run failed (`helper_failed_on_missing_bundle`), and
+      the historical failure mode was tied to `Fitness_Club` non-finite
+      probabilities.
+  next_action: Use this completed issue 127 follow-up to close issue 127, keep dagzoo
+    deferred for issue 96, and record in issue 107 that the current corpus remains
+    the representative post-008 training-data surface.
+  notes:
+  - 'Reference-only support bundle: `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/materialization_summary.json`
+    and `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/manifest_characteristics_summary.json`.'
+  - Issue 124 remains the later filtering-policy question rather than part of this
+    broader shape-aware follow-up.
+  - Historical execution `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v1`
+    was invalid because manifest-backed training ran through the prior-dump backend.
+  - >-
+    The completed rerun kept dagzoo deferred: the broader multi-invocation
+    surface still underperformed the anchor on final large-bundle log loss and
+    Brier, so issue 127 does not change the representative-data decision.
+  - Runtime row caps (`train_row_cap=512`, `test_row_cap=256`) keep the larger-shape
+    dagzoo shards inside the current row-attention budget while preserving the broader
+    feature-shape mix in the support bundle.
+  - Supersedes historical queue run `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v1`;
+    that invalid run id is preserved in queue notes only.
+  - Canonical rerun registered as `sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  benchmark_metrics:
+    best_step: 425
+    max_grad_norm: 521438.09375
+    clipped_step_fraction: 0.12190082644628099
+    best_log_loss: 0.4651157370319072
+    final_log_loss: 0.4658096375835119
+    best_brier_score: 0.29774220485916136
+    final_brier_score: 0.297892304567814
+    best_roc_auc: 0.5054674052031984
+    final_roc_auc: 0.5111004797704289
+    final_minus_best_log_loss: 0.0006939005516047314
+    final_minus_best_brier_score: 0.0001500997086526512
+    final_minus_best_roc_auc: 0.0056330745672305005
+    drift: 0.0056330745672305005
+    delta_final_log_loss: 0.04429907460693272
+    delta_final_brier_score: 0.033515899542441774
+    delta_final_roc_auc: -0.1591237490027304
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.007438347122994204
+    context_encoder_final_window_mean_grad_norm: 0.04565683137719665
+- order: 2
+  delta_ref: delta_data_manifest_curated_realdata_comparator
+  status: completed
+  rationale: Rerun the curated real-data comparator inside the issue 127 follow-up
+    sweep so the broader dagzoo result is interpreted against a self-contained current-vs-dagzoo-vs-curated
+    comparison package.
+  hypothesis: The curated comparator should stay OpenML-first and evidence-only, but
+    rerunning it inside the follow-up sweep keeps the broader dagzoo read comparable
+    without reopening any data-loader boundary.
+  anchor_delta: Keep the promoted anchor model, preprocessing, and training recipe
+    fixed, but rerun the curated real-data comparator manifest family as the explicit
+    evidence-only lane beside the broader shape-aware dagzoo candidate.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_curated_realdata_comparator
+    source: manifest
+    manifest_path: outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet
+    allow_missing_values: true
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_linear_warmup_decay
+    prior_dump_non_finite_policy: skip
+    overrides:
+      apply_schedule: true
+      runtime:
+        max_steps: 2500
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Keep the OpenML baseline canonical and cite approved external augmentations only
+    after issue 114 license approval rows exist.
+  - Interpret this row as comparator-surface contract work, not as a new ingestion
+    pathway.
+  run_id: sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1
+  followup_run_ids: []
+  decision: defer
+  interpretation_status: completed
+  confounders:
+    - >-
+      Direct nanoTabPFN helper comparison remains partially confounded: the
+      missing-value helper run failed (`helper_failed_on_missing_bundle`), and
+      the historical failure mode was tied to `Fitness_Club` non-finite
+      probabilities.
+  next_action: Keep this comparator evidence-only while closing issue 127 and recording
+    the TF-RD-013 defer decision in issues 96 and 107.
+  notes:
+  - This row defines comparator policy only; it does not authorize any dataset outside
+    the review ledger.
+  - The issue 127 follow-up reruns the same OpenML-first comparator lane for same-sweep
+    evidence consistency.
+  - The completed same-sweep comparator remained evidence-only and materially worse
+    than the anchor on final large-bundle log loss and Brier.
+  - Canonical rerun registered as `sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  benchmark_metrics:
+    best_step: 350
+    max_grad_norm: 598.991943359375
+    clipped_step_fraction: 0.5964831096714484
+    best_log_loss: 0.4643251538089226
+    final_log_loss: 2.0848704383580317
+    best_brier_score: 0.2948501439273162
+    final_brier_score: 0.47401873911604775
+    best_roc_auc: 0.5717753445115897
+    final_roc_auc: 0.6001862187999685
+    final_minus_best_log_loss: 1.620545284549109
+    final_minus_best_brier_score: 0.17916859518873157
+    final_minus_best_roc_auc: 0.02841087428837874
+    drift: 0.02841087428837874
+    delta_final_log_loss: 1.6633598753814525
+    delta_final_brier_score: 0.2096423340906755
+    delta_final_roc_auc: -0.07003800997319087
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 1.7357222295506252
+    context_encoder_final_window_mean_grad_norm: 0.48731876593441475

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md
@@ -1,0 +1,43 @@
+# TF-RD-013 Shape-Aware Support Bundle
+
+This directory is the committed reference-only support bundle for issue `#127`.
+
+The canonical local regeneration flow is:
+
+```bash
+.venv/bin/python scripts/materialize_tf_rd_013_support.py --variant shape-aware --force
+```
+
+Environment assumptions:
+
+- `TAB_FOUNDRY_ROOT` is this repo root.
+- `DAGZOO_ROOT` defaults to the sibling checkout `../dagzoo`.
+- The broader dagzoo follow-up uses three config-backed invocations:
+  - `../dagzoo/configs/benchmark_cpu.yaml` with `2048` datasets
+  - `../dagzoo/configs/default.yaml` with `4096` datasets
+  - `../dagzoo/configs/benchmark_cuda_h100_large_shape.yaml` with `128` datasets
+- The curated comparator baseline remains pinned to `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`.
+
+What the script does for this variant:
+
+- materializes three explicit dagzoo generate runs under `outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/`
+- keeps each invocation's handoff manifest and identity separate for provenance review
+- assembles one merged dagzoo manifest with `build_manifest(data_roots=[...])` and no single-handoff manifest metadata
+- exports one OpenML-only curated comparator corpus under the same local support root
+- writes tracked JSON summaries for the shape-aware dagzoo surface and the curated comparator surface
+
+Committed files:
+
+- `materialization_summary.json`: shape-program notes, per-invocation handoff summaries, merged-manifest assembly details, and curated comparator provenance.
+- `manifest_characteristics_summary.json`: `anchor vs shape-aware dagzoo`, `anchor vs curated`, and `shape-aware dagzoo vs curated` manifest comparisons.
+
+Local-only files:
+
+- Generated dagzoo shards, curated OpenML packed shards, and local manifests live under `outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/`.
+- `outputs/` stays ignored because the dagzoo artifacts are too large to commit as repo-tracked fixtures.
+
+Policy notes:
+
+- This bundle is the issue `#127` follow-up to the neutral first promoted-anchor TF-RD-013 read from issue `#122`.
+- The broader dagzoo read is still about synthetic-data coverage, not filtering policy; issue `#124` remains a later question only if the shape-aware result exposes a specific predictability problem.
+- The curated comparator remains OpenML-first and evidence-only unless later approved augmentations are explicitly justified.

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/manifest_characteristics_summary.json
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/manifest_characteristics_summary.json
@@ -1,0 +1,632 @@
+{
+  "comparisons": {
+    "anchor_vs_curated_realdata_openml_baseline": {
+      "comparison_id": "anchor_vs_curated_realdata_openml_baseline",
+      "difference_count": 29,
+      "differences": {
+        "classification_n_classes.histogram.10": {
+          "left": 2,
+          "right": null
+        },
+        "classification_n_classes.histogram.2": {
+          "left": null,
+          "right": 12
+        },
+        "classification_n_classes.histogram.3": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.4": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.5": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.7": {
+          "left": 4,
+          "right": null
+        },
+        "classification_n_classes.histogram.9": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.max": {
+          "left": 10,
+          "right": 2
+        },
+        "classification_n_classes.min": {
+          "left": 3,
+          "right": 2
+        },
+        "filter_status_counts.missing": {
+          "left": 10,
+          "right": null
+        },
+        "filter_status_counts.not_run": {
+          "left": null,
+          "right": 12
+        },
+        "missing_value_status_counts.clean": {
+          "left": null,
+          "right": 11
+        },
+        "missing_value_status_counts.contains_nan_or_inf": {
+          "left": null,
+          "right": 1
+        },
+        "missing_value_status_counts.missing": {
+          "left": 10,
+          "right": null
+        },
+        "n_features.max": {
+          "left": 63,
+          "right": 19
+        },
+        "n_features.min": {
+          "left": 27,
+          "right": 4
+        },
+        "persisted_summary": {
+          "left": null,
+          "right": {
+            "discovered_records": 12,
+            "excluded_for_missing_values": 0,
+            "excluded_records": 0,
+            "filter_policy": "include_all",
+            "filter_status_counts": {
+              "not_run": 12
+            },
+            "missing_value_policy": "allow_any",
+            "missing_value_status_counts": {
+              "clean": 11,
+              "contains_nan_or_inf": 1
+            },
+            "test_records": 1,
+            "total_records": 12,
+            "train_records": 11,
+            "val_records": 0
+          }
+        },
+        "split_counts.train": {
+          "left": 8,
+          "right": 11
+        },
+        "split_counts.val": {
+          "left": 1,
+          "right": null
+        },
+        "task_counts.classification": {
+          "left": 10,
+          "right": 12
+        },
+        "task_missing_value_status_counts.classification.clean": {
+          "left": null,
+          "right": 11
+        },
+        "task_missing_value_status_counts.classification.contains_nan_or_inf": {
+          "left": null,
+          "right": 1
+        },
+        "task_missing_value_status_counts.classification.missing": {
+          "left": 10,
+          "right": null
+        },
+        "task_split_counts.classification.train": {
+          "left": 8,
+          "right": 11
+        },
+        "task_split_counts.classification.val": {
+          "left": 1,
+          "right": null
+        },
+        "task_train_test_record_counts.classification": {
+          "left": null,
+          "right": {
+            "test": 12,
+            "train": 12
+          }
+        },
+        "total_records": {
+          "left": 10,
+          "right": 12
+        },
+        "unique_dataset_id_count": {
+          "left": 10,
+          "right": 12
+        },
+        "unique_source_root_count": {
+          "left": 0,
+          "right": 1
+        }
+      },
+      "left_manifest_id": "anchor_manifest_default",
+      "left_manifest_path": "data/manifests/default.parquet",
+      "right_manifest_id": "curated_realdata_openml_baseline",
+      "right_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "status": "available"
+    },
+    "anchor_vs_dagzoo_shape_aware_multi_invocation": {
+      "comparison_id": "anchor_vs_dagzoo_shape_aware_multi_invocation",
+      "difference_count": 29,
+      "differences": {
+        "classification_n_classes.histogram.10": {
+          "left": 2,
+          "right": null
+        },
+        "classification_n_classes.histogram.2": {
+          "left": null,
+          "right": 6272
+        },
+        "classification_n_classes.histogram.3": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.4": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.5": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.histogram.7": {
+          "left": 4,
+          "right": null
+        },
+        "classification_n_classes.histogram.9": {
+          "left": 1,
+          "right": null
+        },
+        "classification_n_classes.max": {
+          "left": 10,
+          "right": 2
+        },
+        "classification_n_classes.min": {
+          "left": 3,
+          "right": 2
+        },
+        "filter_status_counts.missing": {
+          "left": 10,
+          "right": null
+        },
+        "filter_status_counts.not_run": {
+          "left": null,
+          "right": 6272
+        },
+        "missing_value_status_counts.clean": {
+          "left": null,
+          "right": 6272
+        },
+        "missing_value_status_counts.missing": {
+          "left": 10,
+          "right": null
+        },
+        "n_features.max": {
+          "left": 63,
+          "right": 146
+        },
+        "n_features.min": {
+          "left": 27,
+          "right": 23
+        },
+        "persisted_summary": {
+          "left": null,
+          "right": {
+            "discovered_records": 6272,
+            "excluded_for_missing_values": 0,
+            "excluded_records": 0,
+            "filter_policy": "include_all",
+            "filter_status_counts": {
+              "not_run": 6272
+            },
+            "missing_value_policy": "allow_any",
+            "missing_value_status_counts": {
+              "clean": 6272
+            },
+            "test_records": 340,
+            "total_records": 6272,
+            "train_records": 5596,
+            "val_records": 336
+          }
+        },
+        "split_counts.test": {
+          "left": 1,
+          "right": 340
+        },
+        "split_counts.train": {
+          "left": 8,
+          "right": 5596
+        },
+        "split_counts.val": {
+          "left": 1,
+          "right": 336
+        },
+        "task_counts.classification": {
+          "left": 10,
+          "right": 6272
+        },
+        "task_missing_value_status_counts.classification.clean": {
+          "left": null,
+          "right": 6272
+        },
+        "task_missing_value_status_counts.classification.missing": {
+          "left": 10,
+          "right": null
+        },
+        "task_split_counts.classification.test": {
+          "left": 1,
+          "right": 340
+        },
+        "task_split_counts.classification.train": {
+          "left": 8,
+          "right": 5596
+        },
+        "task_split_counts.classification.val": {
+          "left": 1,
+          "right": 336
+        },
+        "task_train_test_record_counts.classification": {
+          "left": null,
+          "right": {
+            "test": 6272,
+            "train": 6272
+          }
+        },
+        "total_records": {
+          "left": 10,
+          "right": 6272
+        },
+        "unique_dataset_id_count": {
+          "left": 10,
+          "right": 6272
+        },
+        "unique_source_root_count": {
+          "left": 0,
+          "right": 3
+        }
+      },
+      "left_manifest_id": "anchor_manifest_default",
+      "left_manifest_path": "data/manifests/default.parquet",
+      "right_manifest_id": "dagzoo_shape_aware_multi_invocation",
+      "right_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+      "status": "available"
+    },
+    "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline": {
+      "comparison_id": "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline",
+      "difference_count": 28,
+      "differences": {
+        "classification_n_classes.histogram.2": {
+          "left": 6272,
+          "right": 12
+        },
+        "filter_status_counts.not_run": {
+          "left": 6272,
+          "right": 12
+        },
+        "missing_value_status_counts.clean": {
+          "left": 6272,
+          "right": 11
+        },
+        "missing_value_status_counts.contains_nan_or_inf": {
+          "left": null,
+          "right": 1
+        },
+        "n_features.max": {
+          "left": 146,
+          "right": 19
+        },
+        "n_features.min": {
+          "left": 23,
+          "right": 4
+        },
+        "persisted_summary.discovered_records": {
+          "left": 6272,
+          "right": 12
+        },
+        "persisted_summary.filter_status_counts.not_run": {
+          "left": 6272,
+          "right": 12
+        },
+        "persisted_summary.missing_value_status_counts.clean": {
+          "left": 6272,
+          "right": 11
+        },
+        "persisted_summary.missing_value_status_counts.contains_nan_or_inf": {
+          "left": null,
+          "right": 1
+        },
+        "persisted_summary.test_records": {
+          "left": 340,
+          "right": 1
+        },
+        "persisted_summary.total_records": {
+          "left": 6272,
+          "right": 12
+        },
+        "persisted_summary.train_records": {
+          "left": 5596,
+          "right": 11
+        },
+        "persisted_summary.val_records": {
+          "left": 336,
+          "right": 0
+        },
+        "split_counts.test": {
+          "left": 340,
+          "right": 1
+        },
+        "split_counts.train": {
+          "left": 5596,
+          "right": 11
+        },
+        "split_counts.val": {
+          "left": 336,
+          "right": null
+        },
+        "task_counts.classification": {
+          "left": 6272,
+          "right": 12
+        },
+        "task_missing_value_status_counts.classification.clean": {
+          "left": 6272,
+          "right": 11
+        },
+        "task_missing_value_status_counts.classification.contains_nan_or_inf": {
+          "left": null,
+          "right": 1
+        },
+        "task_split_counts.classification.test": {
+          "left": 340,
+          "right": 1
+        },
+        "task_split_counts.classification.train": {
+          "left": 5596,
+          "right": 11
+        },
+        "task_split_counts.classification.val": {
+          "left": 336,
+          "right": null
+        },
+        "task_train_test_record_counts.classification.test": {
+          "left": 6272,
+          "right": 12
+        },
+        "task_train_test_record_counts.classification.train": {
+          "left": 6272,
+          "right": 12
+        },
+        "total_records": {
+          "left": 6272,
+          "right": 12
+        },
+        "unique_dataset_id_count": {
+          "left": 6272,
+          "right": 12
+        },
+        "unique_source_root_count": {
+          "left": 3,
+          "right": 1
+        }
+      },
+      "left_manifest_id": "dagzoo_shape_aware_multi_invocation",
+      "left_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+      "right_manifest_id": "curated_realdata_openml_baseline",
+      "right_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "status": "available"
+    }
+  },
+  "generated_at_utc": "2026-03-23T04:11:13Z",
+  "issues": {
+    "downstream_training_surface_issue": 107,
+    "epic_issue": 96,
+    "execution_issue": 127,
+    "materialization_issue": 127,
+    "subsequent_filtering_policy_issue": 124
+  },
+  "manifests": {
+    "anchor_manifest_default": {
+      "inspection": {
+        "classification_n_classes": {
+          "histogram": {
+            "10": 2,
+            "3": 1,
+            "4": 1,
+            "5": 1,
+            "7": 4,
+            "9": 1
+          },
+          "max": 10,
+          "min": 3
+        },
+        "compatibility": null,
+        "filter_status_counts": {
+          "missing": 10
+        },
+        "manifest_path": "data/manifests/default.parquet",
+        "missing_value_status_counts": {
+          "missing": 10
+        },
+        "n_features": {
+          "max": 63,
+          "min": 27
+        },
+        "persisted_summary": null,
+        "split_counts": {
+          "test": 1,
+          "train": 8,
+          "val": 1
+        },
+        "task_counts": {
+          "classification": 10
+        },
+        "task_missing_value_status_counts": {
+          "classification": {
+            "missing": 10
+          }
+        },
+        "task_split_counts": {
+          "classification": {
+            "test": 1,
+            "train": 8,
+            "val": 1
+          }
+        },
+        "task_train_test_record_counts": {},
+        "total_records": 10,
+        "unique_dataset_id_count": 10,
+        "unique_source_root_count": 0
+      },
+      "manifest_path": "data/manifests/default.parquet",
+      "manifest_sha256": "8c56d33a87e6523bccac8dcddb92b075499952e3c0afbcf756b68c7b0e5b3f44",
+      "status": "available"
+    },
+    "curated_realdata_openml_baseline": {
+      "inspection": {
+        "classification_n_classes": {
+          "histogram": {
+            "2": 12
+          },
+          "max": 2,
+          "min": 2
+        },
+        "compatibility": null,
+        "filter_status_counts": {
+          "not_run": 12
+        },
+        "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+        "missing_value_status_counts": {
+          "clean": 11,
+          "contains_nan_or_inf": 1
+        },
+        "n_features": {
+          "max": 19,
+          "min": 4
+        },
+        "persisted_summary": {
+          "discovered_records": 12,
+          "excluded_for_missing_values": 0,
+          "excluded_records": 0,
+          "filter_policy": "include_all",
+          "filter_status_counts": {
+            "not_run": 12
+          },
+          "missing_value_policy": "allow_any",
+          "missing_value_status_counts": {
+            "clean": 11,
+            "contains_nan_or_inf": 1
+          },
+          "test_records": 1,
+          "total_records": 12,
+          "train_records": 11,
+          "val_records": 0
+        },
+        "split_counts": {
+          "test": 1,
+          "train": 11
+        },
+        "task_counts": {
+          "classification": 12
+        },
+        "task_missing_value_status_counts": {
+          "classification": {
+            "clean": 11,
+            "contains_nan_or_inf": 1
+          }
+        },
+        "task_split_counts": {
+          "classification": {
+            "test": 1,
+            "train": 11
+          }
+        },
+        "task_train_test_record_counts": {
+          "classification": {
+            "test": 12,
+            "train": 12
+          }
+        },
+        "total_records": 12,
+        "unique_dataset_id_count": 12,
+        "unique_source_root_count": 1
+      },
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "manifest_sha256": "0e4bd40328d6df0f03836bfb3433159963eb1651a0f92f4df1acfc9ac4c95b97",
+      "status": "available"
+    },
+    "dagzoo_shape_aware_multi_invocation": {
+      "inspection": {
+        "classification_n_classes": {
+          "histogram": {
+            "2": 6272
+          },
+          "max": 2,
+          "min": 2
+        },
+        "compatibility": null,
+        "filter_status_counts": {
+          "not_run": 6272
+        },
+        "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+        "missing_value_status_counts": {
+          "clean": 6272
+        },
+        "n_features": {
+          "max": 146,
+          "min": 23
+        },
+        "persisted_summary": {
+          "discovered_records": 6272,
+          "excluded_for_missing_values": 0,
+          "excluded_records": 0,
+          "filter_policy": "include_all",
+          "filter_status_counts": {
+            "not_run": 6272
+          },
+          "missing_value_policy": "allow_any",
+          "missing_value_status_counts": {
+            "clean": 6272
+          },
+          "test_records": 340,
+          "total_records": 6272,
+          "train_records": 5596,
+          "val_records": 336
+        },
+        "split_counts": {
+          "test": 340,
+          "train": 5596,
+          "val": 336
+        },
+        "task_counts": {
+          "classification": 6272
+        },
+        "task_missing_value_status_counts": {
+          "classification": {
+            "clean": 6272
+          }
+        },
+        "task_split_counts": {
+          "classification": {
+            "test": 340,
+            "train": 5596,
+            "val": 336
+          }
+        },
+        "task_train_test_record_counts": {
+          "classification": {
+            "test": 6272,
+            "train": 6272
+          }
+        },
+        "total_records": 6272,
+        "unique_dataset_id_count": 6272,
+        "unique_source_root_count": 3
+      },
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+      "manifest_sha256": "8099cde14b8ac2d3831247fc1f85a115e699f5508064bbf6ac06122a1e98079b",
+      "status": "available"
+    }
+  },
+  "schema": "tab-foundry-tf-rd-013-shape-aware-manifest-characteristics-summary-v1"
+}

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/materialization_summary.json
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/materialization_summary.json
@@ -1,0 +1,634 @@
+{
+  "artifacts": {
+    "curated_openml_baseline_data_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards",
+    "curated_openml_baseline_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+    "curated_openml_baseline_manifest_sha256": "0e4bd40328d6df0f03836bfb3433159963eb1651a0f92f4df1acfc9ac4c95b97",
+    "curated_openml_baseline_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline",
+    "dagzoo_shape_aware_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+    "dagzoo_shape_aware_manifest_sha256": "8099cde14b8ac2d3831247fc1f85a115e699f5508064bbf6ac06122a1e98079b",
+    "dagzoo_shape_aware_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation",
+    "local_output_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1"
+  },
+  "assembly": {
+    "combined_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+    "combined_manifest_sha256": "8099cde14b8ac2d3831247fc1f85a115e699f5508064bbf6ac06122a1e98079b",
+    "input_roots": [
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated",
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated",
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated"
+    ],
+    "invocation_count": 3,
+    "notes": [
+      "Each invocation keeps its own handoff manifest and identity record.",
+      "The follow-up sweep trains against one merged manifest that combines all generated roots."
+    ],
+    "persisted_summary": {
+      "discovered_records": 6272,
+      "excluded_for_missing_values": 0,
+      "excluded_records": 0,
+      "filter_policy": "include_all",
+      "filter_status_counts": {
+        "not_run": 6272
+      },
+      "missing_value_policy": "allow_any",
+      "missing_value_status_counts": {
+        "clean": 6272
+      },
+      "test_records": 340,
+      "total_records": 6272,
+      "train_records": 5596,
+      "val_records": 336
+    }
+  },
+  "config_refs": {
+    "benchmark_bundle": [
+      "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json"
+    ],
+    "dagzoo": [
+      "configs/benchmark_cpu.yaml",
+      "configs/default.yaml",
+      "configs/benchmark_cuda_h100_large_shape.yaml"
+    ],
+    "tab_foundry": [
+      "configs/data/default.yaml"
+    ]
+  },
+  "env_hints": {
+    "dagzoo_root": "../dagzoo",
+    "tab_foundry_root": "."
+  },
+  "generated_at_utc": "2026-03-23T04:11:13Z",
+  "issues": {
+    "downstream_training_surface_issue": 107,
+    "downstream_training_surface_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/107",
+    "epic_issue": 96,
+    "epic_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/96",
+    "execution_issue": 127,
+    "execution_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/127",
+    "materialization_issue": 127,
+    "materialization_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/127",
+    "subsequent_filtering_policy_issue": 124,
+    "subsequent_filtering_policy_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/124"
+  },
+  "schema": "tab-foundry-tf-rd-013-shape-aware-materialization-summary-v1",
+  "shape_program": {
+    "assembly_policy": "build_manifest(data_roots=[...]) without dagzoo_handoff_manifest_path",
+    "input_roots": [
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated",
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated",
+      "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated"
+    ],
+    "invocation_ids": [
+      "benchmark_cpu",
+      "default_medium",
+      "large_shape"
+    ],
+    "kind": "config_ladder",
+    "notes": [
+      "The broader dagzoo follow-up uses three explicit config-backed invocations rather than a single default-config generate run.",
+      "The combined manifest intentionally omits single-handoff manifest metadata so the multi-invocation surface stays schema-stable.",
+      "Keep filtering policy out of this follow-up; issue 124 remains a later decision only if the broader read shows a predictability problem."
+    ]
+  },
+  "steps": [
+    {
+      "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cpu.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu\" --num-datasets 2048 --seed 1 --device cpu --hardware-policy none",
+      "cwd": "$DAGZOO_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "dagzoo_generate_benchmark_cpu"
+    },
+    {
+      "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/default.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium\" --num-datasets 4096 --seed 1 --device cpu --hardware-policy none",
+      "cwd": "$DAGZOO_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "dagzoo_generate_default_medium"
+    },
+    {
+      "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cuda_h100_large_shape.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape\" --num-datasets 128 --seed 1 --device cpu --hardware-policy none",
+      "cwd": "$DAGZOO_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "dagzoo_generate_large_shape"
+    },
+    {
+      "command": "build_manifest(data_roots=[outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated, outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated, outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated], out_path=outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet)",
+      "cwd": "$TAB_FOUNDRY_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "build_manifest_dagzoo_shape_aware_multi_invocation"
+    },
+    {
+      "command": "cd \"$TAB_FOUNDRY_ROOT\" && ./.venv/bin/python scripts/materialize_tf_rd_013_support.py --variant shape-aware --force",
+      "cwd": "$TAB_FOUNDRY_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "prepare_openml_baseline_shards"
+    },
+    {
+      "command": "cd \"$TAB_FOUNDRY_ROOT\" && ./.venv/bin/tab-foundry data build-manifest --data-root outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards --out-manifest outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "cwd": "$TAB_FOUNDRY_ROOT",
+      "returncode": 0,
+      "status": "completed",
+      "step_id": "build_manifest_curated_realdata_openml_baseline"
+    }
+  ],
+  "surfaces": {
+    "curated_realdata_openml_baseline": {
+      "curated_realdata_provenance": {
+        "approved_external_augmentations": [],
+        "benchmark_bundle": {
+          "all_tasks_no_missing": false,
+          "allow_missing_values": true,
+          "name": "nanotabpfn_openml_binary_large",
+          "selection": {
+            "max_classes": 2,
+            "max_features": 20,
+            "max_missing_pct": 5.0,
+            "min_minority_class_pct": 2.5,
+            "new_instances": 200,
+            "task_type": "supervised_classification"
+          },
+          "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json",
+          "task_count": 12,
+          "task_ids": [
+            363613,
+            363618,
+            363619,
+            363621,
+            363623,
+            363629,
+            363632,
+            363671,
+            363679,
+            363682,
+            363691,
+            363700
+          ],
+          "version": 1
+        },
+        "commands": [
+          "cd \"$TAB_FOUNDRY_ROOT\" && ./.venv/bin/python scripts/materialize_tf_rd_013_support.py --variant shape-aware --force",
+          "cd \"$TAB_FOUNDRY_ROOT\" && ./.venv/bin/tab-foundry data build-manifest --data-root outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards --out-manifest outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet"
+        ],
+        "comparator_role": "evidence_only_openml_baseline",
+        "dataset_names": [
+          "Amazon_employee_access",
+          "bank-marketing",
+          "Bank_Customer_Churn",
+          "blood-transfusion-service-center",
+          "churn",
+          "diabetes",
+          "E-CommereShippingData",
+          "Fitness_Club",
+          "HR_Analytics_Job_Change_of_Data_Scientists",
+          "Is-this-a-good-customer",
+          "online_shoppers_intention",
+          "seismic-bumps"
+        ],
+        "execution_issue": 127,
+        "split_policy": {
+          "fallback_mode": "unstratified_fallback",
+          "name": "deterministic_holdout",
+          "preferred_mode": "stratified",
+          "seed": 0,
+          "test_size": 0.2
+        },
+        "surface_variant": "curated_realdata_openml_baseline",
+        "task_ids": [
+          363613,
+          363618,
+          363619,
+          363621,
+          363623,
+          363629,
+          363632,
+          363671,
+          363679,
+          363682,
+          363691,
+          363700
+        ],
+        "task_summaries": [
+          {
+            "dataset_name": "Amazon_employee_access",
+            "n_classes": 2,
+            "n_features": 9,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00001_amazon_employee_access",
+            "split_mode": "stratified",
+            "task_id": 363613
+          },
+          {
+            "dataset_name": "bank-marketing",
+            "n_classes": 2,
+            "n_features": 13,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00002_bank_marketing",
+            "split_mode": "stratified",
+            "task_id": 363618
+          },
+          {
+            "dataset_name": "Bank_Customer_Churn",
+            "n_classes": 2,
+            "n_features": 10,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00003_bank_customer_churn",
+            "split_mode": "stratified",
+            "task_id": 363619
+          },
+          {
+            "dataset_name": "blood-transfusion-service-center",
+            "n_classes": 2,
+            "n_features": 4,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00004_blood_transfusion_service_center",
+            "split_mode": "stratified",
+            "task_id": 363621
+          },
+          {
+            "dataset_name": "churn",
+            "n_classes": 2,
+            "n_features": 19,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00005_churn",
+            "split_mode": "stratified",
+            "task_id": 363623
+          },
+          {
+            "dataset_name": "diabetes",
+            "n_classes": 2,
+            "n_features": 8,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00006_diabetes",
+            "split_mode": "stratified",
+            "task_id": 363629
+          },
+          {
+            "dataset_name": "E-CommereShippingData",
+            "n_classes": 2,
+            "n_features": 10,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00007_e_commereshippingdata",
+            "split_mode": "stratified",
+            "task_id": 363632
+          },
+          {
+            "dataset_name": "Fitness_Club",
+            "n_classes": 2,
+            "n_features": 6,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00008_fitness_club",
+            "split_mode": "stratified",
+            "task_id": 363671
+          },
+          {
+            "dataset_name": "HR_Analytics_Job_Change_of_Data_Scientists",
+            "n_classes": 2,
+            "n_features": 12,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00009_hr_analytics_job_change_of_data_scientists",
+            "split_mode": "stratified",
+            "task_id": 363679
+          },
+          {
+            "dataset_name": "Is-this-a-good-customer",
+            "n_classes": 2,
+            "n_features": 13,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00010_is_this_a_good_customer",
+            "split_mode": "stratified",
+            "task_id": 363682
+          },
+          {
+            "dataset_name": "online_shoppers_intention",
+            "n_classes": 2,
+            "n_features": 17,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00011_online_shoppers_intention",
+            "split_mode": "stratified",
+            "task_id": 363691
+          },
+          {
+            "dataset_name": "seismic-bumps",
+            "n_classes": 2,
+            "n_features": 15,
+            "n_rows": 200,
+            "n_test": 40,
+            "n_train": 160,
+            "shard_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/packed_shards/shard_00012_seismic_bumps",
+            "split_mode": "stratified",
+            "task_id": 363700
+          }
+        ]
+      },
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "manifest_sha256": "0e4bd40328d6df0f03836bfb3433159963eb1651a0f92f4df1acfc9ac4c95b97",
+      "state": "materialized_local_only"
+    },
+    "dagzoo_shape_aware_multi_invocation": {
+      "dagzoo_provenance": {
+        "commands": [
+          "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cpu.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu\" --num-datasets 2048 --seed 1 --device cpu --hardware-policy none",
+          "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/default.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium\" --num-datasets 4096 --seed 1 --device cpu --hardware-policy none",
+          "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cuda_h100_large_shape.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape\" --num-datasets 128 --seed 1 --device cpu --hardware-policy none",
+          "build_manifest(data_roots=[outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated, outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated, outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated], out_path=outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet)"
+        ],
+        "comparator_role": "promoted_anchor_candidate",
+        "config_refs": [
+          "configs/benchmark_cpu.yaml",
+          "configs/default.yaml",
+          "configs/benchmark_cuda_h100_large_shape.yaml"
+        ],
+        "corpus_variant": "dagzoo_shape_aware_multi_invocation",
+        "curated_root_lineage": [],
+        "invocations": [
+          {
+            "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cpu.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu\" --num-datasets 2048 --seed 1 --device cpu --hardware-policy none",
+            "config_ref": "configs/benchmark_cpu.yaml",
+            "device": "cpu",
+            "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated",
+            "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/handoff_manifest.json",
+            "handoff_manifest_sha256": "32316476bcf5f68252f0357a7c00066a246c2900fd690f7f3a19e3b6f150c4c6",
+            "hardware_policy": "none",
+            "identity": {
+              "generate_run_id": "ce57625bef61e4ec1778610bf413838b",
+              "generated_corpus_id": "fe6aa1e7ceecc560f74af2f1b5ab36c6",
+              "source_family": "dagzoo.fixed_layout_scm"
+            },
+            "invocation_id": "benchmark_cpu",
+            "num_datasets": 2048,
+            "seed": 1,
+            "summary": {
+              "generated_datasets": 2048
+            }
+          },
+          {
+            "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/default.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium\" --num-datasets 4096 --seed 1 --device cpu --hardware-policy none",
+            "config_ref": "configs/default.yaml",
+            "device": "cpu",
+            "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated",
+            "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/handoff_manifest.json",
+            "handoff_manifest_sha256": "373e0609c4112d82590f90df38d67bb762c5c71c8b86225004a6d61b5cb24bec",
+            "hardware_policy": "none",
+            "identity": {
+              "generate_run_id": "d5124ed9614213e36449594149186251",
+              "generated_corpus_id": "ab63f162c4d180ec114659ba30436467",
+              "source_family": "dagzoo.fixed_layout_scm"
+            },
+            "invocation_id": "default_medium",
+            "num_datasets": 4096,
+            "seed": 1,
+            "summary": {
+              "generated_datasets": 4096
+            }
+          },
+          {
+            "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cuda_h100_large_shape.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape\" --num-datasets 128 --seed 1 --device cpu --hardware-policy none",
+            "config_ref": "configs/benchmark_cuda_h100_large_shape.yaml",
+            "device": "cpu",
+            "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated",
+            "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/handoff_manifest.json",
+            "handoff_manifest_sha256": "fb4b944c2acfed52e4e5ecdab769f5cf5d93f18a7f0ac0c609af350e94dd47a8",
+            "hardware_policy": "none",
+            "identity": {
+              "generate_run_id": "79b34914332fa3714ab65df0c41ef67b",
+              "generated_corpus_id": "23b89aefc0780e32418a8a1a438de059",
+              "source_family": "dagzoo.fixed_layout_scm"
+            },
+            "invocation_id": "large_shape",
+            "num_datasets": 128,
+            "seed": 1,
+            "summary": {
+              "generated_datasets": 128
+            }
+          }
+        ],
+        "materialization_issue": 127
+      },
+      "invocation_handoffs": [
+        {
+          "artifacts_relative": {
+            "effective_config_path": "generated/effective_config.yaml",
+            "effective_config_trace_path": "generated/effective_config_trace.yaml",
+            "generated_dir": "generated",
+            "run_root": "."
+          },
+          "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cpu.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu\" --num-datasets 2048 --seed 1 --device cpu --hardware-policy none",
+          "config_ref": "configs/benchmark_cpu.yaml",
+          "defaults": {
+            "curation_policy": "none",
+            "recommended_training_artifact_key": "generated_dir",
+            "recommended_training_corpus": "generated"
+          },
+          "device": "cpu",
+          "generate_invocation": {
+            "config_path": "../dagzoo/configs/benchmark_cpu.yaml",
+            "overrides": {
+              "device": "cpu",
+              "diagnostics": false,
+              "diagnostics_out_dir": null,
+              "handoff_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu",
+              "hardware_policy": "none",
+              "missing_mar_logit_scale": null,
+              "missing_mar_observed_fraction": null,
+              "missing_mechanism": null,
+              "missing_mnar_logit_scale": null,
+              "missing_rate": null,
+              "num_datasets": 2048,
+              "rows": null,
+              "seed": 1
+            }
+          },
+          "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/generated",
+          "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu/handoff_manifest.json",
+          "handoff_manifest_sha256": "32316476bcf5f68252f0357a7c00066a246c2900fd690f7f3a19e3b6f150c4c6",
+          "hardware": {
+            "backend": "cpu",
+            "device_name": "cpu",
+            "hardware_policy": "none",
+            "requested_device": "cpu",
+            "resolved_device": "cpu",
+            "tier": "cpu"
+          },
+          "hardware_policy": "none",
+          "identity": {
+            "generate_run_id": "ce57625bef61e4ec1778610bf413838b",
+            "generated_corpus_id": "fe6aa1e7ceecc560f74af2f1b5ab36c6",
+            "source_family": "dagzoo.fixed_layout_scm"
+          },
+          "invocation_id": "benchmark_cpu",
+          "invocation_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/benchmark_cpu",
+          "num_datasets": 2048,
+          "seed": 1,
+          "summary": {
+            "generated_datasets": 2048
+          },
+          "throughput": {
+            "generation_stage": {
+              "datasets_per_minute": 3269.618312415827,
+              "elapsed_seconds": 37.58236841694452,
+              "generated_datasets": 2048
+            }
+          }
+        },
+        {
+          "artifacts_relative": {
+            "effective_config_path": "generated/effective_config.yaml",
+            "effective_config_trace_path": "generated/effective_config_trace.yaml",
+            "generated_dir": "generated",
+            "run_root": "."
+          },
+          "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/default.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium\" --num-datasets 4096 --seed 1 --device cpu --hardware-policy none",
+          "config_ref": "configs/default.yaml",
+          "defaults": {
+            "curation_policy": "none",
+            "recommended_training_artifact_key": "generated_dir",
+            "recommended_training_corpus": "generated"
+          },
+          "device": "cpu",
+          "generate_invocation": {
+            "config_path": "../dagzoo/configs/default.yaml",
+            "overrides": {
+              "device": "cpu",
+              "diagnostics": false,
+              "diagnostics_out_dir": null,
+              "handoff_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium",
+              "hardware_policy": "none",
+              "missing_mar_logit_scale": null,
+              "missing_mar_observed_fraction": null,
+              "missing_mechanism": null,
+              "missing_mnar_logit_scale": null,
+              "missing_rate": null,
+              "num_datasets": 4096,
+              "rows": null,
+              "seed": 1
+            }
+          },
+          "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/generated",
+          "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium/handoff_manifest.json",
+          "handoff_manifest_sha256": "373e0609c4112d82590f90df38d67bb762c5c71c8b86225004a6d61b5cb24bec",
+          "hardware": {
+            "backend": "cpu",
+            "device_name": "cpu",
+            "hardware_policy": "none",
+            "requested_device": "cpu",
+            "resolved_device": "cpu",
+            "tier": "cpu"
+          },
+          "hardware_policy": "none",
+          "identity": {
+            "generate_run_id": "d5124ed9614213e36449594149186251",
+            "generated_corpus_id": "ab63f162c4d180ec114659ba30436467",
+            "source_family": "dagzoo.fixed_layout_scm"
+          },
+          "invocation_id": "default_medium",
+          "invocation_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/default_medium",
+          "num_datasets": 4096,
+          "seed": 1,
+          "summary": {
+            "generated_datasets": 4096
+          },
+          "throughput": {
+            "generation_stage": {
+              "datasets_per_minute": 3659.906156655567,
+              "elapsed_seconds": 67.14926270802971,
+              "generated_datasets": 4096
+            }
+          }
+        },
+        {
+          "artifacts_relative": {
+            "effective_config_path": "generated/effective_config.yaml",
+            "effective_config_trace_path": "generated/effective_config_trace.yaml",
+            "generated_dir": "generated",
+            "run_root": "."
+          },
+          "command": "cd \"$DAGZOO_ROOT\" && uv run dagzoo generate --config configs/benchmark_cuda_h100_large_shape.yaml --handoff-root \"$TAB_FOUNDRY_ROOT/outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape\" --num-datasets 128 --seed 1 --device cpu --hardware-policy none",
+          "config_ref": "configs/benchmark_cuda_h100_large_shape.yaml",
+          "defaults": {
+            "curation_policy": "none",
+            "recommended_training_artifact_key": "generated_dir",
+            "recommended_training_corpus": "generated"
+          },
+          "device": "cpu",
+          "generate_invocation": {
+            "config_path": "../dagzoo/configs/benchmark_cuda_h100_large_shape.yaml",
+            "overrides": {
+              "device": "cpu",
+              "diagnostics": false,
+              "diagnostics_out_dir": null,
+              "handoff_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape",
+              "hardware_policy": "none",
+              "missing_mar_logit_scale": null,
+              "missing_mar_observed_fraction": null,
+              "missing_mechanism": null,
+              "missing_mnar_logit_scale": null,
+              "missing_rate": null,
+              "num_datasets": 128,
+              "rows": null,
+              "seed": 1
+            }
+          },
+          "generated_dir": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/generated",
+          "handoff_manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape/handoff_manifest.json",
+          "handoff_manifest_sha256": "fb4b944c2acfed52e4e5ecdab769f5cf5d93f18a7f0ac0c609af350e94dd47a8",
+          "hardware": {
+            "backend": "cpu",
+            "device_name": "cpu",
+            "hardware_policy": "none",
+            "requested_device": "cpu",
+            "resolved_device": "cpu",
+            "tier": "cpu"
+          },
+          "hardware_policy": "none",
+          "identity": {
+            "generate_run_id": "79b34914332fa3714ab65df0c41ef67b",
+            "generated_corpus_id": "23b89aefc0780e32418a8a1a438de059",
+            "source_family": "dagzoo.fixed_layout_scm"
+          },
+          "invocation_id": "large_shape",
+          "invocation_root": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/invocations/large_shape",
+          "num_datasets": 128,
+          "seed": 1,
+          "summary": {
+            "generated_datasets": 128
+          },
+          "throughput": {
+            "generation_stage": {
+              "datasets_per_minute": 32.40828630314208,
+              "elapsed_seconds": 236.97643029200844,
+              "generated_datasets": 128
+            }
+          }
+        }
+      ],
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+      "manifest_sha256": "8099cde14b8ac2d3831247fc1f85a115e699f5508064bbf6ac06122a1e98079b",
+      "state": "materialized_local_only"
+    }
+  }
+}

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/sweep.yaml
@@ -1,0 +1,71 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_013_shape_aware_dagzoo_v1
+parent_sweep_id: tf_rd_013_data_source_contract_v1
+status: completed
+complexity_level: binary_md
+anchor_run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+benchmark_bundle_path: src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json
+control_baseline_id: cls_benchmark_linear_v2
+comparison_policy: anchor_only
+training_experiment: cls_benchmark_staged
+training_config_profile: cls_benchmark_staged
+surface_role: architecture_screen
+upstream_reference:
+  name: TabICLv2
+  model_source: https://arxiv.org/abs/2602.11139
+anchor_surface:
+  notes:
+  - This completed sweep records the issue 127 TF-RD-013 follow-up on broader multi-invocation dagzoo coverage for `row_cls + qass + no tfcol`.
+  - The locked current-corpus surface remains the anchor because the broader shape-aware read did not beat it on final large-bundle log loss or Brier.
+  - The shape-aware follow-up uses a config-backed ladder of dagzoo invocations rather than a single default-config generate run.
+  - Reuse the existing `dagzoo_provenance` mapping on data surfaces and expand it with an `invocations` array instead of introducing a parallel metadata path.
+  - Keep one canonical OpenML real-data baseline and treat approved manifest-backed external datasets as augmentation evidence only after the license ledger is satisfied.
+  - Keep nanoTabPFN as the benchmark/control reference bundle while TabICLv2 remains the primary upstream architecture reference for the row-first target lane.
+  dimension_table:
+  - dimension: model anchor
+    upstream: TabICLv2 is the primary row-first architectural reference, but it does not define this exact repo-local promoted-anchor contract.
+    anchor: The settled promoted row-first benchmark anchor `row_cls + qass + no tfcol`.
+    interpretation: TF-RD-013 changes only the training-data comparison surface, not the promoted model surface.
+  - dimension: training data surface
+    upstream: TabICLv2 motivates synthetic pretraining at scale but does not define this repo-local manifest contract.
+    anchor: Current manifest-backed prior-training corpus with data surface label `anchor_manifest_default`.
+    interpretation: The broader TF-RD-013 follow-up keeps the current corpus as baseline while testing one explicit multi-invocation dagzoo alternative plus the curated real-data comparator lane.
+  - dimension: dagzoo provenance contract
+    upstream: Not applicable.
+    anchor: No dagzoo provenance is attached to the current-corpus anchor surface.
+    interpretation: The broader dagzoo candidate row should keep one top-level `dagzoo_provenance` payload and make each generate invocation explicit inside `dagzoo_provenance.invocations`.
+  - dimension: benchmark and control context
+    upstream: TabICLv2 is the architectural reference, while nanoTabPFN remains the current benchmark/control bundle family used by this repo.
+    anchor: Benchmark bundle `nanotabpfn_openml_binary_large` remains the benchmark-facing evaluation surface.
+    interpretation: TF-RD-013 should keep benchmark/control context stable while it reads the training-data surface change.
+  - dimension: training recipe
+    upstream: TabICLv2 informs the row-first staged recipe direction, but there is no repo-local shared prior-dump training-surface contract to copy literally.
+    anchor: Training surface label `prior_linear_warmup_decay`.
+    interpretation: The issue 127 follow-up should not mix optimizer or schedule changes into the data-source decision.
+anchor_context:
+  run_id: sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1
+  experiment: cls_benchmark_staged
+  config_profile: cls_benchmark_staged
+  model:
+    arch: tabfoundry_staged
+    benchmark_profile: delta_qass_no_column_v3
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_selection:
+      allow_test_self_attention: true
+      column_encoder: none
+      context_encoder: qass
+      feature_encoder: shared
+      head: small_class
+      post_encoder_norm: none
+      post_stack_norm: none
+      row_pool: row_cls
+      table_block_residual_scale: none
+      table_block_style: prenorm
+      target_conditioner: label_token
+      tokenizer: shifted_grouped
+  surface_labels:
+    data: anchor_manifest_default
+    model: delta_qass_no_column_v3
+    preprocessing: runtime_default
+    training: prior_linear_warmup_decay

--- a/scripts/docs/sync_hugo_content.py
+++ b/scripts/docs/sync_hugo_content.py
@@ -158,11 +158,11 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         description="Roadmap-to-reference mapping and repo-local evidence notes.",
     ),
     PageSpec(
-        source_rel="reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/README.md",
+        source_rel="reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md",
         route="reference/tf-rd-013-support",
         weight=30,
         link_title="TF-RD-013 Support",
-        description="Support bundle notes for the current dagzoo synthetic-data contract.",
+        description="Support bundle notes for the current shape-aware dagzoo synthetic-data contract.",
     ),
     PageSpec(
         source_rel="CONTRIBUTING.md",

--- a/scripts/materialize_tf_rd_013_support.py
+++ b/scripts/materialize_tf_rd_013_support.py
@@ -35,6 +35,7 @@ from tab_foundry.bench.nanotabpfn.datasets import (  # noqa: E402
     PreparedOpenMLBenchmarkTask,
     prepare_openml_benchmark_task,
 )
+from tab_foundry.data.manifest import build_manifest  # noqa: E402
 
 
 DEFAULT_DAGZOO_ROOT = REPO_ROOT.parent / "dagzoo"
@@ -46,9 +47,12 @@ DEFAULT_SEED = 1
 DEFAULT_DEVICE = "cpu"
 DEFAULT_COMPARATOR_SPLIT_SEED = 0
 DEFAULT_COMPARATOR_TEST_SIZE = 0.20
-MATERIALIZATION_ISSUE_NUMBER = 120
-EXECUTION_ISSUE_NUMBER = 122
+
+FIRST_MATERIALIZATION_ISSUE_NUMBER = 120
+FIRST_EXECUTION_ISSUE_NUMBER = 122
+SHAPE_AWARE_ISSUE_NUMBER = 127
 FILTERING_POLICY_ISSUE_NUMBER = 124
+
 LOCAL_OUTPUT_ROOT = REPO_ROOT / "outputs" / "staged_ladder_support" / "tf_rd_013"
 SUPPORT_ROOT = (
     REPO_ROOT
@@ -57,15 +61,22 @@ SUPPORT_ROOT = (
     / "tf_rd_013_data_source_contract_v1"
     / "support"
 )
+
+SHAPE_AWARE_SWEEP_ID = "tf_rd_013_shape_aware_dagzoo_v1"
+SHAPE_AWARE_LOCAL_OUTPUT_ROOT = (
+    REPO_ROOT / "outputs" / "staged_ladder_support" / SHAPE_AWARE_SWEEP_ID
+)
+SHAPE_AWARE_SUPPORT_ROOT = (
+    REPO_ROOT
+    / "reference"
+    / "system_delta_sweeps"
+    / SHAPE_AWARE_SWEEP_ID
+    / "support"
+)
+SHAPE_AWARE_DAGZOO_SURFACE_ROOT_NAME = "dagzoo_shape_aware_multi_invocation"
+
 ANCHOR_MANIFEST_PATH = REPO_ROOT / "data" / "manifests" / "default.parquet"
 TAB_FOUNDRY_BIN = REPO_ROOT / ".venv" / "bin" / "tab-foundry"
-ISSUE_URLS = {
-    "materialization_issue": f"https://github.com/bensonlee5/tab-foundry/issues/{MATERIALIZATION_ISSUE_NUMBER}",
-    "execution_issue": f"https://github.com/bensonlee5/tab-foundry/issues/{EXECUTION_ISSUE_NUMBER}",
-    "subsequent_filtering_policy_issue": (
-        f"https://github.com/bensonlee5/tab-foundry/issues/{FILTERING_POLICY_ISSUE_NUMBER}"
-    ),
-}
 
 
 @dataclass(frozen=True)
@@ -79,6 +90,67 @@ class MaterializationPaths:
     curated_openml_baseline_root: Path
     curated_openml_baseline_data_root: Path
     curated_openml_baseline_manifest_path: Path
+
+
+@dataclass(frozen=True)
+class ShapeAwareInvocationSpec:
+    invocation_id: str
+    config_ref: str
+    num_datasets: int
+    seed: int = DEFAULT_SEED
+    device: str = DEFAULT_DEVICE
+    hardware_policy: str = "none"
+
+
+@dataclass(frozen=True)
+class ShapeAwareInvocationPaths:
+    invocation_id: str
+    invocation_root: Path
+    generated_dir: Path
+    handoff_manifest_path: Path
+
+
+@dataclass(frozen=True)
+class ShapeAwareMaterializationPaths:
+    local_output_root: Path
+    dagzoo_surface_root: Path
+    dagzoo_manifest_path: Path
+    invocation_paths: tuple[ShapeAwareInvocationPaths, ...]
+    curated_realdata_root: Path
+    curated_openml_baseline_root: Path
+    curated_openml_baseline_data_root: Path
+    curated_openml_baseline_manifest_path: Path
+
+
+SHAPE_AWARE_INVOCATIONS: tuple[ShapeAwareInvocationSpec, ...] = (
+    ShapeAwareInvocationSpec(
+        invocation_id="benchmark_cpu",
+        config_ref="configs/benchmark_cpu.yaml",
+        num_datasets=2048,
+    ),
+    ShapeAwareInvocationSpec(
+        invocation_id="default_medium",
+        config_ref="configs/default.yaml",
+        num_datasets=4096,
+    ),
+    ShapeAwareInvocationSpec(
+        invocation_id="large_shape",
+        config_ref="configs/benchmark_cuda_h100_large_shape.yaml",
+        num_datasets=128,
+    ),
+)
+
+
+def _issue_urls(*, materialization_issue: int, execution_issue: int) -> dict[str, str]:
+    return {
+        "materialization_issue": (
+            f"https://github.com/bensonlee5/tab-foundry/issues/{materialization_issue}"
+        ),
+        "execution_issue": f"https://github.com/bensonlee5/tab-foundry/issues/{execution_issue}",
+        "subsequent_filtering_policy_issue": (
+            f"https://github.com/bensonlee5/tab-foundry/issues/{FILTERING_POLICY_ISSUE_NUMBER}"
+        ),
+    }
 
 
 def _utc_now() -> str:
@@ -197,6 +269,34 @@ def _materialization_paths(local_output_root: Path) -> MaterializationPaths:
     )
 
 
+def _shape_aware_materialization_paths(
+    local_output_root: Path,
+) -> ShapeAwareMaterializationPaths:
+    dagzoo_surface_root = local_output_root / SHAPE_AWARE_DAGZOO_SURFACE_ROOT_NAME
+    invocation_root = dagzoo_surface_root / "invocations"
+    curated_realdata_root = local_output_root / "curated_realdata"
+    curated_openml_baseline_root = curated_realdata_root / "openml_baseline"
+    invocation_paths = tuple(
+        ShapeAwareInvocationPaths(
+            invocation_id=spec.invocation_id,
+            invocation_root=invocation_root / spec.invocation_id,
+            generated_dir=invocation_root / spec.invocation_id / "generated",
+            handoff_manifest_path=invocation_root / spec.invocation_id / "handoff_manifest.json",
+        )
+        for spec in SHAPE_AWARE_INVOCATIONS
+    )
+    return ShapeAwareMaterializationPaths(
+        local_output_root=local_output_root,
+        dagzoo_surface_root=dagzoo_surface_root,
+        dagzoo_manifest_path=dagzoo_surface_root / "manifest.parquet",
+        invocation_paths=invocation_paths,
+        curated_realdata_root=curated_realdata_root,
+        curated_openml_baseline_root=curated_openml_baseline_root,
+        curated_openml_baseline_data_root=curated_openml_baseline_root / "packed_shards",
+        curated_openml_baseline_manifest_path=curated_openml_baseline_root / "manifest.parquet",
+    )
+
+
 def _dagzoo_commands(paths: MaterializationPaths) -> list[str]:
     return [
         (
@@ -216,9 +316,44 @@ def _dagzoo_commands(paths: MaterializationPaths) -> list[str]:
     ]
 
 
-def _curated_commands(paths: MaterializationPaths) -> list[str]:
+def _shape_aware_generate_command(
+    spec: ShapeAwareInvocationSpec,
+    paths: ShapeAwareInvocationPaths,
+) -> str:
+    return (
+        'cd "$DAGZOO_ROOT" && uv run dagzoo generate '
+        f"--config {spec.config_ref} "
+        f'--handoff-root "$TAB_FOUNDRY_ROOT/{_portable_path(paths.invocation_root)}" '
+        f"--num-datasets {spec.num_datasets} "
+        f"--seed {spec.seed} "
+        f"--device {spec.device} "
+        f"--hardware-policy {spec.hardware_policy}"
+    )
+
+
+def _shape_aware_build_manifest_command(paths: ShapeAwareMaterializationPaths) -> str:
+    roots_rendered = ", ".join(
+        _portable_path(invocation_paths.generated_dir)
+        for invocation_paths in paths.invocation_paths
+    )
+    return (
+        "build_manifest(data_roots=["
+        f"{roots_rendered}"
+        f"], out_path={_portable_path(paths.dagzoo_manifest_path)})"
+    )
+
+
+def _curated_commands(
+    paths: MaterializationPaths | ShapeAwareMaterializationPaths,
+    *,
+    variant: str,
+) -> list[str]:
+    variant_flag = "" if variant == "historical" else f" --variant {variant}"
     return [
-        'cd "$TAB_FOUNDRY_ROOT" && ./.venv/bin/python scripts/materialize_tf_rd_013_support.py --force',
+        (
+            'cd "$TAB_FOUNDRY_ROOT" && ./.venv/bin/python '
+            f"scripts/materialize_tf_rd_013_support.py{variant_flag} --force"
+        ),
         (
             'cd "$TAB_FOUNDRY_ROOT" && ./.venv/bin/tab-foundry data build-manifest '
             f"--data-root {_portable_path(paths.curated_openml_baseline_data_root)} "
@@ -345,7 +480,7 @@ def _split_prepared_task(
 
 def _materialize_curated_openml_baseline(
     *,
-    paths: MaterializationPaths,
+    paths: MaterializationPaths | ShapeAwareMaterializationPaths,
     bundle_path: Path,
 ) -> dict[str, Any]:
     bundle, allow_missing_values = load_benchmark_bundle_for_execution(bundle_path)
@@ -431,102 +566,41 @@ def _materialize_curated_openml_baseline(
     }
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dagzoo-root", default=str(DEFAULT_DAGZOO_ROOT), help="Local dagzoo checkout root")
-    parser.add_argument("--force", action="store_true", help="Replace existing local TF-RD-013 outputs")
-    args = parser.parse_args(argv)
-
-    dagzoo_root = Path(str(args.dagzoo_root)).expanduser().resolve()
+def _assert_common_inputs(*, dagzoo_root: Path) -> Path:
     if not dagzoo_root.exists():
         raise RuntimeError(f"dagzoo root does not exist: {dagzoo_root}")
     if not TAB_FOUNDRY_BIN.exists():
         raise RuntimeError(f"tab-foundry CLI not found at {TAB_FOUNDRY_BIN}")
-    dagzoo_config_path = dagzoo_root / DEFAULT_DAGZOO_CONFIG_REF
-    if not dagzoo_config_path.exists():
-        raise RuntimeError(f"dagzoo config does not exist: {dagzoo_config_path}")
     if not ANCHOR_MANIFEST_PATH.exists():
         raise RuntimeError(f"anchor manifest does not exist: {ANCHOR_MANIFEST_PATH}")
     benchmark_bundle_path = REPO_ROOT / DEFAULT_BENCHMARK_BUNDLE_REF
     if not benchmark_bundle_path.exists():
         raise RuntimeError(f"benchmark bundle does not exist: {benchmark_bundle_path}")
+    return benchmark_bundle_path
 
-    paths = _materialization_paths(LOCAL_OUTPUT_ROOT)
-    _ensure_absent(paths.generated_source_root, force=bool(args.force))
-    _ensure_absent(paths.curated_openml_baseline_root, force=bool(args.force))
-    paths.generated_source_root.mkdir(parents=True, exist_ok=True)
-    paths.curated_openml_baseline_root.mkdir(parents=True, exist_ok=True)
 
-    generate_cmd = [
-        "uv",
-        "run",
-        "dagzoo",
-        "generate",
-        "--config",
-        str(dagzoo_config_path),
-        "--handoff-root",
-        str(paths.generated_source_root),
-        "--num-datasets",
-        str(DEFAULT_NUM_DATASETS),
-        "--seed",
-        str(DEFAULT_SEED),
-        "--device",
-        DEFAULT_DEVICE,
-        "--hardware-policy",
-        "none",
-    ]
-    generated_manifest_cmd = [
-        str(TAB_FOUNDRY_BIN),
-        "data",
-        "build-manifest",
-        "--data-root",
-        str(paths.generated_dir),
-        "--out-manifest",
-        str(paths.generated_manifest_path),
-    ]
-
-    generate_completed = _run_checked(generate_cmd, cwd=dagzoo_root)
-    generated_manifest_completed = _run_checked(generated_manifest_cmd, cwd=REPO_ROOT)
-    curated_result = _materialize_curated_openml_baseline(
-        paths=paths,
-        bundle_path=benchmark_bundle_path,
+def _historical_materialization_summary(
+    *,
+    paths: MaterializationPaths,
+    manifests: dict[str, dict[str, Any]],
+    handoff_payload: dict[str, Any],
+    dagzoo_commands: list[str],
+    curated_commands: list[str],
+    generate_completed: subprocess.CompletedProcess[str],
+    generated_manifest_completed: subprocess.CompletedProcess[str],
+    curated_result: dict[str, Any],
+) -> dict[str, Any]:
+    issue_urls = _issue_urls(
+        materialization_issue=FIRST_MATERIALIZATION_ISSUE_NUMBER,
+        execution_issue=FIRST_EXECUTION_ISSUE_NUMBER,
     )
-
-    handoff_payload = _sanitize_paths(_load_json(paths.handoff_manifest_path))
-    dagzoo_commands = _dagzoo_commands(paths)
-    curated_commands = _curated_commands(paths)
-    anchor_inspection = _manifest_inspect(ANCHOR_MANIFEST_PATH)
-    generated_inspection = _manifest_inspect(paths.generated_manifest_path)
-    curated_inspection = _manifest_inspect(paths.curated_openml_baseline_manifest_path)
-
-    manifests = {
-        "anchor_manifest_default": {
-            "status": "available",
-            "manifest_path": _portable_path(ANCHOR_MANIFEST_PATH),
-            "manifest_sha256": _sha256_path(ANCHOR_MANIFEST_PATH),
-            "inspection": anchor_inspection,
-        },
-        "dagzoo_generated_source": {
-            "status": "available",
-            "manifest_path": _portable_path(paths.generated_manifest_path),
-            "manifest_sha256": _sha256_path(paths.generated_manifest_path),
-            "inspection": generated_inspection,
-        },
-        "curated_realdata_openml_baseline": {
-            "status": "available",
-            "manifest_path": _portable_path(paths.curated_openml_baseline_manifest_path),
-            "manifest_sha256": _sha256_path(paths.curated_openml_baseline_manifest_path),
-            "inspection": curated_inspection,
-        },
-    }
-
     dagzoo_provenance = {
         "corpus_variant": "dagzoo_generated_source",
         "comparator_role": "promoted_anchor_candidate",
         "commands": dagzoo_commands,
         "config_refs": [DEFAULT_DAGZOO_CONFIG_REF],
         "curated_root_lineage": [],
-        "materialization_issue": MATERIALIZATION_ISSUE_NUMBER,
+        "materialization_issue": FIRST_MATERIALIZATION_ISSUE_NUMBER,
     }
     curated_openml_provenance = {
         "surface_variant": "curated_realdata_openml_baseline",
@@ -544,19 +618,18 @@ def main(argv: list[str] | None = None) -> int:
             "preferred_mode": "stratified",
             "fallback_mode": "unstratified_fallback",
         },
-        "execution_issue": EXECUTION_ISSUE_NUMBER,
+        "execution_issue": FIRST_EXECUTION_ISSUE_NUMBER,
     }
-
-    materialization_summary = {
+    return {
         "schema": "tab-foundry-tf-rd-013-materialization-summary-v4",
         "generated_at_utc": _utc_now(),
         "issues": {
-            "materialization_issue": MATERIALIZATION_ISSUE_NUMBER,
-            "materialization_issue_url": ISSUE_URLS["materialization_issue"],
-            "execution_issue": EXECUTION_ISSUE_NUMBER,
-            "execution_issue_url": ISSUE_URLS["execution_issue"],
+            "materialization_issue": FIRST_MATERIALIZATION_ISSUE_NUMBER,
+            "materialization_issue_url": issue_urls["materialization_issue"],
+            "execution_issue": FIRST_EXECUTION_ISSUE_NUMBER,
+            "execution_issue_url": issue_urls["execution_issue"],
             "subsequent_filtering_policy_issue": FILTERING_POLICY_ISSUE_NUMBER,
-            "subsequent_filtering_policy_issue_url": ISSUE_URLS["subsequent_filtering_policy_issue"],
+            "subsequent_filtering_policy_issue_url": issue_urls["subsequent_filtering_policy_issue"],
         },
         "env_hints": {
             "dagzoo_root": "../dagzoo",
@@ -635,12 +708,17 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    manifest_characteristics_summary = {
+
+def _historical_manifest_characteristics_summary(
+    *,
+    manifests: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    return {
         "schema": "tab-foundry-tf-rd-013-manifest-characteristics-summary-v4",
         "generated_at_utc": _utc_now(),
         "issues": {
-            "materialization_issue": MATERIALIZATION_ISSUE_NUMBER,
-            "execution_issue": EXECUTION_ISSUE_NUMBER,
+            "materialization_issue": FIRST_MATERIALIZATION_ISSUE_NUMBER,
+            "execution_issue": FIRST_EXECUTION_ISSUE_NUMBER,
             "subsequent_filtering_policy_issue": FILTERING_POLICY_ISSUE_NUMBER,
         },
         "manifests": manifests,
@@ -666,13 +744,487 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    _write_json(SUPPORT_ROOT / "materialization_summary.json", materialization_summary)
-    _write_json(SUPPORT_ROOT / "manifest_characteristics_summary.json", manifest_characteristics_summary)
 
+def _materialize_historical_support(*, dagzoo_root: Path, force: bool) -> int:
+    benchmark_bundle_path = _assert_common_inputs(dagzoo_root=dagzoo_root)
+    dagzoo_config_path = dagzoo_root / DEFAULT_DAGZOO_CONFIG_REF
+    if not dagzoo_config_path.exists():
+        raise RuntimeError(f"dagzoo config does not exist: {dagzoo_config_path}")
+
+    paths = _materialization_paths(LOCAL_OUTPUT_ROOT)
+    _ensure_absent(paths.generated_source_root, force=force)
+    _ensure_absent(paths.curated_openml_baseline_root, force=force)
+    paths.generated_source_root.mkdir(parents=True, exist_ok=True)
+    paths.curated_openml_baseline_root.mkdir(parents=True, exist_ok=True)
+
+    generate_cmd = [
+        "uv",
+        "run",
+        "dagzoo",
+        "generate",
+        "--config",
+        str(dagzoo_config_path),
+        "--handoff-root",
+        str(paths.generated_source_root),
+        "--num-datasets",
+        str(DEFAULT_NUM_DATASETS),
+        "--seed",
+        str(DEFAULT_SEED),
+        "--device",
+        DEFAULT_DEVICE,
+        "--hardware-policy",
+        "none",
+    ]
+    generated_manifest_cmd = [
+        str(TAB_FOUNDRY_BIN),
+        "data",
+        "build-manifest",
+        "--data-root",
+        str(paths.generated_dir),
+        "--out-manifest",
+        str(paths.generated_manifest_path),
+    ]
+
+    generate_completed = _run_checked(generate_cmd, cwd=dagzoo_root)
+    generated_manifest_completed = _run_checked(generated_manifest_cmd, cwd=REPO_ROOT)
+    curated_result = _materialize_curated_openml_baseline(
+        paths=paths,
+        bundle_path=benchmark_bundle_path,
+    )
+
+    handoff_payload = _sanitize_paths(_load_json(paths.handoff_manifest_path))
+    dagzoo_commands = _dagzoo_commands(paths)
+    curated_commands = _curated_commands(paths, variant="historical")
+    anchor_inspection = _manifest_inspect(ANCHOR_MANIFEST_PATH)
+    generated_inspection = _manifest_inspect(paths.generated_manifest_path)
+    curated_inspection = _manifest_inspect(paths.curated_openml_baseline_manifest_path)
+
+    manifests = {
+        "anchor_manifest_default": {
+            "status": "available",
+            "manifest_path": _portable_path(ANCHOR_MANIFEST_PATH),
+            "manifest_sha256": _sha256_path(ANCHOR_MANIFEST_PATH),
+            "inspection": anchor_inspection,
+        },
+        "dagzoo_generated_source": {
+            "status": "available",
+            "manifest_path": _portable_path(paths.generated_manifest_path),
+            "manifest_sha256": _sha256_path(paths.generated_manifest_path),
+            "inspection": generated_inspection,
+        },
+        "curated_realdata_openml_baseline": {
+            "status": "available",
+            "manifest_path": _portable_path(paths.curated_openml_baseline_manifest_path),
+            "manifest_sha256": _sha256_path(paths.curated_openml_baseline_manifest_path),
+            "inspection": curated_inspection,
+        },
+    }
+
+    materialization_summary = _historical_materialization_summary(
+        paths=paths,
+        manifests=manifests,
+        handoff_payload=handoff_payload,
+        dagzoo_commands=dagzoo_commands,
+        curated_commands=curated_commands,
+        generate_completed=generate_completed,
+        generated_manifest_completed=generated_manifest_completed,
+        curated_result=curated_result,
+    )
+    manifest_characteristics_summary = _historical_manifest_characteristics_summary(
+        manifests=manifests,
+    )
+
+    _write_json(SUPPORT_ROOT / "materialization_summary.json", materialization_summary)
+    _write_json(
+        SUPPORT_ROOT / "manifest_characteristics_summary.json",
+        manifest_characteristics_summary,
+    )
     print("Wrote support summaries:")
     print(f"  {SUPPORT_ROOT / 'materialization_summary.json'}")
     print(f"  {SUPPORT_ROOT / 'manifest_characteristics_summary.json'}")
     return 0
+
+
+def _shape_aware_invocation_summary(
+    *,
+    spec: ShapeAwareInvocationSpec,
+    paths: ShapeAwareInvocationPaths,
+    handoff_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "invocation_id": spec.invocation_id,
+        "command": _shape_aware_generate_command(spec, paths),
+        "config_ref": spec.config_ref,
+        "num_datasets": spec.num_datasets,
+        "seed": spec.seed,
+        "device": spec.device,
+        "hardware_policy": spec.hardware_policy,
+        "invocation_root": _portable_path(paths.invocation_root),
+        "generated_dir": _portable_path(paths.generated_dir),
+        "handoff_manifest_path": _portable_path(paths.handoff_manifest_path),
+        "handoff_manifest_sha256": _sha256_path(paths.handoff_manifest_path),
+        "identity": handoff_payload.get("identity"),
+        "artifacts_relative": handoff_payload.get("artifacts_relative"),
+        "defaults": handoff_payload.get("defaults"),
+        "hardware": handoff_payload.get("hardware"),
+        "summary": handoff_payload.get("summary"),
+        "throughput": handoff_payload.get("throughput"),
+        "generate_invocation": handoff_payload.get("generate_invocation"),
+    }
+
+
+def _shape_aware_materialization_summary(
+    *,
+    paths: ShapeAwareMaterializationPaths,
+    manifests: dict[str, dict[str, Any]],
+    invocation_summaries: list[dict[str, Any]],
+    generate_steps: list[dict[str, Any]],
+    curated_commands: list[str],
+    curated_result: dict[str, Any],
+    combined_summary: Any,
+) -> dict[str, Any]:
+    issue_urls = _issue_urls(
+        materialization_issue=SHAPE_AWARE_ISSUE_NUMBER,
+        execution_issue=SHAPE_AWARE_ISSUE_NUMBER,
+    )
+    dagzoo_commands = [str(invocation["command"]) for invocation in invocation_summaries]
+    dagzoo_commands.append(_shape_aware_build_manifest_command(paths))
+    dagzoo_provenance = {
+        "corpus_variant": "dagzoo_shape_aware_multi_invocation",
+        "comparator_role": "promoted_anchor_candidate",
+        "commands": dagzoo_commands,
+        "config_refs": [spec.config_ref for spec in SHAPE_AWARE_INVOCATIONS],
+        "curated_root_lineage": [],
+        "materialization_issue": SHAPE_AWARE_ISSUE_NUMBER,
+        "invocations": [
+            {
+                "invocation_id": invocation["invocation_id"],
+                "config_ref": invocation["config_ref"],
+                "num_datasets": invocation["num_datasets"],
+                "seed": invocation["seed"],
+                "device": invocation["device"],
+                "hardware_policy": invocation["hardware_policy"],
+                "command": invocation["command"],
+                "generated_dir": invocation["generated_dir"],
+                "handoff_manifest_path": invocation["handoff_manifest_path"],
+                "handoff_manifest_sha256": invocation["handoff_manifest_sha256"],
+                "identity": invocation["identity"],
+                "summary": invocation["summary"],
+            }
+            for invocation in invocation_summaries
+        ],
+    }
+    curated_openml_provenance = {
+        "surface_variant": "curated_realdata_openml_baseline",
+        "comparator_role": "evidence_only_openml_baseline",
+        "commands": curated_commands,
+        "benchmark_bundle": curated_result["bundle_summary"],
+        "task_ids": [int(task["task_id"]) for task in curated_result["task_summaries"]],
+        "dataset_names": [str(task["dataset_name"]) for task in curated_result["task_summaries"]],
+        "task_summaries": curated_result["task_summaries"],
+        "approved_external_augmentations": [],
+        "split_policy": {
+            "name": "deterministic_holdout",
+            "test_size": DEFAULT_COMPARATOR_TEST_SIZE,
+            "seed": DEFAULT_COMPARATOR_SPLIT_SEED,
+            "preferred_mode": "stratified",
+            "fallback_mode": "unstratified_fallback",
+        },
+        "execution_issue": SHAPE_AWARE_ISSUE_NUMBER,
+    }
+    return {
+        "schema": "tab-foundry-tf-rd-013-shape-aware-materialization-summary-v1",
+        "generated_at_utc": _utc_now(),
+        "issues": {
+            "materialization_issue": SHAPE_AWARE_ISSUE_NUMBER,
+            "materialization_issue_url": issue_urls["materialization_issue"],
+            "execution_issue": SHAPE_AWARE_ISSUE_NUMBER,
+            "execution_issue_url": issue_urls["execution_issue"],
+            "epic_issue": 96,
+            "epic_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/96",
+            "downstream_training_surface_issue": 107,
+            "downstream_training_surface_issue_url": "https://github.com/bensonlee5/tab-foundry/issues/107",
+            "subsequent_filtering_policy_issue": FILTERING_POLICY_ISSUE_NUMBER,
+            "subsequent_filtering_policy_issue_url": issue_urls["subsequent_filtering_policy_issue"],
+        },
+        "env_hints": {
+            "dagzoo_root": "../dagzoo",
+            "tab_foundry_root": ".",
+        },
+        "config_refs": {
+            "dagzoo": [spec.config_ref for spec in SHAPE_AWARE_INVOCATIONS],
+            "tab_foundry": [DEFAULT_MANIFEST_CONFIG_REF],
+            "benchmark_bundle": [DEFAULT_BENCHMARK_BUNDLE_REF],
+        },
+        "artifacts": {
+            "local_output_root": _portable_path(paths.local_output_root),
+            "dagzoo_shape_aware_root": _portable_path(paths.dagzoo_surface_root),
+            "dagzoo_shape_aware_manifest_path": _portable_path(paths.dagzoo_manifest_path),
+            "dagzoo_shape_aware_manifest_sha256": _sha256_path(paths.dagzoo_manifest_path),
+            "curated_openml_baseline_root": _portable_path(paths.curated_openml_baseline_root),
+            "curated_openml_baseline_data_root": _portable_path(paths.curated_openml_baseline_data_root),
+            "curated_openml_baseline_manifest_path": _portable_path(paths.curated_openml_baseline_manifest_path),
+            "curated_openml_baseline_manifest_sha256": _sha256_path(paths.curated_openml_baseline_manifest_path),
+        },
+        "shape_program": {
+            "kind": "config_ladder",
+            "assembly_policy": "build_manifest(data_roots=[...]) without dagzoo_handoff_manifest_path",
+            "notes": [
+                "The broader dagzoo follow-up uses three explicit config-backed invocations rather than a single default-config generate run.",
+                "The combined manifest intentionally omits single-handoff manifest metadata so the multi-invocation surface stays schema-stable.",
+                "Keep filtering policy out of this follow-up; issue 124 remains a later decision only if the broader read shows a predictability problem.",
+            ],
+            "invocation_ids": [spec.invocation_id for spec in SHAPE_AWARE_INVOCATIONS],
+            "input_roots": [_portable_path(invocation.generated_dir) for invocation in paths.invocation_paths],
+        },
+        "steps": (
+            generate_steps
+            + [
+                {
+                    "step_id": "build_manifest_dagzoo_shape_aware_multi_invocation",
+                    "cwd": "$TAB_FOUNDRY_ROOT",
+                    "command": _shape_aware_build_manifest_command(paths),
+                    "status": "completed",
+                    "returncode": 0,
+                },
+                {
+                    "step_id": "prepare_openml_baseline_shards",
+                    "cwd": "$TAB_FOUNDRY_ROOT",
+                    "command": curated_commands[0],
+                    "status": "completed",
+                    "returncode": 0,
+                },
+                {
+                    "step_id": "build_manifest_curated_realdata_openml_baseline",
+                    "cwd": "$TAB_FOUNDRY_ROOT",
+                    "command": curated_commands[1],
+                    "status": "completed",
+                    "returncode": int(curated_result["build_manifest_completed"].returncode),
+                },
+            ]
+        ),
+        "assembly": {
+            "combined_manifest_path": _portable_path(paths.dagzoo_manifest_path),
+            "combined_manifest_sha256": _sha256_path(paths.dagzoo_manifest_path),
+            "invocation_count": len(invocation_summaries),
+            "input_roots": [_portable_path(invocation.generated_dir) for invocation in paths.invocation_paths],
+            "persisted_summary": {
+                "discovered_records": int(combined_summary.discovered_records),
+                "excluded_records": int(combined_summary.excluded_records),
+                "excluded_for_missing_values": int(combined_summary.excluded_for_missing_values),
+                "filter_policy": str(combined_summary.filter_policy),
+                "missing_value_policy": str(combined_summary.missing_value_policy),
+                "total_records": int(combined_summary.total_records),
+                "train_records": int(combined_summary.train_records),
+                "val_records": int(combined_summary.val_records),
+                "test_records": int(combined_summary.test_records),
+                "filter_status_counts": dict(combined_summary.filter_status_counts),
+                "missing_value_status_counts": dict(combined_summary.missing_value_status_counts),
+            },
+            "notes": [
+                "Each invocation keeps its own handoff manifest and identity record.",
+                "The follow-up sweep trains against one merged manifest that combines all generated roots.",
+            ],
+        },
+        "surfaces": {
+            "dagzoo_shape_aware_multi_invocation": {
+                "state": "materialized_local_only",
+                "manifest_path": manifests["dagzoo_shape_aware_multi_invocation"]["manifest_path"],
+                "manifest_sha256": manifests["dagzoo_shape_aware_multi_invocation"]["manifest_sha256"],
+                "dagzoo_provenance": dagzoo_provenance,
+                "invocation_handoffs": invocation_summaries,
+            },
+            "curated_realdata_openml_baseline": {
+                "state": "materialized_local_only",
+                "manifest_path": manifests["curated_realdata_openml_baseline"]["manifest_path"],
+                "manifest_sha256": manifests["curated_realdata_openml_baseline"]["manifest_sha256"],
+                "curated_realdata_provenance": curated_openml_provenance,
+            },
+        },
+    }
+
+
+def _shape_aware_manifest_characteristics_summary(
+    *,
+    manifests: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema": "tab-foundry-tf-rd-013-shape-aware-manifest-characteristics-summary-v1",
+        "generated_at_utc": _utc_now(),
+        "issues": {
+            "materialization_issue": SHAPE_AWARE_ISSUE_NUMBER,
+            "execution_issue": SHAPE_AWARE_ISSUE_NUMBER,
+            "epic_issue": 96,
+            "downstream_training_surface_issue": 107,
+            "subsequent_filtering_policy_issue": FILTERING_POLICY_ISSUE_NUMBER,
+        },
+        "manifests": manifests,
+        "comparisons": {
+            "anchor_vs_dagzoo_shape_aware_multi_invocation": _comparison_entry(
+                comparison_id="anchor_vs_dagzoo_shape_aware_multi_invocation",
+                left_id="anchor_manifest_default",
+                right_id="dagzoo_shape_aware_multi_invocation",
+                manifests=manifests,
+            ),
+            "anchor_vs_curated_realdata_openml_baseline": _comparison_entry(
+                comparison_id="anchor_vs_curated_realdata_openml_baseline",
+                left_id="anchor_manifest_default",
+                right_id="curated_realdata_openml_baseline",
+                manifests=manifests,
+            ),
+            "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline": _comparison_entry(
+                comparison_id="dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline",
+                left_id="dagzoo_shape_aware_multi_invocation",
+                right_id="curated_realdata_openml_baseline",
+                manifests=manifests,
+            ),
+        },
+    }
+
+
+def _materialize_shape_aware_support(*, dagzoo_root: Path, force: bool) -> int:
+    benchmark_bundle_path = _assert_common_inputs(dagzoo_root=dagzoo_root)
+    for spec in SHAPE_AWARE_INVOCATIONS:
+        dagzoo_config_path = dagzoo_root / spec.config_ref
+        if not dagzoo_config_path.exists():
+            raise RuntimeError(f"dagzoo config does not exist: {dagzoo_config_path}")
+
+    paths = _shape_aware_materialization_paths(SHAPE_AWARE_LOCAL_OUTPUT_ROOT)
+    _ensure_absent(paths.dagzoo_surface_root, force=force)
+    _ensure_absent(paths.curated_openml_baseline_root, force=force)
+    paths.dagzoo_surface_root.mkdir(parents=True, exist_ok=True)
+    paths.curated_openml_baseline_root.mkdir(parents=True, exist_ok=True)
+
+    invocation_summaries: list[dict[str, Any]] = []
+    generate_steps: list[dict[str, Any]] = []
+    for spec, invocation_paths in zip(
+        SHAPE_AWARE_INVOCATIONS,
+        paths.invocation_paths,
+        strict=True,
+    ):
+        generate_cmd = [
+            "uv",
+            "run",
+            "dagzoo",
+            "generate",
+            "--config",
+            str((dagzoo_root / spec.config_ref).resolve()),
+            "--handoff-root",
+            str(invocation_paths.invocation_root),
+            "--num-datasets",
+            str(spec.num_datasets),
+            "--seed",
+            str(spec.seed),
+            "--device",
+            spec.device,
+            "--hardware-policy",
+            spec.hardware_policy,
+        ]
+        generate_completed = _run_checked(generate_cmd, cwd=dagzoo_root)
+        handoff_payload = _sanitize_paths(_load_json(invocation_paths.handoff_manifest_path))
+        invocation_summaries.append(
+            _shape_aware_invocation_summary(
+                spec=spec,
+                paths=invocation_paths,
+                handoff_payload=handoff_payload,
+            )
+        )
+        generate_steps.append(
+            {
+                "step_id": f"dagzoo_generate_{spec.invocation_id}",
+                "cwd": "$DAGZOO_ROOT",
+                "command": _shape_aware_generate_command(spec, invocation_paths),
+                "status": "completed",
+                "returncode": generate_completed.returncode,
+            }
+        )
+
+    combined_summary = build_manifest(
+        data_roots=[invocation.generated_dir for invocation in paths.invocation_paths],
+        out_path=paths.dagzoo_manifest_path,
+    )
+    curated_result = _materialize_curated_openml_baseline(
+        paths=paths,
+        bundle_path=benchmark_bundle_path,
+    )
+    curated_commands = _curated_commands(paths, variant="shape-aware")
+
+    anchor_inspection = _manifest_inspect(ANCHOR_MANIFEST_PATH)
+    generated_inspection = _manifest_inspect(paths.dagzoo_manifest_path)
+    curated_inspection = _manifest_inspect(paths.curated_openml_baseline_manifest_path)
+    manifests = {
+        "anchor_manifest_default": {
+            "status": "available",
+            "manifest_path": _portable_path(ANCHOR_MANIFEST_PATH),
+            "manifest_sha256": _sha256_path(ANCHOR_MANIFEST_PATH),
+            "inspection": anchor_inspection,
+        },
+        "dagzoo_shape_aware_multi_invocation": {
+            "status": "available",
+            "manifest_path": _portable_path(paths.dagzoo_manifest_path),
+            "manifest_sha256": _sha256_path(paths.dagzoo_manifest_path),
+            "inspection": generated_inspection,
+        },
+        "curated_realdata_openml_baseline": {
+            "status": "available",
+            "manifest_path": _portable_path(paths.curated_openml_baseline_manifest_path),
+            "manifest_sha256": _sha256_path(paths.curated_openml_baseline_manifest_path),
+            "inspection": curated_inspection,
+        },
+    }
+    materialization_summary = _shape_aware_materialization_summary(
+        paths=paths,
+        manifests=manifests,
+        invocation_summaries=invocation_summaries,
+        generate_steps=generate_steps,
+        curated_commands=curated_commands,
+        curated_result=curated_result,
+        combined_summary=combined_summary,
+    )
+    manifest_characteristics_summary = _shape_aware_manifest_characteristics_summary(
+        manifests=manifests,
+    )
+
+    _write_json(
+        SHAPE_AWARE_SUPPORT_ROOT / "materialization_summary.json",
+        materialization_summary,
+    )
+    _write_json(
+        SHAPE_AWARE_SUPPORT_ROOT / "manifest_characteristics_summary.json",
+        manifest_characteristics_summary,
+    )
+    print("Wrote support summaries:")
+    print(f"  {SHAPE_AWARE_SUPPORT_ROOT / 'materialization_summary.json'}")
+    print(f"  {SHAPE_AWARE_SUPPORT_ROOT / 'manifest_characteristics_summary.json'}")
+    return 0
+
+
+def materialize_support(*, variant: str, dagzoo_root: Path, force: bool) -> int:
+    if variant == "historical":
+        return _materialize_historical_support(dagzoo_root=dagzoo_root, force=force)
+    if variant == "shape-aware":
+        return _materialize_shape_aware_support(dagzoo_root=dagzoo_root, force=force)
+    raise RuntimeError(f"unsupported materialization variant: {variant}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dagzoo-root", default=str(DEFAULT_DAGZOO_ROOT), help="Local dagzoo checkout root")
+    parser.add_argument("--force", action="store_true", help="Replace existing local TF-RD-013 outputs")
+    parser.add_argument(
+        "--variant",
+        choices=("historical", "shape-aware"),
+        default="historical",
+        help="Support bundle variant to materialize",
+    )
+    args = parser.parse_args(argv)
+
+    dagzoo_root = Path(str(args.dagzoo_root)).expanduser().resolve()
+    return materialize_support(
+        variant=str(args.variant),
+        dagzoo_root=dagzoo_root,
+        force=bool(args.force),
+    )
 
 
 if __name__ == "__main__":

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -12288,17 +12288,17 @@
         "wall_elapsed_seconds": 72.07819995799218
       }
     },
-    "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1": {
+    "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2": {
       "artifacts": {
-        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/benchmark",
-        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/benchmark/benchmark_run_record.json",
-        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/train/checkpoints/step_002500.pt",
-        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/benchmark/comparison_curve.png",
-        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/benchmark/comparison_summary.json",
-        "history_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/train/train_history.jsonl",
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/train/train_history.jsonl",
         "prior_dir": null,
-        "run_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/train",
-        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1/train/training_surface_record.json"
+        "run_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_root_dagzoo_generated_source/sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2/train/training_surface_record.json"
       },
       "benchmark_bundle": {
         "name": "nanotabpfn_openml_binary_large",
@@ -12323,31 +12323,31 @@
       "budget_class": "short-run",
       "comparisons": {
         "vs_anchor": {
-          "best_roc_auc_delta": -5.139802631570767e-05,
-          "best_training_time_delta": -26.572277507570107,
+          "best_roc_auc_delta": -0.2156436783843389,
+          "best_training_time_delta": -2439.691140986164,
           "final_avg_pinball_loss_delta": null,
-          "final_brier_score_delta": -3.026016270890608e-09,
+          "final_brier_score_delta": 0.03424049537111251,
           "final_crps_delta": null,
-          "final_log_loss_delta": -3.3296791435155626e-09,
+          "final_log_loss_delta": 0.045592466413199695,
           "final_picp_90_delta": null,
-          "final_roc_auc_delta": -5.139802631570767e-05,
-          "final_training_time_delta": -26.572277507570107,
+          "final_roc_auc_delta": -0.19653788343200745,
+          "final_training_time_delta": -2221.9488824388827,
           "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
         },
         "vs_parent": {
-          "best_roc_auc_delta": -5.139802631570767e-05,
-          "best_training_time_delta": -26.572277507570107,
+          "best_roc_auc_delta": -0.2156436783843389,
+          "best_training_time_delta": -2439.691140986164,
           "final_avg_pinball_loss_delta": null,
-          "final_brier_score_delta": -3.026016270890608e-09,
+          "final_brier_score_delta": 0.03424049537111251,
           "final_crps_delta": null,
-          "final_log_loss_delta": -3.3296791435155626e-09,
+          "final_log_loss_delta": 0.045592466413199695,
           "final_picp_90_delta": null,
-          "final_roc_auc_delta": -5.139802631570767e-05,
-          "final_training_time_delta": -26.572277507570107,
+          "final_roc_auc_delta": -0.19653788343200745,
+          "final_training_time_delta": -2221.9488824388827,
           "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
         }
       },
-      "conclusion": "Neutral first promoted-anchor read: the single-invocation dagzoo surface matched the anchor and the OpenML-only comparator on the recorded large-bundle metrics, so dagzoo stays deferred pending broader multi-invocation coverage under issue 127.",
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
       "config_profile": "cls_benchmark_staged",
       "decision": "defer",
       "experiment": "cls_benchmark_staged",
@@ -12430,8 +12430,8 @@
         "total_params": 868706,
         "trainable_params": 868706
       },
-      "registered_at_utc": "2026-03-22T17:21:05Z",
-      "run_id": "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1",
+      "registered_at_utc": "2026-03-23T05:49:11Z",
+      "run_id": "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2",
       "seed_set": [
         1
       ],
@@ -12450,46 +12450,46 @@
       },
       "tab_foundry_metrics": {
         "best_avg_pinball_loss": null,
-        "best_brier_score": 0.26437640199935597,
+        "best_brier_score": 0.29789851264214673,
         "best_crps": null,
-        "best_log_loss": 0.42151055964690004,
+        "best_log_loss": 0.46516748233892263,
         "best_picp_90": null,
-        "best_roc_auc": 0.6701728307468436,
-        "best_step": 2500.0,
-        "best_training_time": 2523.5166713882354,
+        "best_roc_auc": 0.45458055038882045,
+        "best_step": 250.0,
+        "best_training_time": 110.39780790964141,
         "final_avg_pinball_loss": null,
-        "final_brier_score": 0.26437640199935597,
+        "final_brier_score": 0.29861690039648475,
         "final_crps": null,
-        "final_log_loss": 0.42151055964690004,
+        "final_log_loss": 0.4671030293897789,
         "final_picp_90": null,
-        "final_roc_auc": 0.6701728307468436,
-        "final_step": 2500.0,
-        "final_training_time": 2523.5166713882354
+        "final_roc_auc": 0.4736863453411519,
+        "final_step": 725.0,
+        "final_training_time": 328.1400664569228
       },
       "track": "system_delta_binary_medium_v1",
       "training_diagnostics": {
-        "best_val_loss": null,
-        "best_val_step": null,
-        "final_grad_norm": 0.19756247103214264,
-        "final_val_loss": null,
-        "max_grad_norm": 5.782161712646484,
-        "mean_grad_norm": 0.16830273798406123,
-        "post_warmup_train_loss_var": 0.0017787082772249445,
-        "train_elapsed_seconds": 2523.5166713882354,
-        "wall_elapsed_seconds": 2552.920567125024
+        "best_val_loss": 0.658787727355957,
+        "best_val_step": 300.0,
+        "final_grad_norm": 0.05604730546474457,
+        "final_val_loss": 0.6587879061698914,
+        "max_grad_norm": 8.983333587646484,
+        "mean_grad_norm": 0.2801274581256914,
+        "post_warmup_train_loss_var": 0.018343282590490766,
+        "train_elapsed_seconds": 330.1357793309726,
+        "wall_elapsed_seconds": 403.1188981249579
       }
     },
-    "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1": {
+    "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2": {
       "artifacts": {
-        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark",
-        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/benchmark_run_record.json",
-        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/checkpoints/step_002500.pt",
-        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/comparison_curve.png",
-        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/comparison_summary.json",
-        "history_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/train_history.jsonl",
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/train/train_history.jsonl",
         "prior_dir": null,
-        "run_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train",
-        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/training_surface_record.json"
+        "run_dir": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_data_source_contract_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2/train/training_surface_record.json"
       },
       "benchmark_bundle": {
         "name": "nanotabpfn_openml_binary_large",
@@ -12514,31 +12514,31 @@
       "budget_class": "short-run",
       "comparisons": {
         "vs_anchor": {
-          "best_roc_auc_delta": -5.139802631570767e-05,
-          "best_training_time_delta": 12.256157753581647,
+          "best_roc_auc_delta": -0.10882041748663795,
+          "best_training_time_delta": -2494.993876529392,
           "final_avg_pinball_loss_delta": null,
-          "final_brier_score_delta": -3.026016270890608e-09,
+          "final_brier_score_delta": 0.2289466527295459,
           "final_crps_delta": null,
-          "final_log_loss_delta": -3.3296791435155626e-09,
+          "final_log_loss_delta": 1.6855631269535394,
           "final_picp_90_delta": null,
-          "final_roc_auc_delta": -5.139802631570767e-05,
-          "final_training_time_delta": 12.256157753581647,
+          "final_roc_auc_delta": -0.08744782698605724,
+          "final_training_time_delta": -2223.1197221548064,
           "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
         },
         "vs_parent": {
-          "best_roc_auc_delta": -5.139802631570767e-05,
-          "best_training_time_delta": 12.256157753581647,
+          "best_roc_auc_delta": -0.10882041748663795,
+          "best_training_time_delta": -2494.993876529392,
           "final_avg_pinball_loss_delta": null,
-          "final_brier_score_delta": -3.026016270890608e-09,
+          "final_brier_score_delta": 0.2289466527295459,
           "final_crps_delta": null,
-          "final_log_loss_delta": -3.3296791435155626e-09,
+          "final_log_loss_delta": 1.6855631269535394,
           "final_picp_90_delta": null,
-          "final_roc_auc_delta": -5.139802631570767e-05,
-          "final_training_time_delta": 12.256157753581647,
+          "final_roc_auc_delta": -0.08744782698605724,
+          "final_training_time_delta": -2223.1197221548064,
           "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
         }
       },
-      "conclusion": "OpenML-only curated comparator matched the anchor and the unfiltered dagzoo row on the recorded large-bundle metrics, so it remains evidence-only and does not unblock issue 107 before issue 127 broadens dagzoo coverage.",
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
       "config_profile": "cls_benchmark_staged",
       "decision": "defer",
       "experiment": "cls_benchmark_staged",
@@ -12621,8 +12621,8 @@
         "total_params": 868706,
         "trainable_params": 868706
       },
-      "registered_at_utc": "2026-03-22T18:09:43Z",
-      "run_id": "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1",
+      "registered_at_utc": "2026-03-23T06:15:08Z",
+      "run_id": "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2",
       "seed_set": [
         1
       ],
@@ -12641,33 +12641,415 @@
       },
       "tab_foundry_metrics": {
         "best_avg_pinball_loss": null,
-        "best_brier_score": 0.26437640199935597,
+        "best_brier_score": 0.29308872328473784,
         "best_crps": null,
-        "best_log_loss": 0.42151055964690004,
+        "best_log_loss": 0.4613900827138487,
         "best_picp_90": null,
-        "best_roc_auc": 0.6701728307468436,
-        "best_step": 2500.0,
-        "best_training_time": 2562.345106649387,
+        "best_roc_auc": 0.5614038112865214,
+        "best_step": 325.0,
+        "best_training_time": 55.09507236641366,
         "final_avg_pinball_loss": null,
-        "final_brier_score": 0.26437640199935597,
+        "final_brier_score": 0.49332305775491814,
         "final_crps": null,
-        "final_log_loss": 0.42151055964690004,
+        "final_log_loss": 2.1070736899301186,
         "final_picp_90": null,
-        "final_roc_auc": 0.6701728307468436,
-        "final_step": 2500.0,
-        "final_training_time": 2562.345106649387
+        "final_roc_auc": 0.5827764017871021,
+        "final_step": 2025.0,
+        "final_training_time": 326.96922674099915
       },
       "track": "system_delta_binary_medium_v1",
       "training_diagnostics": {
         "best_val_loss": null,
         "best_val_step": null,
-        "final_grad_norm": 0.19756247103214264,
+        "final_grad_norm": 139.33848571777344,
         "final_val_loss": null,
-        "max_grad_norm": 5.782161712646484,
-        "mean_grad_norm": 0.16830273798406123,
-        "post_warmup_train_loss_var": 0.0017787082772249445,
-        "train_elapsed_seconds": 2562.345106649387,
-        "wall_elapsed_seconds": 2590.6656173330266
+        "max_grad_norm": 711.2716674804688,
+        "mean_grad_norm": 7.958942587718521,
+        "post_warmup_train_loss_var": 0.036661444885170896,
+        "train_elapsed_seconds": 330.0361776968348,
+        "wall_elapsed_seconds": 370.7948942090152
+      }
+    },
+    "sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_root_dagzoo_shape_aware_multi_invocation/sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_large",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json",
+        "task_count": 12,
+        "task_ids": [
+          363613,
+          363618,
+          363619,
+          363621,
+          363623,
+          363629,
+          363632,
+          363671,
+          363679,
+          363682,
+          363691,
+          363700
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": -0.1647568235699609,
+          "best_training_time_delta": -2237.5873539299937,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.033515899542441774,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 0.04429907460693272,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.1591237490027304,
+          "final_training_time_delta": -2222.5153787599993,
+          "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": -0.1647568235699609,
+          "best_training_time_delta": -2237.5873539299937,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.033515899542441774,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 0.04429907460693272,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.1591237490027304,
+          "final_training_time_delta": -2222.5153787599993,
+          "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+      },
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/dagzoo_shape_aware_multi_invocation/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_qass_no_column_v3",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": true,
+            "ff_expansion": 2,
+            "n_heads": 4,
+            "n_layers": 3,
+            "name": "qass",
+            "norm_type": "layernorm",
+            "use_qass": true
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": 4,
+            "n_heads": 8,
+            "n_layers": 3,
+            "name": "row_cls",
+            "norm_type": "layernorm"
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "qass",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "row_cls",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "shifted_grouped"
+        },
+        "stage": "qass_context",
+        "stage_label": "delta_qass_no_column_v3",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 868706,
+        "trainable_params": 868706
+      },
+      "registered_at_utc": "2026-03-23T06:46:35Z",
+      "run_id": "sd_tf_rd_013_shape_aware_dagzoo_v1_01_delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_013_dagzoo_shape_aware_multi_invocation",
+        "model": "delta_qass_no_column_v3",
+        "preprocessing": "runtime_default",
+        "training": "prior_linear_warmup_decay"
+      },
+      "sweep": {
+        "delta_id": "delta_data_manifest_root_dagzoo_shape_aware_multi_invocation",
+        "parent_sweep_id": "tf_rd_013_data_source_contract_v1",
+        "queue_order": 1,
+        "run_kind": "primary",
+        "sweep_id": "tf_rd_013_shape_aware_dagzoo_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.29774220485916136,
+        "best_crps": null,
+        "best_log_loss": 0.4651157370319072,
+        "best_picp_90": null,
+        "best_roc_auc": 0.5054674052031984,
+        "best_step": 425.0,
+        "best_training_time": 312.5015949658118,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.297892304567814,
+        "final_crps": null,
+        "final_log_loss": 0.4658096375835119,
+        "final_picp_90": null,
+        "final_roc_auc": 0.5111004797704289,
+        "final_step": 475.0,
+        "final_training_time": 327.5735701358062
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.07579437643289566,
+        "final_val_loss": null,
+        "max_grad_norm": 521438.09375,
+        "mean_grad_norm": 6415.371443789246,
+        "post_warmup_train_loss_var": 0.016752752148945557,
+        "train_elapsed_seconds": 330.13352351193316,
+        "wall_elapsed_seconds": 340.7129405839951
+      }
+    },
+    "sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_013_shape_aware_dagzoo_v1/delta_data_manifest_curated_realdata_comparator/sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_large",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json",
+        "task_count": 12,
+        "task_ids": [
+          363613,
+          363618,
+          363619,
+          363621,
+          363623,
+          363629,
+          363632,
+          363671,
+          363679,
+          363682,
+          363691,
+          363700
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": -0.09844888426156961,
+          "best_training_time_delta": -2495.546186515363,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.2096423340906755,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 1.6633598753814525,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.07003800997319087,
+          "final_training_time_delta": -2221.738983524032,
+          "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": -0.09844888426156961,
+          "best_training_time_delta": -2495.546186515363,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.2096423340906755,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 1.6633598753814525,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.07003800997319087,
+          "final_training_time_delta": -2221.738983524032,
+          "reference_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged",
+      "lineage": {
+        "anchor_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+      },
+      "manifest_path": "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/curated_realdata/openml_baseline/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_qass_no_column_v3",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": true,
+            "ff_expansion": 2,
+            "n_heads": 4,
+            "n_layers": 3,
+            "name": "qass",
+            "norm_type": "layernorm",
+            "use_qass": true
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": 4,
+            "n_heads": 8,
+            "n_layers": 3,
+            "name": "row_cls",
+            "norm_type": "layernorm"
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "qass",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "row_cls",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "shifted_grouped"
+        },
+        "stage": "qass_context",
+        "stage_label": "delta_qass_no_column_v3",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 868706,
+        "trainable_params": 868706
+      },
+      "registered_at_utc": "2026-03-23T06:54:19Z",
+      "run_id": "sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_013_curated_realdata_comparator",
+        "model": "delta_qass_no_column_v3",
+        "preprocessing": "runtime_default",
+        "training": "prior_linear_warmup_decay"
+      },
+      "sweep": {
+        "delta_id": "delta_data_manifest_curated_realdata_comparator",
+        "parent_sweep_id": "tf_rd_013_data_source_contract_v1",
+        "queue_order": 2,
+        "run_kind": "primary",
+        "sweep_id": "tf_rd_013_shape_aware_dagzoo_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.2948501439273162,
+        "best_crps": null,
+        "best_log_loss": 0.4643251538089226,
+        "best_picp_90": null,
+        "best_roc_auc": 0.5717753445115897,
+        "best_step": 350.0,
+        "best_training_time": 54.54276238044258,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.47401873911604775,
+        "final_crps": null,
+        "final_log_loss": 2.0848704383580317,
+        "final_picp_90": null,
+        "final_roc_auc": 0.6001862187999685,
+        "final_step": 2150.0,
+        "final_training_time": 328.3499653717736
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 247.51583862304688,
+        "final_val_loss": null,
+        "max_grad_norm": 598.991943359375,
+        "mean_grad_norm": 6.266949548786299,
+        "post_warmup_train_loss_var": 0.03887795086256782,
+        "train_elapsed_seconds": 330.048513161717,
+        "wall_elapsed_seconds": 369.99855345801916
       }
     },
     "sd_tokenization_migration_v1_01_delta_architecture_screen_grouped_tokens_v1": {

--- a/src/tab_foundry/bench/prior/loop.py
+++ b/src/tab_foundry/bench/prior/loop.py
@@ -12,11 +12,20 @@ from typing import Any, cast
 from omegaconf import DictConfig, OmegaConf
 import torch
 
+from tab_foundry.training.surface import TRAINING_BACKEND_PRIOR_DUMP
 from tab_foundry.training.instability import grad_norm_summary_from_running_totals
 from tab_foundry.types import TrainResult
 
 
 _PRIOR_STAGE_NAME = "prior_dump"
+
+
+def _global_grad_norm_kind(value: float) -> str:
+    if math.isnan(value):
+        return "nan"
+    if math.isinf(value):
+        return "pos_inf" if value > 0.0 else "neg_inf"
+    return "finite"
 
 
 @dataclass(frozen=True)
@@ -306,6 +315,7 @@ def run_prior_training(
             training_surface_path,
             raw_cfg=raw_cfg,
             run_dir=output_dir,
+            backend=TRAINING_BACKEND_PRIOR_DUMP,
         )
         run = deps.init_wandb_run(
             cfg,
@@ -444,6 +454,53 @@ def run_prior_training(
             local_grad_norm = deps.total_grad_norm(model.parameters())
             clipped = torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             local_grad_norm = deps.normalize_grad_norm_value(clipped, fallback=local_grad_norm)
+            global_grad_norm_kind = _global_grad_norm_kind(float(local_grad_norm))
+            if global_grad_norm_kind != "finite":
+                nan_skip_count += 1
+                optimizer.zero_grad(set_to_none=True)
+                elapsed_seconds = time.perf_counter() - train_start
+                non_finite_grad_log: dict[str, Any] = {
+                    "train/non_finite_grad_guard_triggered": True,
+                    "train/non_finite_grad_kind": global_grad_norm_kind,
+                    "train/nan_skip_count": float(nan_skip_count),
+                }
+                deps.log_wandb_metrics(run, non_finite_grad_log, step=global_step)
+                history_payload = deps.history_record(
+                    global_step=global_step,
+                    stage_name=_PRIOR_STAGE_NAME,
+                    train_loss=float("nan"),
+                    train_metrics={"non_finite_grad_guard_triggered": 1.0},
+                    lr=float(optimizer.param_groups[0]["lr"]),
+                    grad_norm=None,
+                    elapsed_seconds=elapsed_seconds,
+                    train_elapsed_seconds=train_elapsed_seconds,
+                    val_metrics=None,
+                    train_loss_delta=None,
+                    train_loss_ema=loss_ema,
+                    grad_clip_threshold=float(grad_clip),
+                    grad_clip_triggered=False,
+                )
+                history_records.append(history_payload)
+                if history_path is not None:
+                    deps.append_history_record(history_path, history_payload)
+                gradient_payload = deps.gradient_history_record(
+                    global_step=global_step,
+                    stage_name=_PRIOR_STAGE_NAME,
+                    train_loss=float("nan"),
+                    train_acc=None,
+                    lr=float(optimizer.param_groups[0]["lr"]),
+                    global_grad_norm=None,
+                    global_grad_norm_kind=global_grad_norm_kind,
+                    module_grad_norms=pre_clip_module_grad_norms,
+                    activation_norms=activation_norms,
+                    elapsed_seconds=elapsed_seconds,
+                    train_elapsed_seconds=train_elapsed_seconds,
+                    grad_clip_threshold=float(grad_clip),
+                    grad_clip_triggered=False,
+                )
+                gradient_records.append(gradient_payload)
+                deps.append_jsonl_record(gradient_path, gradient_payload)
+                continue
             grad_clip_triggered = bool(local_grad_norm > grad_clip)
             if grad_clip_triggered:
                 clipped_step_count += 1

--- a/src/tab_foundry/research/sweep/runner.py
+++ b/src/tab_foundry/research/sweep/runner.py
@@ -6,6 +6,7 @@ import json
 import re
 import shlex
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
@@ -38,6 +39,12 @@ from tab_foundry.research.lane_contract import (
 from tab_foundry.research import system_delta
 from tab_foundry.research.system_delta_promote import promote_anchor
 from tab_foundry.training.artifacts import resolve_latest_checkpoint_path
+from tab_foundry.training.surface import (
+    TRAINING_BACKEND_MANIFEST,
+    TRAINING_BACKEND_PRIOR_DUMP,
+    resolve_training_backend_from_data_cfg,
+)
+from tab_foundry.training.trainer import train as train_from_manifest_cfg
 from tab_foundry.training.wandb import posthoc_update_wandb_summary
 
 from .artifacts import ExecutionPaths, read_yaml, result_card_text, write_research_package, write_yaml
@@ -62,6 +69,10 @@ DEFAULT_CONCLUSION = (
 ALLOWED_DECISIONS = {"keep", "defer", "reject"}
 SCREEN_ONLY_POLICY = "screen_only"
 BENCHMARK_FULL_POLICY = "benchmark_full"
+_ALLOWED_TRAINING_BACKENDS = {
+    TRAINING_BACKEND_MANIFEST,
+    TRAINING_BACKEND_PRIOR_DUMP,
+}
 
 
 @dataclass(frozen=True)
@@ -195,18 +206,6 @@ def ensure_nanotabpfn_python(*, nanotabpfn_root: Path, fallback_python: Path) ->
     return nanotab_python
 
 
-def completed_train_artifacts_exist(run_dir: Path) -> bool:
-    required_paths = (
-        run_dir / "train_history.jsonl",
-        run_dir / "gradient_history.jsonl",
-        run_dir / "telemetry.json",
-        run_dir / "training_surface_record.json",
-    )
-    return all(path.exists() for path in required_paths) and (
-        resolve_latest_checkpoint_path(run_dir) is not None
-    )
-
-
 def materialized_row_map(*, sweep_id: str, paths: ExecutionPaths) -> dict[str, dict[str, Any]]:
     materialized = system_delta.load_system_delta_queue(
         sweep_id=sweep_id,
@@ -314,6 +313,87 @@ def _read_json_mapping(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise RuntimeError(f"expected JSON mapping at {path}")
     return cast(dict[str, Any], payload)
+
+
+def _cfg_data_mapping(cfg: Any) -> Mapping[str, Any] | None:
+    raw_data_cfg = getattr(cfg, "data", None)
+    if raw_data_cfg is None and isinstance(cfg, Mapping):
+        raw_data_cfg = cfg.get("data")
+    if raw_data_cfg is None:
+        return None
+    if isinstance(raw_data_cfg, DictConfig):
+        raw_data_cfg = OmegaConf.to_container(raw_data_cfg, resolve=True)
+    if not isinstance(raw_data_cfg, Mapping):
+        raise RuntimeError("cfg.data must be a mapping when present")
+    return cast(Mapping[str, Any], raw_data_cfg)
+
+
+def resolve_training_backend(cfg: Any) -> str:
+    return resolve_training_backend_from_data_cfg(_cfg_data_mapping(cfg))
+
+
+def _training_surface_record_backend(record_path: Path) -> str | None:
+    if not record_path.exists():
+        return None
+    try:
+        payload = _read_json_mapping(record_path)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError):
+        return None
+    training = payload.get("training")
+    if not isinstance(training, Mapping):
+        return None
+    raw_backend = training.get("backend")
+    if not isinstance(raw_backend, str) or not raw_backend.strip():
+        return None
+    backend = str(raw_backend).strip().lower()
+    return backend if backend in _ALLOWED_TRAINING_BACKENDS else None
+
+
+def _training_telemetry_succeeded(telemetry_path: Path) -> bool:
+    if not telemetry_path.exists():
+        return False
+    try:
+        payload = _read_json_mapping(telemetry_path)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError):
+        return False
+    return bool(payload.get("success") is True)
+
+
+def _archive_incomplete_train_dir(train_dir: Path) -> Path | None:
+    if not train_dir.exists() or not train_dir.is_dir():
+        return None
+    try:
+        has_entries = any(train_dir.iterdir())
+    except OSError:
+        return None
+    if not has_entries:
+        return None
+    suffix = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+    candidate = train_dir.with_name(f"{train_dir.name}_incomplete_{suffix}")
+    counter = 1
+    while candidate.exists():
+        candidate = train_dir.with_name(f"{train_dir.name}_incomplete_{suffix}_{counter:02d}")
+        counter += 1
+    train_dir.rename(candidate)
+    return candidate
+
+
+def completed_train_artifacts_exist(run_dir: Path, *, expected_backend: str | None = None) -> bool:
+    required_paths = (
+        run_dir / "train_history.jsonl",
+        run_dir / "gradient_history.jsonl",
+        run_dir / "telemetry.json",
+        run_dir / "training_surface_record.json",
+    )
+    if not all(path.exists() for path in required_paths):
+        return False
+    if resolve_latest_checkpoint_path(run_dir) is None:
+        return False
+    if not _training_telemetry_succeeded(run_dir / "telemetry.json"):
+        return False
+    if expected_backend is None:
+        return True
+    return _training_surface_record_backend(run_dir / "training_surface_record.json") == expected_backend
 
 
 def _candidate_curve_path(summary: Mapping[str, Any], *, summary_path: Path) -> Path | None:
@@ -853,25 +933,55 @@ def run_row(
         training_config_profile=training_config_profile,
         surface_role=surface_role,
     )
-    if completed_train_artifacts_exist(train_dir):
+    cfg = compose_cfg(
+        row=queue_row,
+        run_dir=train_dir,
+        device=device,
+        training_experiment=training_experiment,
+        sweep_id=sweep_id,
+    )
+    training_backend = resolve_training_backend(cfg)
+    if completed_train_artifacts_exist(train_dir, expected_backend=training_backend):
         print(
             f"[row {int(queue_row['order']):02d}] reusing existing train artifacts",
             f"run_id={run_id}",
+            f"training_backend={training_backend}",
             f"output_dir={train_dir}",
             flush=True,
         )
     else:
-        cfg = compose_cfg(
-            row=queue_row,
-            run_dir=train_dir,
-            device=device,
-            training_experiment=training_experiment,
-            sweep_id=sweep_id,
+        existing_backend = _training_surface_record_backend(train_dir / "training_surface_record.json")
+        if completed_train_artifacts_exist(train_dir) and existing_backend != training_backend:
+            print(
+                f"[row {int(queue_row['order']):02d}] existing train artifacts are not reusable",
+                f"expected_backend={training_backend}",
+                f"observed_backend={existing_backend or 'missing'}",
+                flush=True,
+            )
+        archived_train_dir = _archive_incomplete_train_dir(train_dir)
+        if archived_train_dir is not None:
+            print(
+                f"[row {int(queue_row['order']):02d}] archived incomplete train dir",
+                f"run_id={run_id}",
+                f"archived_dir={archived_train_dir}",
+                flush=True,
+            )
+        print(
+            f"[row {int(queue_row['order']):02d}] starting train",
+            f"run_id={run_id}",
+            f"training_backend={training_backend}",
+            flush=True,
         )
-        train_result = train_tabfoundry_simple_prior(cfg, prior_dump_path=prior_dump)
+        if training_backend == TRAINING_BACKEND_MANIFEST:
+            train_result = train_from_manifest_cfg(cfg)
+        elif training_backend == TRAINING_BACKEND_PRIOR_DUMP:
+            train_result = train_tabfoundry_simple_prior(cfg, prior_dump_path=prior_dump)
+        else:  # pragma: no cover - guarded by resolve_training_backend
+            raise RuntimeError(f"unsupported training backend {training_backend!r}")
         print(
             f"[row {int(queue_row['order']):02d}] train complete",
             f"run_id={run_id}",
+            f"training_backend={training_backend}",
             f"output_dir={train_result.output_dir}",
             flush=True,
         )

--- a/src/tab_foundry/training/surface.py
+++ b/src/tab_foundry/training/surface.py
@@ -22,10 +22,42 @@ from tab_foundry.timestamps import utc_now as _shared_utc_now
 
 
 TRAINING_SURFACE_SCHEMA = "tab-foundry-training-surface-v1"
+TRAINING_BACKEND_MANIFEST = "manifest"
+TRAINING_BACKEND_PRIOR_DUMP = "prior_dump"
+_VALID_TRAINING_BACKENDS = {
+    TRAINING_BACKEND_MANIFEST,
+    TRAINING_BACKEND_PRIOR_DUMP,
+}
 
 
 def _utc_now() -> str:
     return _shared_utc_now()
+
+
+def _normalize_training_backend(value: Any) -> str | None:
+    if value is None:
+        return None
+    backend = str(value).strip().lower()
+    if not backend:
+        return None
+    if backend not in _VALID_TRAINING_BACKENDS:
+        raise ValueError(
+            f"training backend must be one of {sorted(_VALID_TRAINING_BACKENDS)}, got {value!r}"
+        )
+    return backend
+
+
+def resolve_training_backend_from_data_cfg(data_cfg: Mapping[str, Any] | None) -> str:
+    """Resolve the training backend from one data surface mapping."""
+
+    if data_cfg is None:
+        return TRAINING_BACKEND_PRIOR_DUMP
+    source = str(resolve_data_surface(data_cfg).source).strip().lower()
+    if source not in _VALID_TRAINING_BACKENDS:
+        raise RuntimeError(
+            f"unsupported training backend source {source!r}; expected one of {sorted(_VALID_TRAINING_BACKENDS)}"
+        )
+    return source
 
 
 def _sha256_path(path: Path) -> str:
@@ -139,6 +171,7 @@ def build_training_surface_record(
     run_dir: Path,
     state_dict: Mapping[str, Any] | None = None,
     include_manifest_characteristics: bool = True,
+    backend: str | None = None,
 ) -> dict[str, Any]:
     """Build one machine-readable training-surface record."""
 
@@ -191,6 +224,9 @@ def build_training_surface_record(
         )
     data_surface = resolve_data_surface(data_cfg)
     preprocessing_surface = resolve_preprocessing_surface(preprocessing_cfg)
+    resolved_backend = _normalize_training_backend(backend)
+    if resolved_backend is None:
+        resolved_backend = resolve_training_backend_from_data_cfg(data_cfg)
     manifest_payload: dict[str, Any] | None = None
     if data_surface.manifest_path is not None:
         manifest_payload = {
@@ -257,38 +293,43 @@ def build_training_surface_record(
             "overrides": preprocessing_surface.overrides,
         },
     }
-    if training_cfg is not None:
-        training_label = str(training_cfg.get("surface_label", "training_default"))
-        labels["training"] = training_label
-        payload["training"] = {
-            "surface_label": training_label,
-            "apply_schedule": bool(training_cfg.get("apply_schedule", False)),
-            "prior_dump_non_finite_policy": str(
-                training_cfg.get("prior_dump_non_finite_policy", "error")
-            ),
-            "prior_dump_batch_size": None
-            if training_cfg.get("prior_dump_batch_size") is None
-            else int(training_cfg["prior_dump_batch_size"]),
-            "prior_dump_lr_scale_rule": None
-            if training_cfg.get("prior_dump_lr_scale_rule") is None
-            else str(training_cfg["prior_dump_lr_scale_rule"]),
-            "prior_dump_batch_reference_size": None
-            if training_cfg.get("prior_dump_batch_reference_size") is None
-            else int(training_cfg["prior_dump_batch_reference_size"]),
-            "effective_lr_scale_factor": None
-            if training_cfg.get("effective_lr_scale_factor") is None
-            else float(training_cfg["effective_lr_scale_factor"]),
-            "optimizer_name": None
-            if optimizer_cfg is None or optimizer_cfg.get("name") is None
-            else str(optimizer_cfg["name"]),
-            "optimizer_min_lr": None
-            if optimizer_cfg is None or optimizer_cfg.get("min_lr") is None
-            else float(optimizer_cfg["min_lr"]),
-            "schedule_stages": None
-            if schedule_cfg is None
-            else schedule_cfg.get("stages"),
-            "overrides": training_cfg.get("overrides", {}),
-        }
+    if training_cfg is not None or resolved_backend is not None:
+        training_payload: dict[str, Any] = {}
+        if training_cfg is not None:
+            training_label = str(training_cfg.get("surface_label", "training_default"))
+            labels["training"] = training_label
+            training_payload = {
+                "surface_label": training_label,
+                "apply_schedule": bool(training_cfg.get("apply_schedule", False)),
+                "prior_dump_non_finite_policy": str(
+                    training_cfg.get("prior_dump_non_finite_policy", "error")
+                ),
+                "prior_dump_batch_size": None
+                if training_cfg.get("prior_dump_batch_size") is None
+                else int(training_cfg["prior_dump_batch_size"]),
+                "prior_dump_lr_scale_rule": None
+                if training_cfg.get("prior_dump_lr_scale_rule") is None
+                else str(training_cfg["prior_dump_lr_scale_rule"]),
+                "prior_dump_batch_reference_size": None
+                if training_cfg.get("prior_dump_batch_reference_size") is None
+                else int(training_cfg["prior_dump_batch_reference_size"]),
+                "effective_lr_scale_factor": None
+                if training_cfg.get("effective_lr_scale_factor") is None
+                else float(training_cfg["effective_lr_scale_factor"]),
+                "optimizer_name": None
+                if optimizer_cfg is None or optimizer_cfg.get("name") is None
+                else str(optimizer_cfg["name"]),
+                "optimizer_min_lr": None
+                if optimizer_cfg is None or optimizer_cfg.get("min_lr") is None
+                else float(optimizer_cfg["min_lr"]),
+                "schedule_stages": None
+                if schedule_cfg is None
+                else schedule_cfg.get("stages"),
+                "overrides": training_cfg.get("overrides", {}),
+            }
+        if resolved_backend is not None:
+            training_payload["backend"] = resolved_backend
+        payload["training"] = training_payload
     return payload
 
 
@@ -298,6 +339,7 @@ def write_training_surface_record(
     raw_cfg: Mapping[str, Any],
     run_dir: Path,
     state_dict: Mapping[str, Any] | None = None,
+    backend: str | None = None,
 ) -> dict[str, Any]:
     """Write one training-surface record and return the payload."""
 
@@ -305,6 +347,7 @@ def write_training_surface_record(
         raw_cfg=raw_cfg,
         run_dir=run_dir,
         state_dict=state_dict,
+        backend=backend,
     )
     resolved_path = path.expanduser().resolve()
     resolved_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/tab_foundry/training/trainer.py
+++ b/src/tab_foundry/training/trainer.py
@@ -43,7 +43,7 @@ from .instability import (
 from .optimizer import build_optimizer
 from .runtime import build_accelerator_from_runtime
 from .schedule import build_stage_configs, stage_base_lr
-from .surface import write_training_surface_record
+from .surface import TRAINING_BACKEND_MANIFEST, write_training_surface_record
 from .trainer_metrics import (
     _compute_loss_and_metrics,
     _evaluate_loader,
@@ -60,6 +60,7 @@ from .trainer_runtime_config import (
     _resolve_grad_accum_steps,
     _resolve_max_steps,
     _resolve_target_train_seconds,
+    _resolve_val_batches,
 )
 from .trainer_summary import _training_telemetry_summary_payload, _trainer_summary_payload
 from .wandb import (
@@ -106,6 +107,25 @@ def _global_grad_norm_kind(value: float) -> str:
     return "finite"
 
 
+def _reduce_global_grad_norm_kind(
+    accelerator: Any,
+    *,
+    local_kind: str,
+    device: torch.device,
+) -> str:
+    if local_kind not in {"finite", "nan", "pos_inf", "neg_inf"}:
+        raise ValueError(f"unsupported global grad norm kind {local_kind!r}")
+    if _accelerator_num_processes(accelerator) == 1:
+        return local_kind
+    if _reduce_any_flag(accelerator, local_kind == "nan", device=device):
+        return "nan"
+    if _reduce_any_flag(accelerator, local_kind == "pos_inf", device=device):
+        return "pos_inf"
+    if _reduce_any_flag(accelerator, local_kind == "neg_inf", device=device):
+        return "neg_inf"
+    return "finite"
+
+
 def train(cfg: DictConfig) -> TrainResult:
     """Train from config."""
 
@@ -124,6 +144,7 @@ def train(cfg: DictConfig) -> TrainResult:
     checkpoint_every = _checkpoint_every(cfg.runtime)
     max_steps = _resolve_max_steps(cfg.runtime)
     target_train_seconds = _resolve_target_train_seconds(cfg.runtime)
+    val_batches = _resolve_val_batches(cfg.runtime)
 
     accelerator = build_accelerator_from_runtime(
         cfg.runtime,
@@ -137,26 +158,27 @@ def train(cfg: DictConfig) -> TrainResult:
         seed=seed,
         preprocessing_cfg=cfg.get("preprocessing"),
     )
-    val_ds = build_task_dataset(
-        cfg.data,
-        split="val",
-        task=task,
-        seed=seed + 1,
-        preprocessing_cfg=cfg.get("preprocessing"),
-    )
-
     train_loader = build_task_loader(
         train_ds,
         shuffle=True,
         num_workers=int(cfg.runtime.num_workers),
         seed=seed,
     )
-    val_loader = build_task_loader(
-        val_ds,
-        shuffle=False,
-        num_workers=int(cfg.runtime.num_workers),
-        seed=seed + 1,
-    )
+    val_loader = None
+    if val_batches > 0:
+        val_ds = build_task_dataset(
+            cfg.data,
+            split="val",
+            task=task,
+            seed=seed + 1,
+            preprocessing_cfg=cfg.get("preprocessing"),
+        )
+        val_loader = build_task_loader(
+            val_ds,
+            shuffle=False,
+            num_workers=int(cfg.runtime.num_workers),
+            seed=seed + 1,
+        )
 
     raw_model_cfg = OmegaConf.to_container(cfg.model, resolve=True)
     model_cfg: dict[str, Any] = {}
@@ -164,7 +186,10 @@ def train(cfg: DictConfig) -> TrainResult:
         model_cfg = {str(key): value for key, value in raw_model_cfg.items()}
     model_spec = model_build_spec_from_mappings(task=task, primary=model_cfg)
     model = build_model_from_spec(model_spec)
-    model, train_loader, val_loader = accelerator.prepare(model, train_loader, val_loader)
+    if val_loader is None:
+        model, train_loader = accelerator.prepare(model, train_loader)
+    else:
+        model, train_loader, val_loader = accelerator.prepare(model, train_loader, val_loader)
     base_model = accelerator.unwrap_model(model)
     trace_activations = bool(getattr(cfg.runtime, "trace_activations", False))
     enable_activation_trace = getattr(base_model, "enable_activation_trace", None)
@@ -266,6 +291,7 @@ def train(cfg: DictConfig) -> TrainResult:
                 training_surface_path,
                 raw_cfg=raw_cfg,
                 run_dir=output_dir,
+                backend=TRAINING_BACKEND_MANIFEST,
             )
 
         run = init_wandb_run(
@@ -429,7 +455,74 @@ def train(cfg: DictConfig) -> TrainResult:
                 if float(cfg.runtime.grad_clip) > 0:
                     clipped = accelerator.clip_grad_norm_(model.parameters(), float(cfg.runtime.grad_clip))
                     local_grad_norm = normalize_grad_norm_value(clipped, fallback=local_grad_norm)
-                train_metric_sums["grad_norm"] = train_metric_sums.get("grad_norm", 0.0) + float(local_grad_norm)
+                global_grad_norm_kind = _reduce_global_grad_norm_kind(
+                    accelerator,
+                    local_kind=_global_grad_norm_kind(float(local_grad_norm)),
+                    device=accelerator.device,
+                )
+                if global_grad_norm_kind != "finite":
+                    _ = _flush_activation_trace_stats()
+                    nan_skip_count += 1
+                    for _opt_name, opt in prepared_opts:
+                        opt.zero_grad(set_to_none=True)
+                    train_elapsed_seconds += time.perf_counter() - step_train_start
+                    global_step += 1
+                    non_finite_grad_log: dict[str, Any] = {
+                        "train/non_finite_grad_guard_triggered": True,
+                        "train/non_finite_grad_kind": global_grad_norm_kind,
+                        "train/nan_skip_count": float(nan_skip_count),
+                    }
+                    log_wandb_metrics(run, non_finite_grad_log, step=global_step)
+                    if accelerator.is_main_process:
+                        elapsed_seconds = time.perf_counter() - train_start
+                        history_payload = history_record(
+                            global_step=global_step,
+                            stage_name=stage.name,
+                            train_loss=float("nan"),
+                            train_metrics={"non_finite_grad_guard_triggered": 1.0},
+                            lr=float(prepared_opts[0][1].param_groups[0]["lr"]),
+                            grad_norm=None,
+                            elapsed_seconds=elapsed_seconds,
+                            train_elapsed_seconds=train_elapsed_seconds,
+                            val_metrics=None,
+                            train_loss_delta=None,
+                            train_loss_ema=loss_ema,
+                            grad_clip_threshold=float(cfg.runtime.grad_clip),
+                            grad_clip_triggered=False,
+                        )
+                        history_records.append(history_payload)
+                        if history_path is not None:
+                            append_history_record(history_path, history_payload)
+                        gradient_payload = gradient_history_record(
+                            global_step=global_step,
+                            stage_name=stage.name,
+                            train_loss=float("nan"),
+                            train_acc=None,
+                            lr=float(prepared_opts[0][1].param_groups[0]["lr"]),
+                            global_grad_norm=None,
+                            global_grad_norm_kind=global_grad_norm_kind,
+                            module_grad_norms=pre_clip_module_grad_norms,
+                            activation_norms=None,
+                            elapsed_seconds=elapsed_seconds,
+                            train_elapsed_seconds=train_elapsed_seconds,
+                            grad_clip_threshold=float(cfg.runtime.grad_clip),
+                            grad_clip_triggered=False,
+                        )
+                        gradient_records.append(gradient_payload)
+                        append_jsonl_record(gradient_path, gradient_payload)
+                    if max_steps is not None and global_step >= max_steps:
+                        stop_requested = True
+                    if (
+                        target_train_seconds is not None
+                        and train_elapsed_seconds >= target_train_seconds
+                    ):
+                        stop_requested = True
+                    if stop_requested:
+                        break
+                    continue
+                train_metric_sums["grad_norm"] = train_metric_sums.get("grad_norm", 0.0) + float(
+                    local_grad_norm
+                )
                 train_metric_counts["grad_norm"] = train_metric_counts.get("grad_norm", 0) + 1
 
                 for _opt_name, opt in prepared_opts:
@@ -522,7 +615,7 @@ def train(cfg: DictConfig) -> TrainResult:
                 log_wandb_metrics(run, train_log, step=global_step)
 
                 history_val_metrics: dict[str, float] | None = None
-                if global_step % int(cfg.runtime.eval_every) == 0:
+                if val_loader is not None and global_step % int(cfg.runtime.eval_every) == 0:
                     _ = _flush_activation_trace_stats()
                     _set_optimizer_training_mode(prepared_opts, training=False)
                     val_metrics = _evaluate_loader(
@@ -530,7 +623,7 @@ def train(cfg: DictConfig) -> TrainResult:
                         val_loader,
                         accelerator=accelerator,
                         task=task,
-                        max_batches=int(cfg.runtime.val_batches),
+                        max_batches=val_batches,
                     )
                     log_wandb_metrics(
                         run,

--- a/src/tab_foundry/training/trainer_runtime_config.py
+++ b/src/tab_foundry/training/trainer_runtime_config.py
@@ -32,6 +32,14 @@ def _resolve_max_steps(runtime_cfg: DictConfig) -> int | None:
     return value
 
 
+def _resolve_val_batches(runtime_cfg: DictConfig) -> int:
+    raw_value = getattr(runtime_cfg, "val_batches", 0)
+    value = int(raw_value)
+    if value < 0:
+        raise ValueError(f"runtime.val_batches must be >= 0, got {value}")
+    return value
+
+
 def _resolve_target_train_seconds(runtime_cfg: DictConfig) -> float | None:
     raw_value = getattr(runtime_cfg, "target_train_seconds", None)
     if raw_value is None:

--- a/tests/benchmark/prior_train_cases.py
+++ b/tests/benchmark/prior_train_cases.py
@@ -370,15 +370,21 @@ class _OOMRetryConstantLogitModel(_ConstantLogitModel):
 
 
 class _CountingOptimizer:
-    def __init__(self) -> None:
+    def __init__(self, optimizer: torch.optim.Optimizer | None = None) -> None:
+        self._optimizer = optimizer
         self.step_count = 0
-        self.param_groups = [{"lr": 4.0e-3}]
+        self.param_groups = (
+            optimizer.param_groups if optimizer is not None else [{"lr": 4.0e-3}]
+        )
 
     def zero_grad(self, set_to_none: bool = True) -> None:
-        _ = set_to_none
+        if self._optimizer is not None:
+            self._optimizer.zero_grad(set_to_none=set_to_none)
 
     def step(self) -> None:
         self.step_count += 1
+        if self._optimizer is not None:
+            self._optimizer.step()
 
     def train(self) -> None:
         return None
@@ -993,6 +999,7 @@ def test_train_tabfoundry_simple_prior_scales_lr_with_prior_dump_batch_size(
     assert training_surface_record["training"]["schedule_stages"][0]["lr_max"] == pytest.approx(
         4.0e-3 * scale
     )
+    assert training_surface_record["training"]["backend"] == "prior_dump"
 
 
 def test_train_tabfoundry_simple_prior_retries_with_smaller_microbatches_on_oom(
@@ -2036,7 +2043,8 @@ def test_train_tabfoundry_simple_prior_skips_non_finite_loss_steps(
         single_eval_pos=np.asarray([2], dtype=np.int64),
     )
     fake_run = _FakeWandbRun()
-    optimizer = _CountingOptimizer()
+    model = _ConstantLogitModel()
+    optimizer = _CountingOptimizer(torch.optim.SGD(model.parameters(), lr=4.0e-3))
     loss_calls = {"count": 0}
 
     def _loss_with_one_nan(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
@@ -2045,7 +2053,7 @@ def test_train_tabfoundry_simple_prior_skips_non_finite_loss_steps(
             return logits.sum() * float("nan")
         return classification_loss(logits, targets)
 
-    monkeypatch.setattr(prior_train_module, "build_model_from_spec", lambda _spec: _ConstantLogitModel())
+    monkeypatch.setattr(prior_train_module, "build_model_from_spec", lambda _spec: model)
     monkeypatch.setattr(
         prior_train_module,
         "build_optimizer",
@@ -2092,6 +2100,93 @@ def test_train_tabfoundry_simple_prior_skips_non_finite_loss_steps(
     )
     assert telemetry["success"] is True
     assert telemetry["gradient_summary"]["record_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("grad_norm_value", "expected_kind"),
+    [
+        (float("nan"), "nan"),
+        (float("inf"), "pos_inf"),
+        (-float("inf"), "neg_inf"),
+    ],
+)
+def test_train_tabfoundry_simple_prior_skips_non_finite_gradient_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    grad_norm_value: float,
+    expected_kind: str,
+) -> None:
+    path = _write_prior_dump(
+        tmp_path / f"prior_non_finite_grad_{expected_kind}.h5",
+        x=np.asarray([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]], dtype=np.float32),
+        y=np.asarray([[0, 1, 0]], dtype=np.int64),
+        num_features=np.asarray([2], dtype=np.int64),
+        num_datapoints=np.asarray([3], dtype=np.int64),
+        single_eval_pos=np.asarray([2], dtype=np.int64),
+    )
+    fake_run = _FakeWandbRun()
+    model = _ConstantLogitModel()
+    optimizer = _CountingOptimizer(torch.optim.SGD(model.parameters(), lr=4.0e-3))
+
+    monkeypatch.setattr(prior_train_module, "build_model_from_spec", lambda _spec: model)
+    monkeypatch.setattr(
+        prior_train_module,
+        "build_optimizer",
+        lambda *args, **kwargs: OptimizerSelection(
+            optimizers=[("schedulefree_adamw", optimizer)],
+            requested_name="schedulefree_adamw",
+            resolved_name="schedulefree_adamw",
+            fallback_reason=None,
+        ),
+    )
+    monkeypatch.setattr(
+        prior_train_module,
+        "normalize_grad_norm_value",
+        lambda *_args, **_kwargs: grad_norm_value,
+    )
+    monkeypatch.setattr(prior_train_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+    cfg = _prior_cfg(tmp_path, max_steps=1)
+    cfg.logging.use_wandb = True
+    cfg.logging.project = "test-project"
+    cfg.logging.run_name = f"prior-non-finite-grad-{expected_kind}"
+
+    result = prior_train_module.train_tabfoundry_simple_prior(
+        cfg,
+        prior_dump_path=path,
+        batch_size=1,
+    )
+    history = [
+        json.loads(line)
+        for line in (result.output_dir / "train_history.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    gradient_history = [
+        json.loads(line)
+        for line in (result.output_dir / "gradient_history.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    telemetry = json.loads((result.output_dir / "telemetry.json").read_text(encoding="utf-8"))
+
+    assert optimizer.step_count == 0
+    assert result.metrics["nan_skip_count"] == 1.0
+    assert result.metrics["mean_grad_norm"] is None
+    assert result.metrics["max_grad_norm"] is None
+    assert result.metrics["final_grad_norm"] is None
+    assert len(history) == 1
+    assert math.isnan(float(history[0]["train_loss"]))
+    assert len(gradient_history) == 1
+    assert gradient_history[0]["global_grad_norm"] is None
+    assert gradient_history[0]["global_grad_norm_kind"] == expected_kind
+    assert telemetry["success"] is True
+    assert telemetry["gradient_summary"]["non_finite_global_grad_norm_counts"] == {
+        "nan": 1 if expected_kind == "nan" else 0,
+        "pos_inf": 1 if expected_kind == "pos_inf" else 0,
+        "neg_inf": 1 if expected_kind == "neg_inf" else 0,
+    }
+    assert any(
+        payload.get("train/non_finite_grad_guard_triggered") is True and step == 1
+        for payload, step in fake_run.logged
+    )
 
 
 def test_train_tabfoundry_simple_prior_closes_wandb_for_setup_failures(

--- a/tests/research/test_system_delta_execute.py
+++ b/tests/research/test_system_delta_execute.py
@@ -174,6 +174,20 @@ def _write_compare_summary(
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
 
 
+def _write_training_surface_record(path: Path, *, backend: str | None) -> None:
+    payload: dict[str, Any] = {}
+    if backend is not None:
+        payload['training'] = {'backend': backend}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def _write_training_telemetry(path: Path, *, success: bool) -> None:
+    path.write_text(
+        json.dumps({'success': success}, indent=2, sort_keys=True) + '\n',
+        encoding='utf-8',
+    )
+
+
 def test_select_queue_rows_defaults_to_ready_rows() -> None:
     queue = {
         'rows': [
@@ -992,8 +1006,8 @@ def test_run_row_screen_only_updates_queue_without_benchmark(monkeypatch: pytest
     (train_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (train_dir / 'train_history.jsonl').write_text('', encoding='utf-8')
     (train_dir / 'gradient_history.jsonl').write_text('', encoding='utf-8')
-    (train_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (train_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(train_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(train_dir / 'training_surface_record.json', backend='manifest')
     (train_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
 
     queue_row = {
@@ -1086,11 +1100,262 @@ def test_completed_train_artifacts_exist_accepts_stage_scoped_latest_checkpoint(
     (run_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (run_dir / 'train_history.jsonl').write_text('{}\n', encoding='utf-8')
     (run_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
-    (run_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (run_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(run_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(run_dir / 'training_surface_record.json', backend='manifest')
     (run_dir / 'checkpoints' / 'latest_stage1.pt').write_text('stub', encoding='utf-8')
 
-    assert runner_module.completed_train_artifacts_exist(run_dir) is True
+    assert runner_module.completed_train_artifacts_exist(run_dir, expected_backend='manifest') is True
+
+
+def test_completed_train_artifacts_exist_rejects_unsuccessful_telemetry(tmp_path: Path) -> None:
+    run_dir = tmp_path / 'completed_train_run_unsuccessful_telemetry'
+    (run_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
+    (run_dir / 'train_history.jsonl').write_text('{}\n', encoding='utf-8')
+    (run_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
+    _write_training_telemetry(run_dir / 'telemetry.json', success=False)
+    _write_training_surface_record(run_dir / 'training_surface_record.json', backend='manifest')
+    (run_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
+
+    assert runner_module.completed_train_artifacts_exist(run_dir, expected_backend='manifest') is False
+
+
+def test_completed_train_artifacts_exist_rejects_missing_backend_marker(tmp_path: Path) -> None:
+    run_dir = tmp_path / 'completed_train_run_missing_backend'
+    (run_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
+    (run_dir / 'train_history.jsonl').write_text('{}\n', encoding='utf-8')
+    (run_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
+    _write_training_telemetry(run_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(run_dir / 'training_surface_record.json', backend=None)
+    (run_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
+
+    assert runner_module.completed_train_artifacts_exist(run_dir, expected_backend='manifest') is False
+
+
+def test_completed_train_artifacts_exist_rejects_backend_mismatch(tmp_path: Path) -> None:
+    run_dir = tmp_path / 'completed_train_run_backend_mismatch'
+    (run_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
+    (run_dir / 'train_history.jsonl').write_text('{}\n', encoding='utf-8')
+    (run_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
+    _write_training_telemetry(run_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(run_dir / 'training_surface_record.json', backend='prior_dump')
+    (run_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
+
+    assert runner_module.completed_train_artifacts_exist(run_dir, expected_backend='manifest') is False
+
+
+def test_archive_incomplete_train_dir_moves_partial_history_aside(tmp_path: Path) -> None:
+    train_dir = tmp_path / 'partial_run' / 'train'
+    train_dir.mkdir(parents=True, exist_ok=True)
+    (train_dir / 'train_history.jsonl').write_text('{}\n', encoding='utf-8')
+
+    archived_dir = runner_module._archive_incomplete_train_dir(train_dir)
+
+    assert archived_dir is not None
+    assert archived_dir.exists()
+    assert not train_dir.exists()
+    assert archived_dir.name.startswith('train_incomplete_')
+    assert (archived_dir / 'train_history.jsonl').exists()
+
+
+def test_run_row_uses_manifest_trainer_for_manifest_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_row = {
+        'order': 1,
+        'delta_ref': 'delta_manifest_backend_probe',
+        'model': {},
+        'data': {'source': 'manifest', 'surface_label': 'manifest_probe'},
+        'training': {},
+        'execution_policy': 'screen_only',
+        'notes': [],
+    }
+    materialized_row = {
+        'delta_id': 'delta_manifest_backend_probe',
+        'dimension_family': 'training',
+        'family': 'screening',
+        'description': 'Probe manifest backend routing.',
+        'anchor_delta': 'Keep everything else fixed.',
+        'parameter_adequacy_plan': [],
+        'adequacy_knobs': [],
+        'model': {},
+        'notes': [],
+    }
+    queue = {'rows': [queue_row]}
+    paths = ExecutionPaths(
+        repo_root=tmp_path,
+        index_path=tmp_path / 'reference' / 'system_delta_sweeps' / 'index.yaml',
+        catalog_path=tmp_path / 'reference' / 'system_delta_catalog.yaml',
+        sweeps_root=tmp_path / 'reference' / 'system_delta_sweeps',
+        registry_path=REGISTRY_PATH,
+        program_path=tmp_path / 'program.md',
+        control_baseline_registry_path=REPO_ROOT / 'src' / 'tab_foundry' / 'bench' / 'control_baselines_v1.json',
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_manifest_train(cfg: Any) -> Any:
+        captured['manifest_cfg'] = cfg
+        return SimpleNamespace(output_dir=tmp_path / 'manifest_train')
+
+    monkeypatch.setattr(runner_module, 'write_research_package', lambda **_: None)
+    monkeypatch.setattr(runner_module, 'train_from_manifest_cfg', fake_manifest_train)
+    monkeypatch.setattr(
+        runner_module,
+        'train_tabfoundry_simple_prior',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('prior trainer should be skipped')),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        'screen_metrics',
+        lambda **_: {
+            'upper_block_final_window_mean': 1.0,
+            'upper_block_post_warmup_mean_slope': 0.01,
+            'clipped_step_fraction': 0.0,
+            'final_train_loss_ema': 0.5,
+        },
+    )
+    monkeypatch.setattr(
+        runner_module,
+        'run_nanotabpfn_benchmark',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('benchmark should be skipped')),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        'register_benchmark_run',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('registry should be skipped')),
+    )
+
+    runner_module.run_row(
+        sweep_id='backend_probe',
+        sweep_meta={
+            'control_baseline_id': 'cls_benchmark_linear_v2',
+            'benchmark_bundle_path': 'bundle.json',
+            'training_experiment': 'cls_benchmark_staged',
+            'training_config_profile': 'cls_benchmark_staged',
+            'surface_role': 'architecture_screen',
+        },
+        queue_row=queue_row,
+        materialized_row=materialized_row,
+        anchor_run_id='anchor_v1',
+        parent_run_id='anchor_v1',
+        queue=queue,
+        prior_dump=Path('/tmp/prior.h5'),
+        nanotabpfn_root=Path('/tmp/nanotabpfn'),
+        device='cuda',
+        fallback_python=REPO_ROOT / '.venv' / 'bin' / 'python',
+        decision='defer',
+        conclusion='Probe manifest backend selection.',
+        paths=paths,
+    )
+
+    assert captured['manifest_cfg'].data.source == 'manifest'
+    assert queue_row['status'] == 'screened'
+
+
+def test_run_row_uses_prior_dump_trainer_for_prior_dump_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_row = {
+        'order': 1,
+        'delta_ref': 'delta_prior_backend_probe',
+        'model': {},
+        'data': {'source': 'prior_dump', 'surface_label': 'prior_dump'},
+        'training': {},
+        'execution_policy': 'screen_only',
+        'notes': [],
+    }
+    materialized_row = {
+        'delta_id': 'delta_prior_backend_probe',
+        'dimension_family': 'training',
+        'family': 'screening',
+        'description': 'Probe prior backend routing.',
+        'anchor_delta': 'Keep everything else fixed.',
+        'parameter_adequacy_plan': [],
+        'adequacy_knobs': [],
+        'model': {},
+        'notes': [],
+    }
+    queue = {'rows': [queue_row]}
+    paths = ExecutionPaths(
+        repo_root=tmp_path,
+        index_path=tmp_path / 'reference' / 'system_delta_sweeps' / 'index.yaml',
+        catalog_path=tmp_path / 'reference' / 'system_delta_catalog.yaml',
+        sweeps_root=tmp_path / 'reference' / 'system_delta_sweeps',
+        registry_path=REGISTRY_PATH,
+        program_path=tmp_path / 'program.md',
+        control_baseline_registry_path=REPO_ROOT / 'src' / 'tab_foundry' / 'bench' / 'control_baselines_v1.json',
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_prior_train(cfg: Any, *, prior_dump_path: Path) -> Any:
+        captured['prior_cfg'] = cfg
+        captured['prior_dump_path'] = prior_dump_path
+        return SimpleNamespace(output_dir=tmp_path / 'prior_train')
+
+    monkeypatch.setattr(runner_module, 'write_research_package', lambda **_: None)
+    monkeypatch.setattr(
+        runner_module,
+        'train_from_manifest_cfg',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('manifest trainer should be skipped')),
+    )
+    monkeypatch.setattr(runner_module, 'train_tabfoundry_simple_prior', fake_prior_train)
+    monkeypatch.setattr(
+        runner_module,
+        'screen_metrics',
+        lambda **_: {
+            'upper_block_final_window_mean': 1.0,
+            'upper_block_post_warmup_mean_slope': 0.01,
+            'clipped_step_fraction': 0.0,
+            'final_train_loss_ema': 0.5,
+        },
+    )
+    monkeypatch.setattr(
+        runner_module,
+        'run_nanotabpfn_benchmark',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('benchmark should be skipped')),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        'register_benchmark_run',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError('registry should be skipped')),
+    )
+
+    runner_module.run_row(
+        sweep_id='backend_probe',
+        sweep_meta={
+            'control_baseline_id': 'cls_benchmark_linear_v2',
+            'benchmark_bundle_path': 'bundle.json',
+            'training_experiment': 'cls_benchmark_staged_prior',
+            'training_config_profile': 'cls_benchmark_staged_prior',
+            'surface_role': 'architecture_screen',
+        },
+        queue_row=queue_row,
+        materialized_row=materialized_row,
+        anchor_run_id='anchor_v1',
+        parent_run_id='anchor_v1',
+        queue=queue,
+        prior_dump=Path('/tmp/prior.h5'),
+        nanotabpfn_root=Path('/tmp/nanotabpfn'),
+        device='cuda',
+        fallback_python=REPO_ROOT / '.venv' / 'bin' / 'python',
+        decision='defer',
+        conclusion='Probe prior backend selection.',
+        paths=paths,
+    )
+
+    assert captured['prior_cfg'].data.source == 'prior_dump'
+    assert captured['prior_dump_path'] == Path('/tmp/prior.h5')
+    assert queue_row['status'] == 'screened'
+
+
+def test_resolve_training_backend_rejects_unsupported_source() -> None:
+    cfg = OmegaConf.create({'data': {'source': 'unsupported_source'}})
+
+    with pytest.raises(RuntimeError, match='unsupported training backend source'):
+        runner_module.resolve_training_backend(cfg)
 
 
 def test_run_row_legacy_sweep_meta_ignores_synthetic_anchor_context_experiment(
@@ -1234,8 +1499,8 @@ def test_run_row_benchmark_full_uses_sweep_training_contract_for_registration(
     (train_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (train_dir / 'train_history.jsonl').write_text('', encoding='utf-8')
     (train_dir / 'gradient_history.jsonl').write_text('', encoding='utf-8')
-    (train_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (train_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(train_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(train_dir / 'training_surface_record.json', backend='manifest')
     (train_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
     benchmark_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1428,8 +1693,8 @@ def test_run_row_benchmark_full_reuses_anchor_curve_without_bootstrapping_nanota
     (train_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (train_dir / 'train_history.jsonl').write_text('', encoding='utf-8')
     (train_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
-    (train_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (train_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(train_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(train_dir / 'training_surface_record.json', backend='manifest')
     (train_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
     benchmark_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1651,8 +1916,8 @@ def test_run_row_reuses_prior_completed_sweep_row_curve_before_bootstrapping_hel
     (train_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (train_dir / 'train_history.jsonl').write_text('', encoding='utf-8')
     (train_dir / 'gradient_history.jsonl').write_text('{}\n', encoding='utf-8')
-    (train_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (train_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(train_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(train_dir / 'training_surface_record.json', backend='manifest')
     (train_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
     benchmark_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2457,8 +2722,8 @@ def test_run_row_resolves_dynamic_post_stack_norm_from_screened_rows(
     (train_dir / 'checkpoints').mkdir(parents=True, exist_ok=True)
     (train_dir / 'train_history.jsonl').write_text('', encoding='utf-8')
     (train_dir / 'gradient_history.jsonl').write_text('', encoding='utf-8')
-    (train_dir / 'telemetry.json').write_text('{}', encoding='utf-8')
-    (train_dir / 'training_surface_record.json').write_text('{}', encoding='utf-8')
+    _write_training_telemetry(train_dir / 'telemetry.json', success=True)
+    _write_training_surface_record(train_dir / 'training_surface_record.json', backend='prior_dump')
     (train_dir / 'checkpoints' / 'latest.pt').write_text('stub', encoding='utf-8')
 
     row2 = {

--- a/tests/research/test_tf_rd_013_data_source_contract_v1.py
+++ b/tests/research/test_tf_rd_013_data_source_contract_v1.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -23,8 +24,8 @@ EXPECTED_ROWS = [
     "delta_data_manifest_root_dagzoo_generated_source",
     "delta_data_manifest_curated_realdata_comparator",
 ]
-GENERATED_RUN_ID = "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v1"
-CURATED_RUN_ID = "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v1"
+GENERATED_RUN_ID = "sd_tf_rd_013_data_source_contract_v1_01_delta_data_manifest_root_dagzoo_generated_source_v2"
+CURATED_RUN_ID = "sd_tf_rd_013_data_source_contract_v1_02_delta_data_manifest_curated_realdata_comparator_v2"
 REGISTRY_PATH = REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
 SUPPORT_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "support"
 MATRIX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "matrix.md"
@@ -34,19 +35,26 @@ EXPECTED_NUM_DATASETS = 8192
 EXPECTED_CURATED_TASK_COUNT = 12
 
 
-def _assert_full_replay_training_payload(row: dict[str, Any]) -> None:
+def _assert_full_replay_training_payload(
+    row: dict[str, Any],
+    *,
+    expected_val_batches: int | None = None,
+) -> None:
     training = row["training"]
     assert training["surface_label"] == "prior_linear_warmup_decay"
     assert training["prior_dump_non_finite_policy"] == "skip"
 
     overrides = training["overrides"]
     assert overrides["apply_schedule"] is True
-    assert overrides["runtime"] == {
+    runtime = {
         "max_steps": 2500,
         "eval_every": 25,
         "checkpoint_every": 25,
         "trace_activations": False,
     }
+    if expected_val_batches is not None:
+        runtime["val_batches"] = expected_val_batches
+    assert overrides["runtime"] == runtime
     assert overrides["optimizer"] == {
         "name": "schedulefree_adamw",
         "require_requested": True,
@@ -97,10 +105,16 @@ def _assert_row_execution_state(
     assert row["run_id"] == expected_run_id
     benchmark_metrics = row["benchmark_metrics"]
     assert isinstance(benchmark_metrics, dict)
-    assert benchmark_metrics["best_step"] == 2500
-    assert benchmark_metrics["final_log_loss"] == 0.42151055964690004
-    assert benchmark_metrics["final_brier_score"] == 0.26437640199935597
-    assert benchmark_metrics["final_roc_auc"] == 0.6701728307468436
+    assert int(benchmark_metrics["best_step"]) > 0
+    for metric_key in (
+        "final_log_loss",
+        "final_brier_score",
+        "final_roc_auc",
+        "best_log_loss",
+        "best_brier_score",
+        "best_roc_auc",
+    ):
+        assert math.isfinite(float(benchmark_metrics[metric_key]))
 
 
 def _ci_like_registry_path(tmp_path: Path) -> Path:
@@ -189,12 +203,12 @@ def test_tf_rd_013_data_source_contract_metadata_and_rows_match_unfiltered_suppo
     assert realdata_row["data"]["manifest_path"] == (
         "outputs/staged_ladder_support/tf_rd_013/curated_realdata/openml_baseline/manifest.parquet"
     )
-    _assert_full_replay_training_payload(realdata_row)
+    _assert_full_replay_training_payload(realdata_row, expected_val_batches=0)
     _assert_row_execution_state(realdata_row, expected_run_id=CURATED_RUN_ID)
     assert f"issue {MULTI_INVOCATION_ISSUE_NUMBER}" in realdata_row["next_action"]
     assert "issue 107" in realdata_row["next_action"]
     assert any("evidence-only" in note for note in realdata_row["notes"])
-    assert any("matched the anchor" in note for note in realdata_row["notes"])
+    assert any("materially worse than the anchor" in note for note in realdata_row["notes"])
     assert any("Fitness_Club" in confounder for confounder in realdata_row["confounders"])
 
     assert materialization_summary["issues"]["materialization_issue"] == MATERIALIZATION_ISSUE_NUMBER
@@ -260,8 +274,8 @@ def test_tf_rd_013_data_source_contract_metadata_and_rows_match_unfiltered_suppo
     materialized_rows = materialized["rows"]
     assert [row["delta_id"] for row in materialized_rows] == EXPECTED_ROWS
     assert [row["status"] for row in materialized_rows] == ["completed", "completed"]
-    for row in materialized_rows:
-        _assert_full_replay_training_payload(row)
+    _assert_full_replay_training_payload(materialized_rows[0])
+    _assert_full_replay_training_payload(materialized_rows[1], expected_val_batches=0)
 
     comparisons = manifest_characteristics_summary["comparisons"]
     assert set(comparisons) == {
@@ -305,6 +319,7 @@ def test_tf_rd_013_data_source_contract_inspect_and_diff_resolve_explicit_data_s
     assert inspect_realdata["target"]["resolved"]["data"]["surface_label"] == "tf_rd_013_curated_realdata_comparator"
     assert inspect_generated["target"]["resolved"]["training"]["optimizer_name"] == "schedulefree_adamw"
     assert inspect_generated["target"]["resolved"]["training"]["apply_schedule"] is True
+    assert inspect_generated["target"]["resolved"]["training"]["backend"] == "manifest"
     assert inspect_generated["target"]["resolved"]["training"]["prior_dump_non_finite_policy"] == "skip"
 
     diff_payload = diff_module.diff_sweep_row(
@@ -401,6 +416,7 @@ def test_tf_rd_013_support_bundle_and_catalog_defaults_are_tracked_separately() 
     comparator_default = catalog["deltas"]["delta_data_manifest_curated_realdata_comparator"]["default_effective_surface"]["data"]
     assert comparator_default == {
         "surface_label": "curated_realdata_comparator",
+        "allow_missing_values": True,
         "surface_overrides": {
             "source": "manifest",
             "manifest_path": "outputs/staged_ladder_support/curated_realdata/openml_baseline/manifest.parquet",

--- a/tests/research/test_tf_rd_013_shape_aware_dagzoo_v1.py
+++ b/tests/research/test_tf_rd_013_shape_aware_dagzoo_v1.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+import tab_foundry.research.sweep.diff as diff_module
+import tab_foundry.research.sweep.inspect as inspect_module
+from tab_foundry.research.system_delta import load_system_delta_queue
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEP_ID = "tf_rd_013_shape_aware_dagzoo_v1"
+ANCHOR_RUN_ID = "sd_qass_tfcol_large_missing_validation_v1_01_delta_qass_no_column_v3_v1"
+SHAPE_AWARE_ISSUE_NUMBER = 127
+FILTERING_POLICY_ISSUE_NUMBER = 124
+EXPECTED_ROWS = [
+    "delta_data_manifest_root_dagzoo_shape_aware_multi_invocation",
+    "delta_data_manifest_curated_realdata_comparator",
+]
+GENERATED_RUN_ID = (
+    "sd_tf_rd_013_shape_aware_dagzoo_v1_01_"
+    "delta_data_manifest_root_dagzoo_shape_aware_multi_invocation_v2"
+)
+CURATED_RUN_ID = "sd_tf_rd_013_shape_aware_dagzoo_v1_02_delta_data_manifest_curated_realdata_comparator_v1"
+SUPPORT_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "support"
+MATRIX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "matrix.md"
+MATERIALIZATION_SUMMARY_PATH = SUPPORT_ROOT / "materialization_summary.json"
+MANIFEST_CHARACTERISTICS_SUMMARY_PATH = SUPPORT_ROOT / "manifest_characteristics_summary.json"
+
+
+def _assert_training_payload(row: dict[str, Any], *, expected_val_batches: int) -> None:
+    training = row["training"]
+    assert training["surface_label"] == "prior_linear_warmup_decay"
+    assert training["prior_dump_non_finite_policy"] == "skip"
+    overrides = training["overrides"]
+    assert overrides["apply_schedule"] is True
+    assert overrides["runtime"] == {
+        "max_steps": 2500,
+        "eval_every": 25,
+        "checkpoint_every": 25,
+        "trace_activations": False,
+        "val_batches": expected_val_batches,
+    }
+    assert overrides["optimizer"] == {
+        "name": "schedulefree_adamw",
+        "require_requested": True,
+        "weight_decay": 0.0,
+        "betas": [0.9, 0.999],
+        "min_lr": 0.0004,
+        "muon_per_parameter_lr": False,
+    }
+    assert overrides["schedule"] == {
+        "stages": [
+            {
+                "name": "stage1",
+                "steps": 2500,
+                "lr_max": 0.004,
+                "lr_schedule": "linear",
+                "warmup_ratio": 0.05,
+            }
+        ]
+    }
+
+
+def _assert_completed_row(row: dict[str, Any], *, expected_run_id: str) -> None:
+    assert row["status"] == "completed"
+    assert row["run_id"] == expected_run_id
+    assert row["decision"] == "defer"
+    assert row["interpretation_status"] == "completed"
+    benchmark_metrics = row["benchmark_metrics"]
+    assert isinstance(benchmark_metrics, dict)
+    assert int(benchmark_metrics["best_step"]) > 0
+    for metric_key in (
+        "final_log_loss",
+        "final_brier_score",
+        "final_roc_auc",
+        "best_log_loss",
+        "best_brier_score",
+        "best_roc_auc",
+    ):
+        assert math.isfinite(float(benchmark_metrics[metric_key]))
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _row_by_ref(queue: dict[str, Any], delta_ref: str) -> dict[str, Any]:
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    return next(row for row in rows if row["delta_ref"] == delta_ref)
+
+
+def test_tf_rd_013_shape_aware_sweep_is_registered_but_not_active() -> None:
+    index = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml")
+
+    assert index["active_sweep_id"] == "cuda_stack_scale_followup"
+    sweeps = index["sweeps"]
+    assert isinstance(sweeps, dict)
+    assert sweeps[SWEEP_ID] == {
+        "parent_sweep_id": "tf_rd_013_data_source_contract_v1",
+        "status": "completed",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "binary_md",
+        "benchmark_bundle_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+    }
+
+
+def test_tf_rd_013_shape_aware_metadata_rows_and_support_bundle_match() -> None:
+    sweep_root = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+    materialization_summary = _load_json(MATERIALIZATION_SUMMARY_PATH)
+    manifest_characteristics_summary = _load_json(MANIFEST_CHARACTERISTICS_SUMMARY_PATH)
+
+    assert sweep["sweep_id"] == SWEEP_ID
+    assert sweep["parent_sweep_id"] == "tf_rd_013_data_source_contract_v1"
+    assert sweep["status"] == "completed"
+    assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
+    assert sweep["upstream_reference"] == {
+        "name": "TabICLv2",
+        "model_source": "https://arxiv.org/abs/2602.11139",
+    }
+    notes = sweep["anchor_surface"]["notes"]
+    assert isinstance(notes, list)
+    assert any("issue 127" in note for note in notes)
+    assert any("invocations" in note for note in notes)
+
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
+    assert [row["status"] for row in rows] == ["completed", "completed"]
+
+    generated_row = _row_by_ref(queue, EXPECTED_ROWS[0])
+    _assert_completed_row(generated_row, expected_run_id=GENERATED_RUN_ID)
+    _assert_training_payload(generated_row, expected_val_batches=0)
+    assert generated_row["data"]["surface_label"] == "tf_rd_013_dagzoo_shape_aware_multi_invocation"
+    assert generated_row["data"]["manifest_path"] == (
+        "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+        "dagzoo_shape_aware_multi_invocation/manifest.parquet"
+    )
+    generated_provenance = generated_row["data"]["dagzoo_provenance"]
+    assert generated_provenance["corpus_variant"] == "dagzoo_shape_aware_multi_invocation"
+    assert generated_provenance["materialization_issue"] == SHAPE_AWARE_ISSUE_NUMBER
+    assert generated_provenance["config_refs"] == [
+        "configs/benchmark_cpu.yaml",
+        "configs/default.yaml",
+        "configs/benchmark_cuda_h100_large_shape.yaml",
+    ]
+    assert [entry["invocation_id"] for entry in generated_provenance["invocations"]] == [
+        "benchmark_cpu",
+        "default_medium",
+        "large_shape",
+    ]
+    assert any("issue 127" in note for note in generated_row["notes"])
+    assert f"Issue {FILTERING_POLICY_ISSUE_NUMBER}" in "\n".join(generated_row["notes"])
+    assert "issue 127" in generated_row["next_action"]
+    assert "issue 96" in generated_row["next_action"]
+    assert "issue 107" in generated_row["next_action"]
+    assert any("Fitness_Club" in confounder for confounder in generated_row["confounders"])
+
+    curated_row = _row_by_ref(queue, EXPECTED_ROWS[1])
+    _assert_completed_row(curated_row, expected_run_id=CURATED_RUN_ID)
+    _assert_training_payload(curated_row, expected_val_batches=0)
+    assert curated_row["data"]["surface_label"] == "tf_rd_013_curated_realdata_comparator"
+    assert curated_row["data"]["manifest_path"] == (
+        "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+        "curated_realdata/openml_baseline/manifest.parquet"
+    )
+    assert any("evidence-only" in note for note in curated_row["notes"])
+    assert any("materially worse than the anchor" in note for note in curated_row["notes"])
+    assert "issue 127" in curated_row["next_action"]
+    assert "96" in curated_row["next_action"]
+    assert "107" in curated_row["next_action"]
+    assert any("Fitness_Club" in confounder for confounder in curated_row["confounders"])
+
+    assert materialization_summary["issues"]["materialization_issue"] == SHAPE_AWARE_ISSUE_NUMBER
+    assert materialization_summary["issues"]["execution_issue"] == SHAPE_AWARE_ISSUE_NUMBER
+    assert materialization_summary["issues"]["epic_issue"] == 96
+    assert materialization_summary["issues"]["downstream_training_surface_issue"] == 107
+    assert materialization_summary["shape_program"]["kind"] == "config_ladder"
+    assert materialization_summary["assembly"]["invocation_count"] == 3
+    assert materialization_summary["assembly"]["persisted_summary"]["total_records"] > 0
+    assert len(
+        materialization_summary["surfaces"]["dagzoo_shape_aware_multi_invocation"]["invocation_handoffs"]
+    ) == 3
+
+    generated_manifest = manifest_characteristics_summary["manifests"]["dagzoo_shape_aware_multi_invocation"]
+    assert generated_manifest["manifest_path"] == (
+        "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+        "dagzoo_shape_aware_multi_invocation/manifest.parquet"
+    )
+    assert generated_manifest["inspection"]["unique_source_root_count"] == 3
+    assert set(manifest_characteristics_summary["comparisons"]) == {
+        "anchor_vs_curated_realdata_openml_baseline",
+        "anchor_vs_dagzoo_shape_aware_multi_invocation",
+        "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline",
+    }
+
+    materialized = load_system_delta_queue(
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+    materialized_rows = materialized["rows"]
+    assert [row["delta_id"] for row in materialized_rows] == EXPECTED_ROWS
+    assert [row["status"] for row in materialized_rows] == ["completed", "completed"]
+
+
+def test_tf_rd_013_shape_aware_inspect_and_diff_resolve_broader_data_surface() -> None:
+    inspect_generated = inspect_module.inspect_sweep_row(
+        order=1,
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+        sweeps_root=REPO_ROOT / "reference" / "system_delta_sweeps",
+        registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+    )
+
+    resolved_generated = inspect_generated["target"]["resolved"]["data"]
+    assert resolved_generated["surface_label"] == "tf_rd_013_dagzoo_shape_aware_multi_invocation"
+    assert resolved_generated["source"] == "manifest"
+    assert resolved_generated["dagzoo_provenance"]["corpus_variant"] == "dagzoo_shape_aware_multi_invocation"
+    assert len(resolved_generated["dagzoo_provenance"]["invocations"]) == 3
+    assert inspect_generated["target"]["resolved"]["training"]["backend"] == "manifest"
+    assert resolved_generated["manifest"]["manifest_path"].endswith(
+        "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+        "dagzoo_shape_aware_multi_invocation/manifest.parquet"
+    )
+
+    diff_payload = diff_module.diff_sweep_row(
+        order=1,
+        sweep_id=SWEEP_ID,
+        against="anchor",
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+        sweeps_root=REPO_ROOT / "reference" / "system_delta_sweeps",
+        registry_path=REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json",
+    )
+
+    differences = diff_payload["differences"]
+    assert differences["resolved.data.surface_label"] == {
+        "target": "tf_rd_013_dagzoo_shape_aware_multi_invocation",
+        "against": "anchor_manifest_default",
+    }
+    assert differences["resolved.data.dagzoo_provenance"]["target"]["corpus_variant"] == (
+        "dagzoo_shape_aware_multi_invocation"
+    )
+    assert len(differences["resolved.data.dagzoo_provenance"]["target"]["invocations"]) == 3
+
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+    assert "Sweep status: `completed`" in matrix
+    assert GENERATED_RUN_ID in matrix
+    assert CURATED_RUN_ID in matrix
+    assert "helper_failed_on_missing_bundle" in matrix
+    assert "Fitness_Club" in matrix
+    assert "issue 127" in matrix
+
+
+def test_tf_rd_013_shape_aware_support_bundle_and_catalog_defaults_are_tracked_separately() -> None:
+    materialization_summary = _load_json(MATERIALIZATION_SUMMARY_PATH)
+    manifest_characteristics_summary = _load_json(MANIFEST_CHARACTERISTICS_SUMMARY_PATH)
+    catalog = _load_yaml(REPO_ROOT / "reference" / "system_delta_catalog.yaml")
+
+    assert MATERIALIZATION_SUMMARY_PATH.exists()
+    assert MANIFEST_CHARACTERISTICS_SUMMARY_PATH.exists()
+    assert SUPPORT_ROOT.joinpath("README.md").exists()
+    assert materialization_summary["config_refs"]["dagzoo"] == [
+        "configs/benchmark_cpu.yaml",
+        "configs/default.yaml",
+        "configs/benchmark_cuda_h100_large_shape.yaml",
+    ]
+    assert materialization_summary["artifacts"]["dagzoo_shape_aware_manifest_path"] == (
+        "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+        "dagzoo_shape_aware_multi_invocation/manifest.parquet"
+    )
+    assert set(manifest_characteristics_summary["comparisons"]) == {
+        "anchor_vs_curated_realdata_openml_baseline",
+        "anchor_vs_dagzoo_shape_aware_multi_invocation",
+        "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline",
+    }
+    for path in (
+        MATERIALIZATION_SUMMARY_PATH,
+        MANIFEST_CHARACTERISTICS_SUMMARY_PATH,
+        SUPPORT_ROOT / "README.md",
+    ):
+        assert "/Users/" not in path.read_text(encoding="utf-8")
+
+    dagzoo_default = catalog["deltas"]["delta_data_manifest_root_dagzoo_shape_aware_multi_invocation"][
+        "default_effective_surface"
+    ]["data"]
+    assert dagzoo_default == {
+        "surface_label": "tf_rd_013_dagzoo_shape_aware_multi_invocation",
+        "surface_overrides": {
+            "source": "manifest",
+            "manifest_path": (
+                "outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/"
+                "dagzoo_shape_aware_multi_invocation/manifest.parquet"
+            ),
+            "dagzoo_provenance": {
+                "commands": [],
+                "config_refs": [],
+                "curated_root_lineage": [],
+                "invocations": [],
+            },
+        },
+    }

--- a/tests/research/test_tf_rd_013_support_materializer.py
+++ b/tests/research/test_tf_rd_013_support_materializer.py
@@ -9,7 +9,7 @@ import sys
 import numpy as np
 import pyarrow.parquet as pq
 
-from tab_foundry.data.manifest import build_manifest
+from tab_foundry.data.manifest import MANIFEST_SUMMARY_METADATA_KEY, build_manifest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -161,3 +161,224 @@ def test_materialize_curated_openml_baseline_writes_manifest_backed_shards(
     assert payload["metadata"]["source_platform"] == "openml"
     assert payload["metadata"]["benchmark_bundle"]["source_path"] == module.DEFAULT_BENCHMARK_BUNDLE_REF
     assert payload["metadata"]["openml"]["task_id"] == 101
+
+
+def test_shape_aware_materializer_merges_multiple_dagzoo_invocations_without_single_handoff_metadata(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    dagzoo_root = tmp_path / "dagzoo"
+    (dagzoo_root / "configs").mkdir(parents=True, exist_ok=True)
+    for config_name in (
+        "benchmark_cpu.yaml",
+        "default.yaml",
+        "benchmark_cuda_h100_large_shape.yaml",
+    ):
+        (dagzoo_root / "configs" / config_name).write_text("seed: 1\n", encoding="utf-8")
+
+    anchor_root = tmp_path / "anchor"
+    anchor_data_root = anchor_root / "packed_shards"
+    shard_dir = anchor_data_root / "shard_00001_anchor"
+    module._write_packed_shard(
+        shard_dir,
+        x_train=np.array([[0.0, 1.0], [1.0, 2.0]], dtype=np.float32),
+        y_train=np.array([0, 1], dtype=np.int64),
+        x_test=np.array([[2.0, 3.0]], dtype=np.float32),
+        y_test=np.array([1], dtype=np.int64),
+        metadata={
+            "config": {"dataset": {"task": "classification"}},
+            "filter": {"mode": "deferred", "status": "not_run"},
+            "n_classes": 2,
+            "seed": 0,
+        },
+    )
+    anchor_manifest_path = anchor_root / "manifest.parquet"
+    build_manifest([anchor_data_root], anchor_manifest_path)
+
+    fake_bundle = {
+        "name": "nanotabpfn_openml_binary_large",
+        "version": 1,
+        "selection": {
+            "new_instances": 10,
+            "task_type": "supervised_classification",
+            "max_features": 20,
+            "max_missing_pct": 5.0,
+            "max_classes": 2,
+            "min_minority_class_pct": 2.5,
+        },
+        "task_ids": [101],
+        "tasks": [
+            {"task_id": 101, "dataset_name": "first_dataset", "n_rows": 10, "n_features": 3, "n_classes": 2},
+        ],
+    }
+    prepared_task = module.PreparedOpenMLBenchmarkTask(
+        task_id=101,
+        dataset_name="first_dataset",
+        x=np.array(
+            [
+                [0.0, 1.0, 2.0],
+                [1.0, 2.0, 3.0],
+                [2.0, 3.0, 4.0],
+                [3.0, 4.0, 5.0],
+                [4.0, 5.0, 6.0],
+                [5.0, 6.0, 7.0],
+                [6.0, 7.0, 8.0],
+                [7.0, 8.0, 9.0],
+                [8.0, 9.0, 10.0],
+                [9.0, 10.0, 11.0],
+            ],
+            dtype=np.float32,
+        ),
+        y=np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=np.int64),
+        observed_task={"task_id": 101, "dataset_name": "first_dataset", "n_rows": 10, "n_features": 3},
+        qualities={"NumberOfFeatures": 3.0, "PercentageOfInstancesWithMissingValues": 0.0, "NumberOfClasses": 2.0},
+    )
+
+    monkeypatch.setattr(module, "ANCHOR_MANIFEST_PATH", anchor_manifest_path)
+    monkeypatch.setattr(module, "SHAPE_AWARE_LOCAL_OUTPUT_ROOT", tmp_path / "outputs" / "shape_aware")
+    monkeypatch.setattr(module, "SHAPE_AWARE_SUPPORT_ROOT", tmp_path / "support")
+    monkeypatch.setattr(module, "load_benchmark_bundle_for_execution", lambda _path: (fake_bundle, True))
+    monkeypatch.setattr(module, "prepare_openml_benchmark_task", lambda *_args, **_kwargs: prepared_task)
+
+    def fake_manifest_inspect(path: Path) -> dict[str, object]:
+        metadata = pq.read_metadata(path).metadata or {}
+        persisted_summary = None
+        raw_summary = metadata.get(MANIFEST_SUMMARY_METADATA_KEY)
+        if raw_summary is not None:
+            persisted_summary = json.loads(raw_summary.decode("utf-8"))
+        table = pq.read_table(path)
+        return {
+            "manifest_path": module._portable_path(path),
+            "persisted_summary": persisted_summary,
+            "total_records": int(table.num_rows),
+            "unique_dataset_id_count": int(table.num_rows),
+            "unique_source_root_count": len({str(value) for value in table.column("source_root_id").to_pylist()}),
+        }
+
+    monkeypatch.setattr(module, "_manifest_inspect", fake_manifest_inspect)
+
+    def fake_run_checked(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+        if "dagzoo" in cmd and "generate" in cmd:
+            handoff_root = Path(cmd[cmd.index("--handoff-root") + 1])
+            config_path = Path(cmd[cmd.index("--config") + 1])
+            generated_dir = handoff_root / "generated" / "shard_00001_generated"
+            generate_hex = {
+                "benchmark_cpu.yaml": "a" * 32,
+                "default.yaml": "b" * 32,
+                "benchmark_cuda_h100_large_shape.yaml": "c" * 32,
+            }[config_path.name]
+            dataset_hex = {
+                "benchmark_cpu.yaml": "1" * 32,
+                "default.yaml": "2" * 32,
+                "benchmark_cuda_h100_large_shape.yaml": "3" * 32,
+            }[config_path.name]
+            module._write_packed_shard(
+                generated_dir,
+                x_train=np.array([[0.0, 1.0], [1.0, 2.0]], dtype=np.float32),
+                y_train=np.array([0, 1], dtype=np.int64),
+                x_test=np.array([[2.0, 3.0]], dtype=np.float32),
+                y_test=np.array([1], dtype=np.int64),
+                metadata={
+                    "config": {"dataset": {"task": "classification"}},
+                    "filter": {"mode": "deferred", "status": "not_run"},
+                    "dataset_id": dataset_hex,
+                    "split_groups": {"request_run": generate_hex},
+                    "n_classes": 2,
+                    "seed": 1,
+                },
+            )
+            handoff_root.mkdir(parents=True, exist_ok=True)
+            (handoff_root / "handoff_manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_name": "dagzoo_generate_handoff_manifest",
+                        "schema_version": 1,
+                        "identity": {
+                            "source_family": "dagzoo.fixed_layout_scm",
+                            "generate_run_id": generate_hex,
+                            "generated_corpus_id": dataset_hex,
+                        },
+                        "artifacts_relative": {
+                            "run_root": ".",
+                            "generated_dir": "generated",
+                        },
+                        "defaults": {
+                            "recommended_training_corpus": "generated",
+                            "recommended_training_artifact_key": "generated_dir",
+                            "curation_policy": "none",
+                        },
+                        "summary": {"generated_datasets": 1},
+                        "throughput": {"generation_stage": {"generated_datasets": 1, "elapsed_seconds": 1.0}},
+                        "hardware": {
+                            "backend": "cpu",
+                            "device_name": "cpu",
+                            "hardware_policy": "none",
+                            "requested_device": "cpu",
+                            "resolved_device": "cpu",
+                            "tier": "cpu",
+                        },
+                        "generate_invocation": {
+                            "config_path": module._portable_path(config_path),
+                            "overrides": {"num_datasets": 1},
+                        },
+                    },
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if "build-manifest" in cmd:
+            out_manifest = Path(cmd[cmd.index("--out-manifest") + 1])
+            data_root = Path(cmd[cmd.index("--data-root") + 1])
+            build_manifest([data_root], out_manifest)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(module, "_run_checked", fake_run_checked)
+
+    result = module.materialize_support(
+        variant="shape-aware",
+        dagzoo_root=dagzoo_root,
+        force=True,
+    )
+
+    assert result == 0
+    support_root = module.SHAPE_AWARE_SUPPORT_ROOT
+    materialization_summary = json.loads((support_root / "materialization_summary.json").read_text(encoding="utf-8"))
+    manifest_characteristics_summary = json.loads(
+        (support_root / "manifest_characteristics_summary.json").read_text(encoding="utf-8")
+    )
+
+    dagzoo_surface = materialization_summary["surfaces"]["dagzoo_shape_aware_multi_invocation"]
+    dagzoo_provenance = dagzoo_surface["dagzoo_provenance"]
+    assert dagzoo_provenance["corpus_variant"] == "dagzoo_shape_aware_multi_invocation"
+    assert dagzoo_provenance["config_refs"] == [
+        "configs/benchmark_cpu.yaml",
+        "configs/default.yaml",
+        "configs/benchmark_cuda_h100_large_shape.yaml",
+    ]
+    assert [entry["invocation_id"] for entry in dagzoo_provenance["invocations"]] == [
+        "benchmark_cpu",
+        "default_medium",
+        "large_shape",
+    ]
+    assert materialization_summary["assembly"]["invocation_count"] == 3
+
+    combined_manifest_path = Path(dagzoo_surface["manifest_path"])
+    if not combined_manifest_path.is_absolute():
+        combined_manifest_path = REPO_ROOT / combined_manifest_path
+    persisted_summary = json.loads(
+        pq.read_metadata(combined_manifest_path).metadata[MANIFEST_SUMMARY_METADATA_KEY].decode("utf-8")
+    )
+    assert "dagzoo_handoff" not in persisted_summary
+    assert persisted_summary["total_records"] == 3
+
+    comparisons = manifest_characteristics_summary["comparisons"]
+    assert set(comparisons) == {
+        "anchor_vs_curated_realdata_openml_baseline",
+        "anchor_vs_dagzoo_shape_aware_multi_invocation",
+        "dagzoo_shape_aware_multi_invocation_vs_curated_realdata_openml_baseline",
+    }

--- a/tests/training/test_surface.py
+++ b/tests/training/test_surface.py
@@ -434,6 +434,40 @@ def test_build_training_surface_record_includes_optional_training_surface(
     assert record["training"]["effective_lr_scale_factor"] is None
 
 
+def test_build_training_surface_record_infers_manifest_backend_from_data_surface(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path / "manifest_backend.parquet")
+
+    record = build_training_surface_record(
+        raw_cfg={
+            "task": "classification",
+            "model": {"arch": "tabfoundry_staged"},
+            "data": {
+                "source": "manifest",
+                "manifest_path": str(manifest_path),
+            },
+        },
+        run_dir=tmp_path / "run_manifest_backend",
+    )
+
+    assert record["training"]["backend"] == "manifest"
+
+
+def test_build_training_surface_record_infers_prior_dump_backend_without_data_cfg(
+    tmp_path: Path,
+) -> None:
+    record = build_training_surface_record(
+        raw_cfg={
+            "task": "classification",
+            "model": {"arch": "tabfoundry_staged"},
+        },
+        run_dir=tmp_path / "run_prior_dump_backend",
+    )
+
+    assert record["training"]["backend"] == "prior_dump"
+
+
 def test_build_training_surface_record_captures_prior_dump_batch_scaling_metadata(
     tmp_path: Path,
 ) -> None:

--- a/tests/training/test_train_eval_smoke.py
+++ b/tests/training/test_train_eval_smoke.py
@@ -558,6 +558,9 @@ def test_train_smoke_runs_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     cfg = _classification_cfg(tmp_path)
 
     result = trainer_module.train(cfg)
+    training_surface_record = json.loads(
+        (result.output_dir / 'training_surface_record.json').read_text(encoding='utf-8')
+    )
 
     assert result.global_step == 1
     assert result.best_checkpoint is not None
@@ -570,6 +573,30 @@ def test_train_smoke_runs_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert result.metrics["max_grad_norm"] >= 0.0
     best_payload = torch.load(result.best_checkpoint, map_location="cpu", weights_only=False)
     assert "preprocessor_state" not in best_payload
+    assert training_surface_record['training']['backend'] == 'manifest'
+
+
+def test_train_smoke_skips_validation_loader_when_val_batches_is_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_classification_fakes(monkeypatch)
+
+    def _build_task_dataset(*_args, split: str, **_kwargs):
+        if split == 'val':
+            raise AssertionError('val split should be skipped when runtime.val_batches == 0')
+        return _FakeTaskDataset()
+
+    monkeypatch.setattr(trainer_module, 'build_task_dataset', _build_task_dataset)
+    cfg = _classification_cfg(tmp_path)
+    cfg.runtime.val_batches = 0
+
+    result = trainer_module.train(cfg)
+
+    assert result.global_step == 1
+    assert math.isinf(result.metrics['best_val_loss'])
+    assert math.isinf(result.metrics['final_val_loss'])
+    assert result.latest_checkpoint is not None
 
 
 def test_train_smoke_writes_step_snapshots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1119,11 +1146,30 @@ def test_train_records_non_finite_global_grad_norm_kinds(
     expected_kind: str,
 ) -> None:
     _install_classification_fakes(monkeypatch)
+    counting_optimizer: _CountingOptimizer | None = None
+
+    def _build_counting_optimizer(model: nn.Module, **_kwargs: object) -> OptimizerSelection:
+        nonlocal counting_optimizer
+        base_optimizer = torch.optim.AdamW(
+            [param for param in model.parameters() if param.requires_grad],
+            lr=1.0e-3,
+            weight_decay=0.0,
+            betas=(0.9, 0.95),
+        )
+        counting_optimizer = _CountingOptimizer(base_optimizer)
+        return OptimizerSelection(
+            optimizers=[("adamw", counting_optimizer)],
+            requested_name="adamw",
+            resolved_name="adamw",
+            fallback_reason=None,
+        )
+
     cfg = _classification_cfg(tmp_path)
     cfg.runtime.eval_every = 10
     cfg.logging.use_wandb = True
     fake_run = _FakeWandbRun()
     monkeypatch.setattr(trainer_module, "init_wandb_run", lambda *_args, **_kwargs: fake_run)
+    monkeypatch.setattr(trainer_module, "build_optimizer", _build_counting_optimizer)
     monkeypatch.setattr(
         trainer_module,
         "normalize_grad_norm_value",
@@ -1141,6 +1187,8 @@ def test_train_records_non_finite_global_grad_norm_kinds(
 
     assert gradient_history[0]["global_grad_norm"] is None
     assert gradient_history[0]["global_grad_norm_kind"] == expected_kind
+    assert counting_optimizer is not None
+    assert counting_optimizer.step_calls == 0
     assert result.metrics["mean_grad_norm"] is None
     assert result.metrics["max_grad_norm"] is None
     assert result.metrics["final_grad_norm"] is None
@@ -1157,6 +1205,10 @@ def test_train_records_non_finite_global_grad_norm_kinds(
     assert (
         fake_run.summary[f"gradient_summary/non_finite_global_grad_norm_counts/{expected_kind}"]
         == 1
+    )
+    assert any(
+        step == 1 and payload.get("train/non_finite_grad_guard_triggered") is True
+        for payload, step in fake_run.logged
     )
 
 


### PR DESCRIPTION
## Summary
- Add TF-RD-013 shape-aware Dagzoo data source sweep (`tf_rd_013_shape_aware_dagzoo_v1`), a follow-up to `tf_rd_013_data_source_contract_v1` that tests a broader multi-invocation dagzoo config ladder (benchmark_cpu 2048, default_medium 4096, large_shape 128 = 6,272 datasets) against the promoted `row_cls + qass + no tfcol` anchor
- Extend manifest-backed training surface to support per-invocation dagzoo provenance with explicit `dagzoo_provenance.invocations` array, row caps (`train_row_cap=512`, `test_row_cap=256`), and `prior_dump_non_finite_policy: skip`
- Re-run curated real-data OpenML comparator inside the same sweep for self-contained current-vs-dagzoo-vs-curated evidence
- Register canonical benchmark runs and record **defer** decision on both rows: the broader dagzoo surface still underperforms the anchor (log loss 0.4658 vs 0.4215, ROC AUC 0.5111 vs 0.6702), keeping the current corpus as the representative post-TF-RD-008 training-data surface

### Key code changes
- `src/tab_foundry/training/surface.py` / `trainer.py`: manifest-backed data loading with row caps, non-finite skip policy, and `allow_missing_values` support
- `src/tab_foundry/bench/prior/loop.py`: prior-dump training loop additions for manifest surfaces
- `src/tab_foundry/research/sweep/runner.py`: sweep runner extensions for shape-aware dagzoo queue rows
- `scripts/materialize_tf_rd_013_support.py`: shape-aware materialization with multi-invocation assembly and OpenML baseline shard packing

### Sweep artifacts
- Sweep config, queue, and rendered matrix in `reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/`
- Support bundle with materialization summary and manifest characteristics comparison
- Updated parent sweep (`tf_rd_013_data_source_contract_v1`) queue with cross-references to issue 127 follow-up