### PR TITLE
Refine architecture docs and fix worktree hook tool resolution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,33 +4,33 @@ repos:
   hooks:
   - id: version-bump-guard
     name: version bump guard
-    entry: ./.venv/bin/python scripts/audit/check_version_bump.py
+    entry: python3 scripts/audit/pre_commit_exec.py python scripts/audit/check_version_bump.py
     language: system
     always_run: true
     pass_filenames: false
   - id: ruff-check
     name: ruff check
-    entry: ./.venv/bin/ruff check src tests scripts
+    entry: python3 scripts/audit/pre_commit_exec.py ruff check src tests scripts
     language: system
     types_or: [python, pyi]
     files: ^(src/|tests/|scripts/)
     pass_filenames: false
   - id: mypy
     name: mypy
-    entry: ./.venv/bin/python -m mypy src
+    entry: python3 scripts/audit/pre_commit_exec.py python -m mypy src
     language: system
     types_or: [python, pyi]
     files: ^src/
     pass_filenames: false
   - id: verify-paths
     name: verify (paths)
-    entry: env TAB_FOUNDRY_LIVE_PYTEST=1 ./.venv/bin/python scripts/audit/dev_verify.py verify paths --pre-commit
+    entry: env TAB_FOUNDRY_LIVE_PYTEST=1 python3 scripts/audit/pre_commit_exec.py python scripts/audit/dev_verify.py verify paths --pre-commit
     language: system
     files: ^(AGENTS\.md|README\.md|CHANGELOG\.md|program\.md|src/|tests/|scripts/dev$|scripts/audit/|configs/|reference/|docs/)
     pass_filenames: true
   - id: mdformat
     name: mdformat
-    entry: ./.venv/bin/mdformat AGENTS.md README.md docs reference CHANGELOG.md
+    entry: python3 scripts/audit/pre_commit_exec.py mdformat AGENTS.md README.md docs reference CHANGELOG.md
     language: system
     types: [markdown]
     files: ^(AGENTS\.md|README\.md|docs/|reference/|CHANGELOG\.md$)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing
 
-This repo is optimized for research contributors who need to understand the
-architecture, inspect sweep state, and make bounded changes without reopening
-the entire system.
+Use this guide when you want to make a bounded change without reopening the
+entire system.
 
 Start with [docs/getting-started.md](docs/getting-started.md) for repo
 orientation, then choose the path that matches your work:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tab-foundry
 
-Modular tabular prior-data fitted network training on `dagzoo` packed shard outputs.
+Training, comparing, and exporting tabular ML models, with direct routes into
+research, operations, and architecture docs.
 
 ## Start Here
 

--- a/docs/development/architecture-deltas.md
+++ b/docs/development/architecture-deltas.md
@@ -1,16 +1,17 @@
 # Architecture Deltas
 
-This document compares the settled row-first architecture target in `tab-foundry`
-to three reference points:
+Use this comparison when you need to explain how the settled row-first
+architecture differs from the frozen PFN control and the main external
+reference lines in `tab-foundry`.
+
+It compares the current target to three reference points:
 
 - `nanoTabPFN` as the frozen PFN control lineage
 - TabPFN / TabPFN-2.5 as the broader official PFN architecture lineage
 - TabICLv2's row-first architecture as the main external directional reference
 
-The goal is not to restate every implementation detail. It is to make the
-decision-relevant structural deltas visible enough that the repo can explain
-the TF-RD-008 settlement without confusing historical diagnostic sweeps for the
-current normative direction.
+The goal is to make the decision-relevant structural deltas visible without
+blurring historical diagnostic sweeps into the current normative direction.
 
 ## Scope
 

--- a/docs/development/codebase-navigation.md
+++ b/docs/development/codebase-navigation.md
@@ -1,7 +1,7 @@
 # Codebase Navigation
 
-This document describes the current `tab-foundry` layout on the active branch
-and the intended landing zones for future work. It complements
+Use this map when you need to find the right package, entry point, or workflow
+surface before making a change. It complements
 `docs/development/module-dependency-map.md`, which records the observed
 top-level package graph plus the intended dependency direction policy.
 

--- a/docs/development/dataset-curation.md
+++ b/docs/development/dataset-curation.md
@@ -1,9 +1,9 @@
 # Dataset Curation And License Review
 
-This document defines the repo-level acceptance gate for real-data datasets
-used in `tab-foundry`.
+Use this policy when deciding whether a real-data dataset may enter a curated
+benchmark bundle or manifest-backed comparator surface in `tab-foundry`.
 
-Related surfaces:
+Use these alongside this policy:
 
 - canonical roadmap: `docs/development/roadmap.md`
 - operator workflow runbook: `docs/workflows.md`

--- a/docs/development/design-decisions.md
+++ b/docs/development/design-decisions.md
@@ -1,9 +1,9 @@
 # Design Decisions
 
-This document captures enduring architecture direction, repo-structure policy,
-and compatibility guidance for `tab-foundry`.
+Use this page to understand the durable decisions behind the current
+architecture, repo structure, and compatibility boundaries.
 
-Related docs:
+Use these alongside this page:
 
 - quickstart: `README.md`
 - workflow runbooks: `docs/workflows.md`

--- a/docs/development/model-architecture.md
+++ b/docs/development/model-architecture.md
@@ -1,6 +1,7 @@
 # Model Architecture
 
-This document describes the current model surface in `tab-foundry`.
+Use this reference when you need to understand the current model surface, the
+active architecture target, and where the main subsystems live.
 
 The repo now has one active architecture-development surface:
 
@@ -13,13 +14,13 @@ It also keeps one frozen anchor:
 The legacy `tabfoundry` family has been removed. Regression is also removed for
 now and will be rebuilt later on top of `tabfoundry_staged`.
 
-Related docs:
+Use these alongside this page:
 
 - `docs/development/model-config.md`
 - `docs/development/architecture-deltas.md`
 - `docs/inference.md`
 
-Related code paths:
+Key code paths:
 
 - `src/tab_foundry/model/architectures/tabfoundry_staged/`
 - `src/tab_foundry/model/architectures/tabfoundry_simple.py`
@@ -29,8 +30,8 @@ Related code paths:
 
 ## Overview
 
-This page explains how the current model is structured and which model family
-the repo is actually trying to improve.
+Start here when you need the current model surface at a glance or want to
+confirm which family the repo is actively improving.
 
 The short version:
 
@@ -212,7 +213,8 @@ Source: `blocks.py:143-218`
 
 - **`SequenceContextEncoder`**: Adds label embeddings
   `Embedding(many_class_base, d_icl)` to training rows before encoding.
-  Mask: train attends to all, test attends to train + optionally self.
+  Mask: every query can attend to training rows; when
+  `allow_test_self_attention=True`, each row also keeps its diagonal entry.
   `QASSTransformerEncoder` (tficl_n_layers layers + final norm). Each
   layer: pre-norm → `QASSMultiheadAttention` → residual → pre-norm → FFN
   → residual. QASS scaling:
@@ -302,6 +304,591 @@ feature_group_size  = 1            # retained for config/export/checkpoint compa
 - bf16 / mixed precision: not enforced by model; left to training loop.
   QASS scaler adapts dtype automatically from query tensor.
 - Embedding tables: float32
+
+## Mathematical View
+
+This section gives the settled default row-first anchor as a compact operator
+pipeline. Read it when you want the exact computations, masks, and
+factorization choices rather than a prose architecture tour.
+
+### Notation
+
+- (B): task batch size
+- (N\_{\\mathrm{tr}}), (N\_{\\mathrm{te}}): train and test row counts
+- (R = N\_{\\mathrm{tr}} + N\_{\\mathrm{te}}): total row count
+- (C): number of input features
+- (d = d\_{\\mathrm{icl}}): shared embedding width
+- (K_0): label-embedding / direct-head width, corresponding to config field
+  `many_class_base`
+- (q): number of row-CLS tokens, corresponding to config field
+  `tfrow_cls_tokens`
+- (X \\in \\mathbb{R}^{B \\times R \\times C}): concatenated train/test table
+- (y \\in {0, \\dots, K_0 - 1}^{B \\times N\_{\\mathrm{tr}}}): train labels after
+  the model's clamp to `many_class_base - 1`
+- (\\mathcal{I}_{\\mathrm{tr}} = {0, \\dots, N_{\\mathrm{tr}} - 1}),
+  (\\mathcal{I}_{\\mathrm{te}} = {N_{\\mathrm{tr}}, \\dots, R - 1}): train/test
+  row index sets
+- (E^{(\\ell)} \\in \\mathbb{R}^{B \\times R \\times (C+1) \\times d}): cell table
+  after table block (\\ell)
+- (G \\in \\mathbb{R}^{B \\times R \\times d}): one row embedding per row after
+  `RowCLSPool`
+
+The default path in this section is the settled row-first anchor:
+`stage=qass_context + module_overrides.column_encoder=none`, i.e.
+`row_cls + qass + no tfcol`.
+
+### Shared Train/Test Normalization
+
+**Motivation.** The staged default keeps train/test preprocessing on one shared
+surface, but the actual transform is still delegated to
+`input_normalization`.
+
+**Operator.**
+
+\[
+\\begin{aligned}
+X\_{\\mathrm{tr}} &= X[:, 0:N\_{\\mathrm{tr}}, :] \\
+X\_{\\mathrm{te}} &= X[:, N\_{\\mathrm{tr}}:R, :] \\
+(\\widehat{X}_{\\mathrm{tr}}, \\widehat{X}_{\\mathrm{te}})
+&= \\operatorname{Norm}_{\\mathrm{shared}}
+\\bigl(X_{\\mathrm{tr}}, X\_{\\mathrm{te}}; \\texttt{input_normalization}\\bigr) \\
+X^{(0)} &= \\operatorname{concat}_{r}
+\\bigl(\\widehat{X}_{\\mathrm{tr}}, \\widehat{X}\_{\\mathrm{te}}\\bigr)
+\\end{aligned}
+\]
+
+If `input_normalization=none`, then (X^{(0)} = X). If `pre_encoder_clip=c`
+is set, the model applies finite-value clipping before tokenization:
+
+\[
+X^{(0)} \\leftarrow \\operatorname{clip}(X^{(0)}, -c, c).
+\]
+
+**Interpretation.** This keeps normalization policy outside the feature encoder,
+so the later shared linear map sees a consistent train/test surface.
+
+### Shifted-Grouped Tokenizer
+
+**Motivation.** The tokenizer injects lightweight local column context without
+introducing a learned positional system.
+
+**Operator.** Let
+(\\pi_s(c) = (c + s) \\bmod C) for shifts (s \\in {0, 1, 3}). The grouped
+token at feature (c) is
+
+# \[ T\_{b,r,c,:}
+
+\\bigl\[
+X^{(0)}_{b,r,\\pi_0(c)},
+X^{(0)}_{b,r,\\pi_1(c)},
+X^{(0)}\_{b,r,\\pi_3(c)}
+\\bigr\]
+\\in \\mathbb{R}^{3}.
+\]
+
+Stacking over all rows and features gives
+(T \\in \\mathbb{R}^{B \\times R \\times C \\times 3}).
+
+**Interpretation.** Each feature token now carries its own scalar value plus two
+deterministic neighboring views, which is the repo's compact substitute for a
+heavier learned feature-position stack.
+
+### Shared Linear Feature Encoder
+
+**Motivation.** The shared feature encoder lifts the grouped scalar view into
+the common (d\_{\\mathrm{icl}})-dimensional space used everywhere downstream.
+
+**Operator.** With
+(W\_{\\mathrm{feat}} \\in \\mathbb{R}^{3 \\times d}),
+
+\[
+F\_{b,r,c,:} = T\_{b,r,c,:} W\_{\\mathrm{feat}},
+\\qquad
+F \\in \\mathbb{R}^{B \\times R \\times C \\times d}.
+\]
+
+The staged default uses `bias=False`, so there is no additive term.
+
+**Interpretation.** Once this projection is applied, all later modules operate
+on one uniform cell embedding width instead of on raw scalars.
+
+### Label-Token Target Conditioner
+
+**Motivation.** The target conditioner provides explicit train-label evidence
+while reserving a learned placeholder token for test rows whose labels are not
+available at inference time.
+
+**Operator.** Let
+(E\_{\\mathrm{label}} \\in \\mathbb{R}^{K_0 \\times d}) be the target-conditioner
+embedding table and (\\tau\_{\\mathrm{test}} \\in \\mathbb{R}^{d}) the learned test
+token. For each row,
+
+# \[ U\_{b,r,:}
+
+\\begin{cases}
+E\_{\\mathrm{label}}[y\_{b,r}], & r \\in \\mathcal{I}_{\\mathrm{tr}}, \\
+\\tau_{\\mathrm{test}}, & r \\in \\mathcal{I}\_{\\mathrm{te}}.
+\\end{cases}
+\]
+
+The conditioner then inserts a singleton token axis:
+
+\[
+Y\_{b,r,0,:} = U\_{b,r,:},
+\\qquad
+Y \\in \\mathbb{R}^{B \\times R \\times 1 \\times d}.
+\]
+
+**Interpretation.** The model sees labels as one more cell-like token rather
+than as a separate side channel, which keeps later table blocks agnostic to
+whether a token came from features or targets.
+
+### Cell-Table Assembly
+
+**Motivation.** The default stack reasons over one row-major table of cell
+tokens, so feature evidence and target evidence must share one tensor.
+
+**Operator.**
+
+\[
+E^{(0)} = \\operatorname{concat}\_{c}(F, Y)
+\\in \\mathbb{R}^{B \\times R \\times (C+1) \\times d}.
+\]
+
+The final token position on the column axis is the target token.
+
+**Interpretation.** This is the point where the model becomes a cell-table
+transformer rather than separate feature and label pipelines.
+
+### PreNorm Cell Block
+
+**Motivation.** Each table block first mixes information across tokens within a
+row, then across rows within a token position, while blocking test-to-test
+leakage except for each test row's own diagonal entry.
+
+**Operator.** Let (M = C + 1) and let (\\gamma) be the residual branch gain
+((\\gamma = 1) by default, or ((3L)^{-1/2}) for
+`table_block_residual_scale=depth_scaled` across (L) table blocks). For block
+(\\ell),
+
+\[
+\\begin{aligned}
+\\Phi^{(\\ell)} &=
+\\operatorname{reshape}_{BR,M,d}\\bigl(E^{(\\ell)}\\bigr) \\
+\\Phi_{\\mathrm{feat}}^{(\\ell)}
+&=
+\\Phi^{(\\ell)}
+
+- \\gamma ,
+  \\operatorname{MHA}_{\\mathrm{feat}}
+  \\bigl(
+  \\operatorname{LN}_{\\mathrm{feat}}(\\Phi^{(\\ell)}),
+  \\operatorname{LN}_{\\mathrm{feat}}(\\Phi^{(\\ell)}),
+  \\operatorname{LN}_{\\mathrm{feat}}(\\Phi^{(\\ell)})
+  \\bigr).
+  \\end{aligned}
+  \]
+
+Row attention then works on the transposed cell table. The default additive
+mask (A\_{\\mathrm{cell}} \\in {0, -\\infty}^{R \\times R}) is
+
+# \[ A\_{\\mathrm{cell}}(i,j)
+
+\\begin{cases}
+-\\infty, & i,j \\in \\mathcal{I}\_{\\mathrm{te}} \\text{ and } i \\neq j, \\
+0, & \\text{otherwise}.
+\\end{cases}
+\]
+
+The row-mixing update is
+
+\[
+\\begin{aligned}
+\\Psi^{(\\ell)}
+&=
+\\operatorname{reshape}_{BM,R,d}
+\\bigl(\\operatorname{transpose}_{r,c}(\\Phi\_{\\mathrm{feat}}^{(\\ell)})\\bigr) \\
+\\Psi\_{\\mathrm{row}}^{(\\ell)}
+&=
+\\Psi^{(\\ell)}
+
+- \\gamma ,
+  \\operatorname{MHA}_{\\mathrm{row}}
+  \\bigl(
+  \\operatorname{LN}_{\\mathrm{row}}(\\Psi^{(\\ell)}),
+  \\operatorname{LN}_{\\mathrm{row}}(\\Psi^{(\\ell)}),
+  \\operatorname{LN}_{\\mathrm{row}}(\\Psi^{(\\ell)});
+  A\_{\\mathrm{cell}}
+  \\bigr).
+  \\end{aligned}
+  \]
+
+After transposing back, the block applies the per-cell feed-forward update
+
+\[
+\\begin{aligned}
+H^{(\\ell)}
+&=
+\\operatorname{transpose}_{r,c}^{-1}
+\\bigl(\\operatorname{reshape}^{-1}(\\Psi_{\\mathrm{row}}^{(\\ell)})\\bigr) \\
+E^{(\\ell+1)}
+&=
+H^{(\\ell)}
+
+- \\gamma ,
+  \\Bigl(
+  W_2 ,
+  \\operatorname{GELU}
+  \\bigl(W_1 \\operatorname{LN}\_{\\mathrm{ff}}(H^{(\\ell)}) + b_1\\bigr)
+- b_2
+  \\Bigr).
+  \\end{aligned}
+  \]
+
+**Interpretation.** The block decomposes table reasoning into
+"within-row / across-columns" and "within-column / across-rows" passes, which
+is the central factorization the staged family keeps from the PFN-style cell
+table lineage.
+
+### Row CLS Pooling
+
+**Motivation.** After cell-table reasoning, the model needs one embedding per
+row so later context reasoning can operate on rows rather than on every cell.
+
+**Operator.** The settled default has no column encoder, so the input to pooling
+is the last table-block output
+(\\bar{E} = E^{(L\_{\\mathrm{cell}})}). Let
+(C\_{\\mathrm{cls}} \\in \\mathbb{R}^{q \\times d}) be the learned CLS-token bank.
+For each row,
+
+\[
+\\begin{aligned}
+S^{(0)}_{b,r}
+&=
+\\operatorname{concat}_{c}
+\\bigl(C\_{\\mathrm{cls}}, \\bar{E}_{b,r,:,:}\\bigr)
+\\in \\mathbb{R}^{(q + C + 1) \\times d} \\
+S^{(L_{\\mathrm{row}})}_{b,r}
+&=
+\\operatorname{TFRow}
+\\bigl(S^{(0)}_{b,r}\\bigr) \\
+G\_{b,r,:}
+&=
+\\operatorname{vec}
+\\bigl(S^{(L\_{\\mathrm{row}})}_{b,r,0:q,:}\\bigr)
+W_{\\mathrm{row}}
+
+- b\_{\\mathrm{row}}.
+  \\end{aligned}
+  \]
+
+Here `TFRow` is the pre-norm `nn.TransformerEncoder` used by `TFRowEncoder`.
+
+**Interpretation.** The CLS bank acts as a learned bottleneck: each row can use
+all of its cell tokens to write into a small fixed-width summary before the
+model moves to row-level context reasoning.
+
+### QASS Context Encoder
+
+**Motivation.** The context encoder performs row-level in-context reasoning
+after pooling and makes the attention query strength depend on the available
+training context size.
+
+**Operator.** Let
+(E\_{\\mathrm{ctx}} \\in \\mathbb{R}^{K_0 \\times d}) be the context-label
+embedding table. The input sequence is first label-conditioned on training rows:
+
+# \[ H^{(0)}\_{b,r,:}
+
+\\begin{cases}
+G\_{b,r,:} + E\_{\\mathrm{ctx}}[y\_{b,r}], & r \\in \\mathcal{I}_{\\mathrm{tr}}, \\
+G_{b,r,:}, & r \\in \\mathcal{I}\_{\\mathrm{te}}.
+\\end{cases}
+\]
+
+The default boolean attention mask is
+
+# \[ M\_{\\mathrm{ctx}}(i,j)
+
+\\begin{cases}
+1, & j \\in \\mathcal{I}\_{\\mathrm{tr}}, \\
+1, & i = j, \\
+0, & \\text{otherwise}.
+\\end{cases}
+\]
+
+So every query can read training rows, and each row also keeps its own diagonal
+entry. For context layer (\\ell), with (d_h = d / n\_{\\mathrm{heads}}),
+
+\[
+\\begin{aligned}
+\\widetilde{H}^{(\\ell)} &= \\operatorname{LN}\_1(H^{(\\ell)}) \\
+Q &= \\widetilde{H}^{(\\ell)} W_Q,\\quad
+K = \\widetilde{H}^{(\\ell)} W_K,\\quad
+V = \\widetilde{H}^{(\\ell)} W_V.
+\\end{aligned}
+\]
+
+QASS then rescales the per-head queries using the number of training rows
+(N\_{\\mathrm{tr}}), not the total row count (R):
+
+# \[ Q'\_{h,i,:}
+
+Q\_{h,i,:}
+\\odot
+\\beta_h\\bigl(\\log N\_{\\mathrm{tr}}\\bigr)
+\\odot
+\\Bigl(1 + \\tanh\\bigl(g_h(Q\_{h,i,:})\\bigr)\\Bigr),
+\]
+
+where (\\beta_h(\\cdot)) is the learned base MLP output for head (h) and
+(g_h(\\cdot)) is the learned gate MLP. The masked attention update is
+
+\[
+\\begin{aligned}
+A^{(\\ell)}
+&=
+\\operatorname{MaskedSoftmax}
+\\Bigl(
+\\frac{Q' {K}^{\\top}}{\\sqrt{d_h}},
+M\_{\\mathrm{ctx}}
+\\Bigr) V \\
+\\bar{H}^{(\\ell)}
+&=
+H^{(\\ell)} + A^{(\\ell)} W_O \\
+H^{(\\ell+1)}
+&=
+\\bar{H}^{(\\ell)}
+
+- W^{\\mathrm{ctx}}\_2
+  \\operatorname{GELU}
+  \\bigl(
+  W^{\\mathrm{ctx}}\_1 \\operatorname{LN}\_2(\\bar{H}^{(\\ell)})
+  \\bigr).
+  \\end{aligned}
+  \]
+
+After (L\_{\\mathrm{ctx}}) layers, the encoder applies one final norm:
+
+\[
+H\_{\\mathrm{ctx}} = \\operatorname{LN}_{\\mathrm{final}}
+\\bigl(H^{(L_{\\mathrm{ctx}})}\\bigr).
+\]
+
+**Interpretation.** This is where the architecture becomes explicitly row-first:
+cell-table structure has already been compressed, so the context stack only has
+to model train-to-test and row-self interactions between row embeddings.
+
+### Direct Classification Head
+
+**Motivation.** The direct head is the last small-class readout from row
+embeddings to class logits.
+
+**Operator.** The head only consumes test rows:
+
+\[
+G\_{\\mathrm{te}} = H\_{\\mathrm{ctx}}[:, \\mathcal{I}\_{\\mathrm{te}}, :].
+\]
+
+With
+(W^{\\mathrm{head}}\_1 \\in \\mathbb{R}^{d \\times h}),
+(W^{\\mathrm{head}}\_2 \\in \\mathbb{R}^{h \\times K_0}), and
+(h) corresponding to config field `head_hidden_dim`,
+
+# \[ \\operatorname{logits}
+
+\\Bigl(
+\\operatorname{GELU}
+\\bigl(G\_{\\mathrm{te}} W^{\\mathrm{head}}\_1 + b^{\\mathrm{head}}\_1\\bigr)
+\\Bigr)
+W^{\\mathrm{head}}\_2
+
+- b^{\\mathrm{head}}\_2.
+  \]
+
+**Interpretation.** All of the architecture's table and context structure has
+already been distilled into (G\_{\\mathrm{te}}); the head is intentionally just
+an MLP readout.
+
+### Variant: TFCol Before Row Pooling
+
+**Motivation.** The retained TFCol variant adds an explicit column-wise set
+reasoning stage before row pooling, mainly to test whether extra calibration
+signal lives in per-column row sets.
+
+**Operator.** With TFCol on, the model permutes the cell table so each column
+position becomes its own row-set problem:
+
+# \[ \\Xi^{(0)}
+
+\\operatorname{reshape}_{B(C+1),R,d}
+\\bigl(\\operatorname{transpose}_{r,c}(E^{(L\_{\\mathrm{cell}})})\\bigr).
+\]
+
+For one ISAB block, let
+(P \\in \\mathbb{R}^{n\_{\\mathrm{ind}} \\times d}) be the learned inducing-point
+bank and let (n\_{\\mathrm{ctx}} = R). The update is
+
+\[
+\\begin{aligned}
+\\widetilde{\\Xi} &= \\operatorname{LN}\_{\\mathrm{in}}(\\Xi) \\
+P'
+&=
+P
+
+- \\operatorname{Attn}_{\\mathrm{QASS}}
+  \\bigl(P, \\widetilde{\\Xi}, \\widetilde{\\Xi}; n_{\\mathrm{ctx}} = R\\bigr) \\
+  \\Xi'
+  &=
+  \\Xi
+- \\operatorname{Attn}
+  \\bigl(
+  \\widetilde{\\Xi},
+  \\operatorname{LN}_{\\mathrm{mid}}(P'),
+  \\operatorname{LN}_{\\mathrm{mid}}(P')
+  \\bigr) \\
+  \\Xi''
+  &=
+  \\Xi'
+- \\operatorname{FF}
+  \\bigl(\\operatorname{LN}\_{\\mathrm{out}}(\\Xi')\\bigr).
+  \\end{aligned}
+  \]
+
+After the configured number of ISAB blocks, the tensor is reshaped back to
+(\\mathbb{R}^{B \\times R \\times (C+1) \\times d}) and then fed into
+`RowCLSPool`.
+
+**Interpretation.** TFCol keeps the same later row-first stack, but it gives
+each token position one extra chance to aggregate information across rows before
+the model compresses rows with CLS pooling.
+
+### Variant: Many-Class Routing
+
+**Motivation.** The many-class path keeps the same row-first backbone but avoids
+forcing one wide flat softmax when the class count grows beyond
+`many_class_base`.
+
+**Operator.** Let (K) be the task class count and let
+((b_1, \\dots, b_D) = \\operatorname{balanced_bases}(K, K_0)). For each train
+label (y_n), the mixed-radix digit at depth (v) is
+
+# \[ d^{(v)}\_n
+
+\\left\\lfloor
+\\frac{y_n}{\\prod\_{j=v+1}^{D} b_j}
+\\right\\rfloor
+\\bmod b_v.
+\]
+
+The model conditions the same row embeddings on each digit view and averages
+the resulting context outputs:
+
+\[
+\\begin{aligned}
+T^{(v)}_n
+&=
+E_{\\mathrm{ctx}}\[d^{(v)}_n\] + p_v \\
+H^{(v)}
+&=
+\\operatorname{Ctx}
+\\bigl(G, T^{(v)}\\bigr) \\
+H_{\\mathrm{mc}}
+&=
+\\frac{1}{D}
+\\sum\_{v=1}^{D} H^{(v)}.
+\\end{aligned}
+\]
+
+Here (p_v) is the optional digit-position embedding and `Ctx` is the same
+context-encoder operator as above. The hierarchical tree then recursively
+factors class probabilities. For a node (u) with node-local choice
+distribution (\\pi_u(x)),
+
+# \[ \\pi_u(x) = \\operatorname{softmax}\\bigl(h_u(x)\\bigr), \\qquad p(c \\mid x)
+
+\\prod\_{u \\in \\operatorname{path}(c)}
+\\pi_u(x)\\bigl[\\operatorname{child}\_u(c)\\bigr].
+\]
+
+If a node has no training examples, the implementation falls back to a uniform
+split across that node's children or leaf classes. In `path_nll` mode, the
+model stores the node-local logits and targets along each test sample's path
+instead of materializing the full class-probability vector during training.
+
+**Interpretation.** Many-class routing preserves the same row-first reasoning
+stack, then turns the final prediction problem into repeated bounded-base
+decisions that reuse the direct head and context machinery.
+
+### Variant: `tabfoundry_simple`
+
+**Motivation.** The frozen `tabfoundry_simple` path remains the exact binary
+anchor, so it helps to show the operator differences against the active staged
+default in one place.
+
+**Operator.** The nano path keeps normalization inside the feature encoder:
+
+\[
+\\begin{aligned}
+\\mu &= \\operatorname{mean}(X\_{\\mathrm{tr}}) \\
+\\sigma &= \\operatorname{std}(X\_{\\mathrm{tr}}) + 10^{-20} \\
+\\widetilde{X}
+&=
+\\operatorname{clip}
+\\left(
+\\frac{X - \\mu}{\\sigma},
+-100,
+100
+\\right) \\
+F\_{\\mathrm{nano}} &= \\widetilde{X} W_x + b_x.
+\\end{aligned}
+\]
+
+Its target path mean-pads the training labels before projection:
+
+\[
+\\begin{aligned}
+\\bar{y}
+&=
+\\frac{1}{N\_{\\mathrm{tr}}}
+\\sum\_{i=1}^{N\_{\\mathrm{tr}}} y_i \\
+Y\_{\\mathrm{nano}}
+&=
+\\bigl\[
+y_1, \\dots, y\_{N\_{\\mathrm{tr}}},
+\\bar{y}, \\dots, \\bar{y}
+\\bigr\] W_y + b_y.
+\\end{aligned}
+\]
+
+After concatenating feature and target cells, each nano block uses post-norm
+updates and a stricter row mask:
+
+\[
+\\begin{aligned}
+R'_{\\mathrm{tr}}
+&=
+\\operatorname{MHA}(R_{\\mathrm{tr}}, R\_{\\mathrm{tr}}, R\_{\\mathrm{tr}})
+
+- R\_{\\mathrm{tr}} \\
+  R'_{\\mathrm{te}}
+  &=
+  \\operatorname{MHA}(R_{\\mathrm{te}}, R\_{\\mathrm{tr}}, R\_{\\mathrm{tr}})
+- R\_{\\mathrm{te}}.
+  \\end{aligned}
+  \]
+
+The final row summary is just the last token position:
+
+# \[ g\_{b,r,:} = E^{(L)}_{b,r,C,:}, \\qquad \\operatorname{logits}_{\\mathrm{nano}}
+
+\\operatorname{MLP}\\bigl(g\_{b,\\mathcal{I}\_{\\mathrm{te}},:}\\bigr).
+\]
+
+**Interpretation.** Relative to the staged default, the frozen nano anchor keeps
+normalization and target encoding inside the old PFN-compatible pathway, reads
+rows out from the target column directly, and has no separate row-context
+encoder after pooling.
 
 ## Public Stage Surface
 

--- a/docs/development/model-config.md
+++ b/docs/development/model-config.md
@@ -1,10 +1,10 @@
 # Model Config Reference
 
-This document describes the active classification model configuration surface,
-the default values used in the repo, and how those values are resolved across
-training, evaluation, export, and bundle loading.
+Use this reference when you need to know which model settings matter, where
+they come from, and how they resolve across training, evaluation, export, and
+bundle loading.
 
-Related docs:
+Use these alongside this reference:
 
 - architecture reference: `docs/development/model-architecture.md`
 - inference contract: `docs/inference.md`

--- a/docs/development/module-dependency-map.md
+++ b/docs/development/module-dependency-map.md
@@ -1,7 +1,7 @@
 # Module Dependency Map
 
-This file records the current top-level package graph under `src/tab_foundry`
-and the intended dependency-direction policy for future refactors.
+Use this map when you need the current package graph or want to plan a refactor
+without reopening dependency cycles.
 
 The observed graph is synchronized against
 `scripts/audit/module_graph.py --fail-on-doc-drift`. Keep the current-state

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,6 +1,7 @@
 # Mission-Aligned Roadmap (2026Q1)
 
-This is the canonical roadmap for `tab-foundry`.
+Use this roadmap to understand which questions are active now, which surfaces
+are frozen, and what evidence the repo still needs before promotion.
 
 The repo-wide plan is now architecture-first:
 
@@ -12,7 +13,7 @@ The repo-wide plan is now architecture-first:
 - defer regression, extended modalities, and broader runtime handoff until the
   row-first classification anchor is coherent and documented
 
-Related docs:
+Use these alongside this roadmap:
 
 - design decisions and repo structure: `docs/development/design-decisions.md`
 - codebase navigation: `docs/development/codebase-navigation.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 # Getting Started
 
-Use this page for a fast orientation to `tab-foundry`.
+Start here when you need the fastest route to the right part of
+`tab-foundry`.
 
 ## Overview
 
@@ -18,7 +19,7 @@ answer:
 1. how do I contribute to the research side?
 1. how do the artifacts and workflows fit together operationally?
 
-Related docs:
+Use these alongside this page:
 
 - repo overview: [docs/what-is-tab-foundry.md](what-is-tab-foundry.md)
 - research path: [docs/research-contributors.md](research-contributors.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,7 +1,7 @@
 # Glossary
 
-This glossary collects the repo-specific terms that show up across the roadmap,
-sweep system, architecture docs, and operational workflows.
+Use this glossary when architecture, sweep, artifact, and workflow terms start
+to carry too much repo-specific meaning.
 
 ## Anchor
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,9 +1,9 @@
 # Inference Contract
 
-This repository is the training-side producer of inference artifacts. Runtime
-inference is expected to live in a separate repository.
+Use this contract when you need to know what this repo hands to downstream
+runtime systems and what must remain stable.
 
-Related docs:
+Use these alongside this contract:
 
 - quickstart: `README.md`
 - workflow runbooks: `docs/workflows.md`
@@ -12,14 +12,13 @@ Related docs:
 - model config reference: `docs/development/model-config.md`
 - canonical roadmap: `docs/development/roadmap.md`
 
-Planning and architecture rationale live under `docs/development/`.
-This file stays top-level because it is the stable export and validation
-contract.
+Planning and architecture rationale live under `docs/development/`, while this
+page stays focused on the exported bundle and the validation boundary that
+downstream consumers rely on.
 
 ## Overview
 
-This page describes the artifact this repo hands off for runtime inference.
-The key idea is simple:
+The handoff boundary is simple:
 
 - this repo trains models and packages [export bundles](glossary.md#export-bundle)
 - a separate runtime repo or system can then load those bundles

--- a/docs/ml-engineering.md
+++ b/docs/ml-engineering.md
@@ -1,8 +1,7 @@
 # ML Engineering And Infra
 
-This guide is for contributors who need to understand the repo operationally:
-what artifacts it reads and writes, what this repo owns, and how to verify
-changes safely.
+Use this guide when you need the repo's operational view: artifacts, ownership
+boundaries, and verification paths.
 
 ## Overview
 
@@ -14,7 +13,7 @@ descriptions and configs into training [runs](glossary.md#run-directory),
 If you care most about files, artifacts, contracts, and validation paths, start
 here instead of the research-only docs.
 
-Related docs:
+Use these alongside this guide:
 
 - general start page: [docs/getting-started.md](getting-started.md)
 - repo overview: [docs/what-is-tab-foundry.md](what-is-tab-foundry.md)

--- a/docs/research-contributors.md
+++ b/docs/research-contributors.md
@@ -1,7 +1,7 @@
 # Research Contributors
 
-This guide is the fastest path through `tab-foundry` if you are contributing to
-the research side of the repo.
+Use this guide when you are working on architecture, sweeps, synthetic data, or
+broader model-capability questions in `tab-foundry`.
 
 ## Overview
 
@@ -10,14 +10,14 @@ time. It uses [sweeps](glossary.md#sweep) to compare isolated changes against a
 locked [anchor](glossary.md#anchor), so the team can tell whether a model,
 data, or preprocessing change actually helped.
 
-Use this document to answer four common questions:
+Most research contributors come here to answer four common questions:
 
 1. what architecture is active here?
 1. how do sweeps work without breaking attribution?
 1. where does synthetic data fit relative to real-data ladders?
 1. how should broader model capability work be framed?
 
-Related docs:
+Use these alongside this guide:
 
 - shared vocabulary: [docs/glossary.md](glossary.md)
 - general orientation: [docs/getting-started.md](getting-started.md)

--- a/docs/what-is-tab-foundry.md
+++ b/docs/what-is-tab-foundry.md
@@ -1,7 +1,7 @@
 # What Is tab-foundry?
 
-This page provides a concise overview of what the repository does, what it
-produces, and how to route into the rest of the docs.
+Start here when you want the shortest useful explanation of what
+`tab-foundry` owns, what it produces, and where to go next in the docs.
 
 ## Overview
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,8 +1,9 @@
 # Workflows
 
-This document is the operational runbook for `tab-foundry`: setup, local quality checks, core commands, smoke flows, tuning, and benchmark-adjacent comparisons.
+Use this runbook when you need command syntax, artifact expectations, or review
+checks for `tab-foundry`.
 
-Related docs:
+Use these alongside this runbook:
 
 - researcher onboarding: `docs/getting-started.md`
 - contribution workflow: `CONTRIBUTING.md`
@@ -13,20 +14,16 @@ Related docs:
 - inference/export contract: `docs/inference.md`
 - canonical roadmap: `docs/development/roadmap.md`
 
-Planning and repo-shape docs now live under `docs/development/`.
-This file stays top-level because it is the stable operational runbook.
-For agent-driven architecture search, use `program.md` as the execution
-contract; this file stays focused on commands, artifacts, and operational
-policy.
+Planning and repo-shape docs live under `docs/development/`. For
+agent-driven architecture search, use `program.md`; this runbook stays focused
+on commands, artifacts, and operational policy.
 
-The published docs site under `site/` is a navigation layer over these
-canonical Markdown sources. Update this file instead of generated site content
-when the runbook changes.
+Update this source when the runbook changes rather than editing generated site
+content.
 
 ## Overview
 
-This page tells you how to operate the repo safely. It is the best place to
-learn:
+Use this runbook to learn:
 
 - which commands to run
 - what artifacts those commands produce

--- a/program.md
+++ b/program.md
@@ -1,13 +1,13 @@
 # Agent Program
 
-This file is the agent contract for the anchor-only system-delta sweep system in
-`tab-foundry`.
+Use this contract when you are running or reviewing the active anchor-only
+system-delta sweep in `tab-foundry`.
 
 Use `docs/workflows.md` for command syntax and artifact expectations. Use this
-file for the objective, the locked comparison surface, the queue discipline,
-and the interpretation policy.
+contract for the objective, the locked comparison surface, the queue
+discipline, and the interpretation policy.
 
-This file is a research-execution contract, not the architecture roadmap. The
+Treat this as a research-execution contract, not the architecture roadmap. The
 active sweep may intentionally hold a PFN-adjacent or hybrid diagnostic surface
 fixed while isolating one question. The long-term direction for the public
 model surface still comes from `docs/development/roadmap.md` and
@@ -15,9 +15,7 @@ model surface still comes from `docs/development/roadmap.md` and
 
 ## Overview
 
-This page defines the rules for the active research sweep.
-
-Use it when you need to know:
+Read it when you need to know:
 
 - what the current [anchor](docs/glossary.md#anchor) is
 - what is allowed to change in one sweep row

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,8 +1,7 @@
 # Reference Index
 
-`reference/` is the canonical landing zone for repo-local literature notes,
-evidence maps, and adjacent-repo summaries that shape architecture and
-benchmark decisions in `tab-foundry`.
+Start here when you need the papers, evidence notes, and supporting research
+artifacts behind roadmap and architecture decisions in `tab-foundry`.
 
 Structural rules:
 
@@ -37,7 +36,7 @@ Contents:
 - `system_delta_queue.yaml`: generated active-sweep queue alias
 - `system_delta_matrix.md`: generated active-sweep matrix alias
 
-Keeping this material under one indexed home gives future architecture and
-benchmark work a stable citation surface without mixing research notes into the
+Keeping this material under one indexed home gives architecture and benchmark
+work a stable citation surface without mixing research notes into the
 operator-facing docs. The live architecture source of truth still lives in
 `docs/development/`.

--- a/reference/evidence.md
+++ b/reference/evidence.md
@@ -1,9 +1,9 @@
 # Literature Evidence Mapping
 
-This document links the canonical roadmap in `docs/development/roadmap.md` to
-primary references and to the most important repo-local evidence.
+Use this map when you need to trace a roadmap claim back to papers and the most
+important repo-local evidence.
 
-Related docs:
+Use these alongside this map:
 
 - Canonical roadmap: `docs/development/roadmap.md`
 - Design decisions and repo structure: `docs/development/design-decisions.md`

--- a/reference/papers.md
+++ b/reference/papers.md
@@ -1,10 +1,13 @@
 # Papers And References
 
-This directory is the starting point for literature-first architecture work in `tab-foundry`.
+Start here when you want the reading list that actually informs architecture,
+training, and scaling decisions in `tab-foundry`.
 
-It intentionally mirrors the role of `~/dev/dagzoo/reference`, but reads the shared literature through an **architecture, training recipe, and scaling predictability** lens rather than a data-generation lens.
+This list overlaps with `~/dev/dagzoo/reference`, but the lens here is
+**architecture, training recipe, and scaling predictability** rather than data
+generation.
 
-Related docs:
+Use these alongside this reference set:
 
 - Design decisions and repo structure: `docs/development/design-decisions.md`
 - Roadmap: `docs/development/roadmap.md`

--- a/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/README.md
+++ b/reference/system_delta_sweeps/tf_rd_013_data_source_contract_v1/support/README.md
@@ -1,7 +1,10 @@
 # TF-RD-013 Support Bundle
 
-This directory is the committed reference-only support bundle for issues `#120`
-and `#122`.
+Use this support bundle when you need the committed assumptions, regeneration
+flow, and comparison surfaces behind TF-RD-013 issues `#120` and `#122`.
+
+It is a reference-only support surface for that contract, not the main roadmap
+or sweep execution guide.
 
 The canonical local regeneration flow is:
 
@@ -16,7 +19,7 @@ Environment assumptions:
 - The dagzoo config ref is the sibling repo's default config, `../dagzoo/configs/default.yaml`.
 - The curated comparator baseline is pinned to `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`.
 
-What the script does today:
+Current support surface:
 
 - materializes one large unfiltered dagzoo `generate` output under `outputs/staged_ladder_support/tf_rd_013/generated_source/`
 - keeps the initial promoted-anchor support surface pinned to dagzoo's `../dagzoo/configs/default.yaml` with a single `--num-datasets 8192` CPU generate call

--- a/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md
+++ b/reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md
@@ -1,6 +1,10 @@
 # TF-RD-013 Shape-Aware Support Bundle
 
-This directory is the committed reference-only support bundle for issue `#127`.
+Use this support bundle when you need the committed assumptions, regeneration
+flow, and comparison surfaces behind TF-RD-013 issue `#127`.
+
+It is a reference-only support surface for that shape-aware follow-up, not the
+main roadmap or sweep execution guide.
 
 The canonical local regeneration flow is:
 
@@ -18,7 +22,7 @@ Environment assumptions:
   - `../dagzoo/configs/benchmark_cuda_h100_large_shape.yaml` with `128` datasets
 - The curated comparator baseline remains pinned to `src/tab_foundry/bench/nanotabpfn_openml_binary_large_v1.json`.
 
-What the script does for this variant:
+Current support surface:
 
 - materializes three explicit dagzoo generate runs under `outputs/staged_ladder_support/tf_rd_013_shape_aware_dagzoo_v1/`
 - keeps each invocation's handoff manifest and identity separate for provenance review

--- a/scripts/audit/dev_verify.py
+++ b/scripts/audit/dev_verify.py
@@ -19,9 +19,30 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEV_INDEX_PATH = Path(__file__).with_name("dev_index.yaml")
-VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
-VENV_RUFF = REPO_ROOT / ".venv" / "bin" / "ruff"
-VENV_MDFORMAT = REPO_ROOT / ".venv" / "bin" / "mdformat"
+
+
+def _resolve_tool_root() -> Path:
+    primary_root = os.environ.get("TAB_FOUNDRY_PRIMARY_ROOT")
+    if primary_root:
+        return Path(primary_root)
+    completed = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        candidate = Path(completed.stdout.strip()).parent.resolve()
+        if (candidate / ".venv" / "bin" / "python").is_file():
+            return candidate
+    return REPO_ROOT
+
+
+TOOL_ROOT = _resolve_tool_root()
+VENV_PYTHON = TOOL_ROOT / ".venv" / "bin" / "python"
+VENV_RUFF = TOOL_ROOT / ".venv" / "bin" / "ruff"
+VENV_MDFORMAT = TOOL_ROOT / ".venv" / "bin" / "mdformat"
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/audit/pre_commit_exec.py
+++ b/scripts/audit/pre_commit_exec.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Sequence
+
+
+def _git_rev_parse(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or "git rev-parse failed"
+        raise RuntimeError(message)
+    return completed.stdout.strip()
+
+
+def resolve_repo_roots() -> tuple[Path, Path]:
+    worktree_root = Path(_git_rev_parse("--show-toplevel"))
+    common_git_dir = Path(_git_rev_parse("--git-common-dir"))
+    primary_root = common_git_dir.parent.resolve()
+    return worktree_root, primary_root
+
+
+def resolve_primary_venv_bin(primary_root: Path) -> Path:
+    venv_bin = primary_root / ".venv" / "bin"
+    if not (venv_bin / "python").is_file():
+        raise RuntimeError(
+            f"Missing {venv_bin / 'python'}. "
+            "Bootstrap the original checkout before running pre-commit in a worktree."
+        )
+    return venv_bin
+
+
+def build_command(command: Sequence[str], venv_bin: Path) -> list[str]:
+    if not command:
+        raise ValueError("expected a command")
+    tool = command[0]
+    executable = venv_bin / ("python" if tool == "python" else tool)
+    if not executable.is_file():
+        raise RuntimeError(f"Missing {executable}.")
+    return [str(executable), *command[1:]]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    worktree_root, primary_root = resolve_repo_roots()
+    venv_bin = resolve_primary_venv_bin(primary_root)
+    command = build_command(args, venv_bin)
+    env = os.environ.copy()
+    env.setdefault("TAB_FOUNDRY_WORKTREE_ROOT", str(worktree_root))
+    env.setdefault("TAB_FOUNDRY_PRIMARY_ROOT", str(primary_root))
+    completed = subprocess.run(command, cwd=worktree_root, env=env, check=False)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev
+++ b/scripts/dev
@@ -23,6 +23,45 @@ ensure_venv() {
   fi
 }
 
+primary_repo_root() {
+  local common_git_dir
+  common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+  (cd "${common_git_dir}/.." && pwd)
+}
+
+pre_commit_python() {
+  local primary_root
+  primary_root="$(primary_repo_root)"
+  if [[ -x "${primary_root}/.venv/bin/python" ]]; then
+    printf '%s\n' "${primary_root}/.venv/bin/python"
+    return
+  fi
+  printf '%s\n' "${REPO_ROOT}/.venv/bin/python"
+}
+
+rewrite_pre_commit_hook_python() {
+  local common_git_dir hook_path install_python
+  common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+  hook_path="${common_git_dir}/hooks/pre-commit"
+  install_python="$(pre_commit_python)"
+  if [[ ! -f "${hook_path}" ]]; then
+    return
+  fi
+  HOOK_PATH="${hook_path}" INSTALL_PYTHON_PATH="${install_python}" python3 - <<'PY'
+from pathlib import Path
+import os
+
+hook_path = Path(os.environ["HOOK_PATH"])
+install_python = os.environ["INSTALL_PYTHON_PATH"]
+lines = hook_path.read_text(encoding="utf-8").splitlines()
+rewritten = [
+    f"INSTALL_PYTHON={install_python}" if line.startswith("INSTALL_PYTHON=") else line
+    for line in lines
+]
+hook_path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+PY
+}
+
 main() {
   cd "${REPO_ROOT}"
 
@@ -38,7 +77,8 @@ main() {
         exit 1
       fi
       uv sync
-      uv run pre-commit install
+      "$(pre_commit_python)" -m pre_commit install
+      rewrite_pre_commit_hook_python
       ;;
     review-base|verify)
       ensure_venv

--- a/scripts/docs/sync_hugo_content.py
+++ b/scripts/docs/sync_hugo_content.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import posixpath
 import re
@@ -44,14 +45,14 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         source_rel="docs/what-is-tab-foundry.md",
         route="getting-started/what-is-tab-foundry",
         weight=10,
-        description="Repo overview of what tab-foundry does, what it produces, and how to route into the relevant docs paths.",
+        description="Best first stop for what the repo owns, what it produces, and where to go next.",
         aliases=("/docs/what-is-tab-foundry/",),
     ),
     PageSpec(
         source_rel="docs/getting-started.md",
         route="getting-started/_index",
         weight=10,
-        description="General orientation page for repo overview, research contributions, and ML engineering paths.",
+        description="Fast route to the right docs path for repo overview, research work, or ML engineering.",
         link_title="Start Here",
         no_list=True,
     ),
@@ -59,7 +60,7 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         source_rel="docs/research-contributors.md",
         route="research-contributors/_index",
         weight=20,
-        description="Research-first route through architecture, sweeps, synthetic data, and model-breadth work.",
+        description="Research-first route through the active architecture, sweep system, synthetic-data lane, and model-breadth work.",
         link_title="Research",
         no_list=True,
     ),
@@ -67,7 +68,7 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         source_rel="docs/ml-engineering.md",
         route="ml-engineering/_index",
         weight=30,
-        description="Operational route through manifests, runs, checkpoints, export bundles, and verification paths.",
+        description="Operational route through artifacts, validation paths, and runtime handoff boundaries.",
         link_title="ML Engineering",
         no_list=True,
     ),
@@ -76,21 +77,21 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         route="research-contributors/sweep-contract",
         weight=20,
         link_title="Sweep Contract",
-        description="Active system-delta sweep contract, locked surface, and execution loop.",
+        description="Rules for the active system-delta sweep: locked surface, allowed changes, and required artifacts.",
         aliases=("/docs/sweep-contract/",),
     ),
     PageSpec(
         source_rel="docs/workflows.md",
         route="ml-engineering/workflows",
         weight=20,
-        description="Operational runbooks and command syntax for the canonical workflows.",
+        description="Command runbooks for setup, verification, smoke tests, and research execution.",
         aliases=("/docs/workflows/",),
     ),
     PageSpec(
         source_rel="docs/development/roadmap.md",
         route="development/roadmap",
         weight=10,
-        description="Canonical planning state and TF-RD priority order.",
+        description="Current priorities, frozen baselines, and evidence-gated next steps.",
         link_title="Roadmap",
         extra_params={"mermaid": True},
     ),
@@ -98,91 +99,91 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         source_rel="docs/development/model-architecture.md",
         route="development/model-architecture",
         weight=20,
-        description="Detailed architecture reference for the staged and simple model surfaces.",
-        extra_params={"mermaid": True},
+        description="Reference for the active model surface, subsystem roles, and settled row-first target.",
+        extra_params={"mermaid": True, "katex": True},
     ),
     PageSpec(
         source_rel="docs/development/design-decisions.md",
         route="development/design-decisions",
         weight=30,
-        description="Enduring architecture direction, repo-structure policy, and publishing decisions.",
+        description="Durable architecture, repo-structure, and compatibility decisions.",
     ),
     PageSpec(
         source_rel="docs/development/codebase-navigation.md",
         route="development/codebase-navigation",
         weight=40,
-        description="Package layout, workflow surfaces, and entry-point inventory.",
+        description="Where to make changes and which packages own each workflow surface.",
     ),
     PageSpec(
         source_rel="docs/development/module-dependency-map.md",
         route="development/module-dependency-map",
         weight=50,
-        description="Observed top-level package graph and intended dependency direction.",
+        description="Current package graph and intended dependency direction for refactors.",
     ),
     PageSpec(
         source_rel="docs/development/model-config.md",
         route="development/model-config",
         weight=60,
-        description="Model configuration reference and resolution rules.",
+        description="How model settings resolve across training, evaluation, export, and bundle loading.",
     ),
     PageSpec(
         source_rel="docs/development/architecture-deltas.md",
         route="development/architecture-deltas",
         weight=70,
-        description="Diagram-first comparison of the target lane and reference architectures.",
+        description="Decision-focused comparison between the settled row-first line and key reference architectures.",
         extra_params={"mermaid": True},
     ),
     PageSpec(
         source_rel="docs/development/dataset-curation.md",
         route="development/dataset-curation",
         weight=80,
-        description="Dataset curation and license-review gate for real-data ladders.",
+        description="Policy for admitting real-data datasets into curated benchmark and comparator surfaces.",
     ),
     PageSpec(
         source_rel="reference/README.md",
         route="reference/_index",
         weight=50,
-        description="Index for literature notes, evidence maps, and research surfaces.",
+        description="Start here for papers, evidence, and supporting research artifacts behind roadmap decisions.",
         link_title="References",
     ),
     PageSpec(
         source_rel="reference/papers.md",
         route="reference/papers",
         weight=10,
-        description="Curated papers, adjacent-repo borrowing rules, and adoption tiers.",
+        description="Reading list and adoption guidance for architecture and training ideas that matter in this repo.",
     ),
     PageSpec(
         source_rel="reference/evidence.md",
         route="reference/evidence",
         weight=20,
-        description="Roadmap-to-reference mapping and repo-local evidence notes.",
+        description="Map from roadmap claims to papers and repo-local evidence.",
     ),
     PageSpec(
         source_rel="reference/system_delta_sweeps/tf_rd_013_shape_aware_dagzoo_v1/support/README.md",
         route="reference/tf-rd-013-support",
         weight=30,
         link_title="TF-RD-013 Support",
-        description="Support bundle notes for the current shape-aware dagzoo synthetic-data contract.",
+        description="Regeneration assumptions and committed support notes for the current shape-aware dagzoo TF-RD-013 contract.",
     ),
     PageSpec(
         source_rel="CONTRIBUTING.md",
         route="getting-started/contributing",
         weight=30,
-        description="Contribution workflow and review readiness for research contributors.",
+        description="How to make bounded changes without losing the repo's architecture and research context.",
         aliases=("/docs/contributing/",),
     ),
     PageSpec(
         source_rel="docs/glossary.md",
         route="getting-started/glossary",
         weight=20,
-        description="Shared vocabulary for architecture and sweep work.",
+        description="Shared vocabulary for architecture, sweeps, artifacts, and workflow discussions.",
         aliases=("/docs/glossary/",),
     ),
     PageSpec(
         source_rel="README.md",
         route="repo-overview",
         weight=110,
-        description="Top-level repo overview and quickstart.",
+        description="Top-level repo overview, docs routing, and quickstart.",
         link_title="Repo Overview",
         toc_hide=True,
         hide_summary=True,
@@ -191,7 +192,7 @@ PAGE_SPECS: tuple[PageSpec, ...] = (
         source_rel="docs/inference.md",
         route="ml-engineering/inference",
         weight=30,
-        description="Export bundle schema and inference validation contract.",
+        description="Export-bundle schema, validation rules, and runtime handoff boundary.",
         aliases=("/docs/inference/",),
     ),
 )
@@ -238,6 +239,42 @@ def _strip_matching_h1(content: str, title: str) -> str:
                 del lines[idx]
     stripped = "\n".join(lines).rstrip()
     return f"{stripped}\n" if stripped else ""
+
+
+def _rewrite_katex_math(content: str) -> str:
+    def escape_inline_math(body: str) -> str:
+        escaped = html.escape(body)
+        pieces: list[str] = []
+        prev = ""
+        for ch in escaped:
+            if ch == "_" and prev != "\\":
+                pieces.append("&#95;")
+            elif ch == "*" and prev != "\\":
+                pieces.append("&#42;")
+            else:
+                pieces.append(ch)
+            prev = ch
+        return "".join(pieces)
+
+    def display_replacer(match: re.Match[str]) -> str:
+        body = html.escape(match.group(1).strip("\n"))
+        return f'\n<div class="math-display">\n{body}\n</div>\n\n'
+
+    content = re.sub(
+        r"(?ms)^\\\[\s*\n(.*?)\n\\\]\s*$",
+        display_replacer,
+        content,
+    )
+
+    def inline_replacer(match: re.Match[str]) -> str:
+        body = escape_inline_math(match.group(1))
+        return f'<span class="math-inline">{body}</span>'
+
+    return re.sub(
+        r"\\\((.+?)\\\)",
+        inline_replacer,
+        content,
+    )
 
 
 def _yaml_scalar(value: Any) -> str:
@@ -447,6 +484,8 @@ def sync_hugo_content(repo_root: Path = REPO_ROOT, *, check: bool = False) -> li
         body = _strip_matching_h1(content, title)
         body = _rewrite_markdown_links(body, spec.source_rel, route_map=route_map, repo_root=repo_root)
         body = _rewrite_html_links(body, spec.source_rel, route_map=route_map, repo_root=repo_root)
+        if spec.extra_params.get("katex"):
+            body = _rewrite_katex_math(body)
         rendered = _front_matter(title, spec, spec.source_rel, content) + body
         output_path = content_docs_root / _output_rel_path(spec.route)
         valid_paths.add(output_path)

--- a/scripts/materialize_tf_rd_013_support.py
+++ b/scripts/materialize_tf_rd_013_support.py
@@ -76,7 +76,28 @@ SHAPE_AWARE_SUPPORT_ROOT = (
 SHAPE_AWARE_DAGZOO_SURFACE_ROOT_NAME = "dagzoo_shape_aware_multi_invocation"
 
 ANCHOR_MANIFEST_PATH = REPO_ROOT / "data" / "manifests" / "default.parquet"
-TAB_FOUNDRY_BIN = REPO_ROOT / ".venv" / "bin" / "tab-foundry"
+
+
+def _resolve_tool_root() -> Path:
+    primary_root = os.environ.get("TAB_FOUNDRY_PRIMARY_ROOT")
+    if primary_root:
+        return Path(primary_root)
+    completed = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        candidate = Path(completed.stdout.strip()).parent.resolve()
+        if (candidate / ".venv" / "bin" / "tab-foundry").is_file():
+            return candidate
+    return REPO_ROOT
+
+
+TAB_FOUNDRY_ROOT = _resolve_tool_root()
+TAB_FOUNDRY_BIN = TAB_FOUNDRY_ROOT / ".venv" / "bin" / "tab-foundry"
 
 
 @dataclass(frozen=True)

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -15,6 +15,20 @@
   padding: 1rem;
 }
 
+// -- Display math ---------------------------------------------------------
+// Keep KaTeX display equations readable without breaking narrow layouts.
+
+.td-content .katex-display {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.25rem;
+}
+
+.td-content .katex-display > .katex {
+  white-space: nowrap;
+}
+
 // -- Tables ---------------------------------------------------------------
 // Striped, hoverable tables with slightly smaller text for data-dense pages.
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -4,7 +4,8 @@ linkTitle: "Home"
 ---
 
 {{< blocks/cover title="tab-foundry" image_anchor="top" height="med" color="dark" >}}
-<p class="lead mt-3">Training, research, and export workflows for tabular ML models, with routes for repo orientation, research contributions, and ML engineering.</p>
+
+<p class="lead mt-3">Docs, workflows, and research paths for training, comparing, and exporting tabular ML models.</p>
 <a class="btn btn-lg btn-outline-light me-3 mb-4" href="{{< relref "/docs" >}}">
   Read the Docs
 </a>
@@ -15,8 +16,8 @@ linkTitle: "Home"
 
 ## Choose Your Path
 
-Most readers should start with the question they are trying to answer, not
-with repo internals.
+Start with the question you are trying to answer, then follow the shortest
+route into the repo.
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-5">
   <div class="col d-flex">

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -1,14 +1,15 @@
 ---
 title: "Documentation"
 linkTitle: "Docs"
-description: "Audience-based routing, workflow references, and canonical repo docs for tab-foundry."
+description: "Start here to choose the right docs path for repo overview, research work, or ML engineering."
 weight: 1
 no_list: true
 ---
 
 ## Start Here
 
-If you are new to the repo, choose the path that matches your goal first.
+Start with the question you are trying to answer, then take the shortest path
+into the repo.
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-5">
   <div class="col d-flex">

--- a/site/content/docs/development/_index.md
+++ b/site/content/docs/development/_index.md
@@ -1,13 +1,13 @@
 ---
 title: "Development Docs"
 linkTitle: "Development"
-description: "Canonical architecture, roadmap, config, and codebase-evolution docs."
+description: "Deep references for architecture, planning, config, and repo-shape decisions."
 weight: 40
 no_list: true
 ---
 
-These pages are the canonical deep references for architecture, roadmap, and
-repo-shape work.
+Use this section when you need the deeper references behind architecture,
+planning, config, or repo-shape decisions.
 
 If you are not already comfortable with the repo vocabulary, start with
 [Getting Started]({{< relref "/docs/getting-started/_index.md" >}}) or

--- a/site/content/docs/development/architecture.md
+++ b/site/content/docs/development/architecture.md
@@ -1,16 +1,17 @@
 ---
 title: "Architecture"
 linkTitle: "Architecture"
-description: "High-level entry point into the active tab-foundry model surface and the supporting development docs."
+description: "Best route from the active model question to the architecture, design, and code references that answer it."
 weight: 15
 aliases:
-  - /docs/architecture/
+- /docs/architecture/
 ---
 
 ## Overview
 
-Use this page when you want the shortest path from "what model is this repo
-training?" to the docs and files that actually answer it.
+Use this page when the question is "what model is this repo actually
+training?" and you want the shortest route to the docs and files that answer
+it.
 
 The quick mental model is:
 

--- a/site/content/docs/ml-engineering/artifacts-and-inference.md
+++ b/site/content/docs/ml-engineering/artifacts-and-inference.md
@@ -1,16 +1,16 @@
 ---
 title: "Artifacts & Inference"
 linkTitle: "Artifacts & Inference"
-description: "Entry point for manifests, runs, checkpoints, export bundles, and inference handoff boundaries."
+description: "Start here for manifests, runs, checkpoints, export bundles, and runtime handoff boundaries."
 weight: 10
 aliases:
-  - /docs/artifacts-and-inference/
+- /docs/artifacts-and-inference/
 ---
 
 ## Overview
 
-Use this page if you care most about the files and contracts the repo reads and
-writes.
+Use this page when the question is about the files and contracts this repo
+owns.
 
 `tab-foundry` takes data descriptions and training configs, then produces
 [run directories]({{< relref "/docs/getting-started/glossary.md" >}}#run-directory),

--- a/site/content/docs/research-contributors/model-breadth.md
+++ b/site/content/docs/research-contributors/model-breadth.md
@@ -1,10 +1,10 @@
 ---
 title: "Model Breadth"
 linkTitle: "Model Breadth"
-description: "Roadmap entry point for broader model capabilities beyond the settled classification anchor."
+description: "Entry point for many-class, regression, scaling, and later capability-expansion questions."
 weight: 40
 aliases:
-  - /docs/model-breadth/
+- /docs/model-breadth/
 ---
 
 ## Overview

--- a/site/content/docs/research-contributors/sweeps.md
+++ b/site/content/docs/research-contributors/sweeps.md
@@ -1,10 +1,10 @@
 ---
 title: "Sweeps"
 linkTitle: "Sweeps"
-description: "Entry point into the anchor-only system-delta workflow, queue discipline, and sweep artifacts."
+description: "Start here for the active sweep contract, queue discipline, and inspect-first workflow."
 weight: 10
 aliases:
-  - /docs/sweeps/
+- /docs/sweeps/
 ---
 
 ## Overview

--- a/site/content/docs/research-contributors/synthetic-data.md
+++ b/site/content/docs/research-contributors/synthetic-data.md
@@ -1,10 +1,10 @@
 ---
 title: "Synthetic Data"
 linkTitle: "Synthetic Data"
-description: "How dagzoo-backed synthetic corpora fit into tab-foundry's training surface and roadmap."
+description: "How dagzoo-backed synthetic corpora fit into training, comparison, and roadmap work."
 weight: 30
 aliases:
-  - /docs/synthetic-data/
+- /docs/synthetic-data/
 ---
 
 ## Overview

--- a/site/layouts/partials/hooks/head-end.html
+++ b/site/layouts/partials/hooks/head-end.html
@@ -4,6 +4,45 @@
 <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
 
 {{ with .Page }}
+{{ if .Params.katex }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+<script>
+  function renderKatexNodes() {
+    var root = document.querySelector(".td-content") || document.body;
+    if (!root || !window.katex) {
+      return;
+    }
+    root.querySelectorAll(".math-inline").forEach(function (node) {
+      if (node.dataset.katexRendered === "true") {
+        return;
+      }
+      window.katex.render(node.textContent || "", node, {
+        displayMode: false,
+        throwOnError: false
+      });
+      node.dataset.katexRendered = "true";
+    });
+    root.querySelectorAll(".math-display").forEach(function (node) {
+      if (node.dataset.katexRendered === "true") {
+        return;
+      }
+      window.katex.render(node.textContent || "", node, {
+        displayMode: true,
+        throwOnError: false
+      });
+      node.dataset.katexRendered = "true";
+    });
+  }
+
+  if (document.readyState === "complete") {
+    renderKatexNodes();
+  } else {
+    window.addEventListener("load", renderKatexNodes);
+    document.addEventListener("DOMContentLoaded", renderKatexNodes);
+  }
+</script>
+{{ end }}
 {{ if .Params.mermaid }}
 <script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
 <script>

--- a/tests/audit/test_dev_verify.py
+++ b/tests/audit/test_dev_verify.py
@@ -223,10 +223,21 @@ def test_pre_commit_verify_paths_covers_non_python_mapped_paths() -> None:
     pattern = str(verify_hook["files"])
 
     assert "--pre-commit" in str(verify_hook["entry"])
+    assert "pre_commit_exec.py" in str(verify_hook["entry"])
     assert "types_or" not in verify_hook
     assert re.search(pattern, "configs/config.yaml") is not None
     assert re.search(pattern, "reference/system_delta_sweeps/input_norm_followup/queue.yaml") is not None
     assert re.search(pattern, "scripts/audit/dev_verify.py") is not None
+
+
+def test_dev_verify_uses_primary_root_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TAB_FOUNDRY_PRIMARY_ROOT", "/tmp/tab-foundry-primary")
+    override_module = _load_script_module(
+        REPO_ROOT / "scripts" / "audit" / "dev_verify.py",
+        "dev_verify_override_script",
+    )
+
+    assert override_module.VENV_PYTHON == Path("/tmp/tab-foundry-primary/.venv/bin/python")
 
 
 def test_build_precommit_check_ids_drops_expensive_cross_suite_pytest() -> None:

--- a/tests/audit/test_pre_commit_exec.py
+++ b/tests/audit/test_pre_commit_exec.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_script_module(path: Path, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pre_commit_exec = _load_script_module(
+    REPO_ROOT / "scripts" / "audit" / "pre_commit_exec.py",
+    "pre_commit_exec_script",
+)
+
+
+def test_build_command_uses_primary_python_binary(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python").write_text("", encoding="utf-8")
+
+    command = pre_commit_exec.build_command(["python", "-m", "mypy", "src"], venv_bin)
+
+    assert command == [str(venv_bin / "python"), "-m", "mypy", "src"]
+
+
+def test_build_command_uses_tool_binary_from_primary_venv(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "ruff").write_text("", encoding="utf-8")
+
+    command = pre_commit_exec.build_command(["ruff", "check", "src"], venv_bin)
+
+    assert command == [str(venv_bin / "ruff"), "check", "src"]
+
+
+def test_build_command_rejects_missing_binary(tmp_path: Path) -> None:
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="Missing"):
+        pre_commit_exec.build_command(["mdformat", "README.md"], venv_bin)
+
+
+def test_resolve_primary_venv_bin_requires_primary_python(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Bootstrap the original checkout"):
+        pre_commit_exec.resolve_primary_venv_bin(tmp_path)
+

--- a/tests/research/test_tf_rd_013_support_materializer.py
+++ b/tests/research/test_tf_rd_013_support_materializer.py
@@ -25,6 +25,14 @@ def _load_script_module():
     return module
 
 
+def test_materializer_uses_primary_root_override(monkeypatch) -> None:
+    monkeypatch.setenv("TAB_FOUNDRY_PRIMARY_ROOT", "/tmp/tab-foundry-primary")
+    module = _load_script_module()
+
+    assert module.TAB_FOUNDRY_ROOT == Path("/tmp/tab-foundry-primary")
+    assert module.TAB_FOUNDRY_BIN == Path("/tmp/tab-foundry-primary/.venv/bin/tab-foundry")
+
+
 def test_split_prepared_task_falls_back_when_stratification_is_not_possible() -> None:
     module = _load_script_module()
     prepared = module.PreparedOpenMLBenchmarkTask(


### PR DESCRIPTION
## Summary
- add a rendered, math-first architecture reference with brief motivation for each major component and concise variant notes
- normalize the hosted docs tone so pages lead with reader intent instead of document mechanics
- make pre-commit and related audit/materialization tooling resolve the shared primary checkout `.venv` when running from Git worktrees

## Details
- enable page-scoped KaTeX for the model architecture page and keep the canonical source in `docs/development/model-architecture.md`
- clean up the Hugo sync rewrite so markdown and math render correctly on the hosted architecture page
- update site landing/navigation copy and synced page descriptions for a more consistent, reader-oriented docs voice
- route local pre-commit hooks through a wrapper that resolves the original checkout, and teach `dev_verify.py` plus `materialize_tf_rd_013_support.py` to honor `TAB_FOUNDRY_PRIMARY_ROOT`
- add regression coverage for the worktree tool-root resolution

## Verification
- `python3 scripts/audit/pre_commit_exec.py python -m pytest tests/audit/test_pre_commit_exec.py tests/audit/test_dev_verify.py -q`
- `python3 scripts/audit/pre_commit_exec.py python -m pytest -q tests/research/test_tf_rd_013_support_materializer.py`
- `python3 scripts/docs/sync_hugo_content.py`
- `python3 scripts/docs/check_links.py`
- `git diff --check`
- `git commit` (pre-commit hooks passed)

## Release
- no version bump; this branch changes docs and repo-local scripts/tests only