### PR TITLE
Execute TF-RD-018 task-batch ladder

### DIFF
--- a/reference/roadmap_evidence/tf_rd_018_training_surface_adequacy.md
+++ b/reference/roadmap_evidence/tf_rd_018_training_surface_adequacy.md
@@ -3,7 +3,7 @@
 This is the canonical long-form evidence note for
 [TF-RD-018](../../docs/development/roadmap.md#tf-rd-018-training-surface-adequacy-on-the-promoted-anchor).
 
-- Status: `planned`
+- Status: `research`
 - Milestone: `Next`
 - Dependency position: follows TF-RD-013, sets the default training surface for
   [TF-RD-014](tf_rd_014_missingness_robustness.md),
@@ -31,15 +31,26 @@ This is the canonical long-form evidence note for
   `task_batch_size` ladder on the medium surface
 - the current medium-surface singleton runtime is about `227s`, so the roadmap
   gates for `4/8/16/32` remain iterative rather than overnight by default
+- [#109](https://github.com/bensonlee5/tab-foundry/issues/109) executed the first
+  ladder on 2026-03-24: `task_batch_size=4` finished in `699.4s` with `0.0%`
+  singleton fallback, while `task_batch_size=8` finished in `1109.3s` with
+  `0.0%` singleton fallback and reused the saved nanoTabPFN curve from row 1
+- `task_batch_size=4` is now the preferred TF-RD-018 batch rung on the settled
+  medium surface, and `task_batch_size=16` plus `32` remain blocked by the row-2
+  runtime miss
 
 ## Current Interpretation
 
-- search for the largest useful manifest task batch on the settled medium
-  surface before reopening optimizer or schedule-family follow-up
-- treat `task_batch_size=4` and `8` as unconditional reads; treat `16` and `32`
-  as gated by runtime, OOM, and singleton-fallback behavior
+- `task_batch_size=4` is the current default training-surface rung on the
+  settled medium surface because it satisfied the runtime gate that stopped the
+  first ladder
+- `task_batch_size=8` is now negative gate evidence rather than the new default:
+  it preserved clean batching, reused the row-1 nanoTabPFN curve, but still
+  missed the `<=900s` gate and regressed final benchmark-facing metrics
 - after the preferred batch rung is chosen, retune LR and schedule on that rung
   rather than jointly searching batch and LR across the whole ladder
+- issues `#137`, `#138`, and `#139` should now rebase onto
+  `task_batch_size=4` instead of reopening singleton updates
 - compare strong Adam-family baselines before treating `muon` or other
   specialized optimizers as necessary
 - keep architecture changes out of TF-RD-018; they belong later under
@@ -47,13 +58,13 @@ This is the canonical long-form evidence note for
 
 ## Open Evidence Gaps
 
-- the repo does not yet have a benchmark-backed preferred batch rung on the
-  representative medium surface
-- optimizer-family, LR-shape, clipping, and step-budget evidence are still
-  contingent on the batch decision
+- optimizer-family, LR-shape, clipping, and step-budget evidence are still open,
+  but they should now be read on top of `task_batch_size=4`
 - the repo still needs an explicit handoff rule for how much of the TF-RD-018
   recipe should stay fixed when
   [TF-RD-009](tf_rd_009_scaling_law_measurement.md) starts
+- the current medium-surface record still lacks evidence that larger manifest
+  task batches are worth reopening without separate runtime work
 
 ## Exit Signals
 

--- a/reference/system_delta_matrix.md
+++ b/reference/system_delta_matrix.md
@@ -44,17 +44,17 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_training_task_batch4` | batch_size | yes | ready | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface. | Run first as the opening manifest task-batch rung on the settled TF-RD-013 medium surface. |
-| 2 | `delta_training_task_batch8` | batch_size | yes | ready | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface. | Run second as the highest unconditional manifest task-batch rung on the settled TF-RD-013 medium surface. |
-| 3 | `delta_training_task_batch16` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to sixteen at a time on the TF-RD-013 medium corpus surface. | Wait for the `task_batch_size=8` rung to clear the runtime, OOM, and singleton-fallback gate before running this row. |
-| 4 | `delta_training_task_batch32` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to thirty-two at a time on the TF-RD-013 medium corpus surface. | Wait for the `task_batch_size=16` rung to clear the runtime, OOM, and singleton-fallback gate before running this row. |
+| 1 | `delta_training_task_batch4` | batch_size | yes | completed | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface. | Lock `task_batch_size=4` as the preferred TF-RD-018 batch rung and rebase issues `#137`, `#138`, and `#139` onto this manifest-batched surface instead of reopening singleton updates. |
+| 2 | `delta_training_task_batch8` | batch_size | yes | completed | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface. | Stop the ladder here because this row kept singleton fallback at `0.0%` but finished in `1109.3s`, so `task_batch_size=16` and `32` stay blocked and issues `#137`, `#138`, and `#139` should rebase onto the kept four-task rung. |
+| 3 | `delta_training_task_batch16` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to sixteen at a time on the TF-RD-013 medium corpus surface. | Do not run this row in the current ladder; row 2 finished in `1109.3s` and failed the `<=900s` promotion gate, so issues `#137`, `#138`, and `#139` should continue from the kept `task_batch_size=4` surface instead. |
+| 4 | `delta_training_task_batch32` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to thirty-two at a time on the TF-RD-013 medium corpus surface. | Keep this rung blocked because the current ladder stopped when row 2 missed the row-3 promotion gate; only reopen larger task batches if later runtime work changes the economics. |
 
 ## Detailed Rows
 
 ### 1. `delta_training_task_batch4`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `none`
 - Description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface.
@@ -64,6 +64,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=4`.
 - Expected effect: A four-task manifest batch should improve dataset-throughput efficiency with lower packing and memory risk than the larger rungs.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_shape_aware_size_medium`, preprocessing=`runtime_default`, training=`linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.2624`); context (grad `0.1001`)
 - Training overrides: `{'apply_schedule': True, 'optimizer': {'name': 'schedulefree_adamw', 'require_requested': True, 'weight_decay': 0.0, 'betas': [0.9, 0.999], 'min_lr': 0.0004, 'muon_per_parameter_lr': False}, 'runtime': {'grad_accum_steps': 1, 'max_steps': 2500, 'target_train_seconds': None, 'eval_every': 25, 'checkpoint_every': 25, 'trace_activations': False, 'val_batches': 0}, 'schedule': {'stages': [{'name': 'stage1', 'steps': 2500, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.05}]}}`
 - Parameter adequacy plan:
   - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
@@ -74,16 +75,20 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - batched_update_count
   - train_elapsed_seconds
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `keep`
+- Notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Locked as the preferred rung because it finished in `699.4s`, avoided recorded OOM mitigation, and kept singleton fallback at `0.0%` while the eight-task rung missed the `<=900s` gate.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1` with final log loss `4.4473`, delta final log loss `+2.1869`, final Brier score `0.6465`, delta final Brier score `+0.1553`, best ROC AUC `0.5958`, final ROC AUC `0.5746`, final-minus-best `-0.0213`, delta final ROC AUC `+0.0120`, delta drift `-0.0127`, delta final training time `+472.7s`
 
 ### 2. `delta_training_task_batch8`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `none`
 - Description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface.
@@ -93,6 +98,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=8`.
 - Expected effect: An eight-task manifest batch may improve wall-clock efficiency further if the medium corpus still spends too much time on singleton task dispatch.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_shape_aware_size_medium`, preprocessing=`runtime_default`, training=`linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.0082`); context (grad `0.0041`)
 - Training overrides: `{'apply_schedule': True, 'optimizer': {'name': 'schedulefree_adamw', 'require_requested': True, 'weight_decay': 0.0, 'betas': [0.9, 0.999], 'min_lr': 0.0004, 'muon_per_parameter_lr': False}, 'runtime': {'grad_accum_steps': 1, 'max_steps': 2500, 'target_train_seconds': None, 'eval_every': 25, 'checkpoint_every': 25, 'trace_activations': False, 'val_batches': 0}, 'schedule': {'stages': [{'name': 'stage1', 'steps': 2500, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.05}]}}`
 - Parameter adequacy plan:
   - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
@@ -103,11 +109,16 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - batched_update_count
   - train_elapsed_seconds
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
+- Notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Reused the saved nanoTabPFN curve from row 1 rather than running a fresh external helper benchmark.
+  - This row missed the `<=900s` promotion gate at `1109.3s` even though singleton fallback stayed at `0.0%` and no recorded OOM mitigation was needed.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1` with final log loss `5.0365`, delta final log loss `+2.7761`, final Brier score `0.6119`, delta final Brier score `+0.1207`, best ROC AUC `0.6246`, final ROC AUC `0.5508`, final-minus-best `-0.0738`, delta final ROC AUC `-0.0117`, delta drift `-0.0653`, delta final training time `+882.6s`
 
 ### 3. `delta_training_task_batch16`
 
@@ -136,6 +147,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Decision: `None`
 - Notes:
   - This row is intentionally blocked pending the row-2 gate.
+  - Row 2 completed in `1109.3s` with `0.0%` singleton fallback and no recorded OOM mitigation, so the ladder stops before this rung.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch16/result_card.md`
 - Benchmark metrics: pending
@@ -167,6 +179,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Decision: `None`
 - Notes:
   - This row is intentionally blocked pending the row-3 gate.
+  - Row 3 never unblocked because the eight-task rung already failed the runtime promotion gate.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch32/result_card.md`
 - Benchmark metrics: pending

--- a/reference/system_delta_queue.yaml
+++ b/reference/system_delta_queue.yaml
@@ -134,7 +134,7 @@ anchor_context:
 rows:
 - order: 1
   delta_id: delta_training_task_batch4
-  status: ready
+  status: completed
   dimension_family: training
   family: batch_size
   binary_applicable: true
@@ -218,19 +218,63 @@ rows:
   - Read final log loss, final ROC AUC, train elapsed seconds, and singleton-fallback
     fraction together before preferring a larger rung.
   execution_policy: benchmark_full
-  run_id: null
+  run_id: sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: keep
+  interpretation_status: completed
   confounders: []
-  next_action: Run first as the opening manifest task-batch rung on the settled TF-RD-013
-    medium surface.
-  notes: []
+  next_action: Lock `task_batch_size=4` as the preferred TF-RD-018 batch rung and
+    rebase issues `#137`, `#138`, and `#139` onto this manifest-batched surface instead
+    of reopening singleton updates.
+  notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Locked as the preferred rung because it finished in `699.4s`, avoided recorded
+    OOM mitigation, and kept singleton fallback at `0.0%` while the eight-task rung
+    missed the `<=900s` gate.
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 125
+    max_grad_norm: 11.365192413330078
+    clipped_step_fraction: 0.366
+    primary_external_benchmark: nanotabpfn
+    primary_external_label: nanoTabPFN
+    best_log_loss: 0.5552691711984782
+    primary_external_best_log_loss: 0.4510985126422435
+    nanotabpfn_best_log_loss: 0.4510985126422435
+    final_log_loss: 4.447267230712592
+    primary_external_final_log_loss: 0.453973433403279
+    nanotabpfn_final_log_loss: 0.453973433403279
+    best_brier_score: 0.37513787610088556
+    primary_external_best_brier_score: 0.2928541132979815
+    nanotabpfn_best_brier_score: 0.2928541132979815
+    final_brier_score: 0.646497149322779
+    primary_external_final_brier_score: 0.29490909093072887
+    nanotabpfn_final_brier_score: 0.29490909093072887
+    best_roc_auc: 0.595822713367738
+    primary_external_best_roc_auc: 0.7482958403555632
+    nanotabpfn_best_roc_auc: 0.7482958403555632
+    final_roc_auc: 0.5745704860521681
+    primary_external_final_roc_auc: 0.7446752311186746
+    nanotabpfn_final_roc_auc: 0.7446752311186746
+    final_minus_best_log_loss: 3.891998059514114
+    final_minus_best_brier_score: 0.27135927322189346
+    final_minus_best_roc_auc: -0.02125222731556986
+    drift: -0.02125222731556986
+    primary_external_best: 0.7482958403555632
+    primary_external_final: 0.7446752311186746
+    nanotabpfn_best: 0.7482958403555632
+    nanotabpfn_final: 0.7446752311186746
+    delta_final_log_loss: 2.1868905579368514
+    delta_final_brier_score: 0.15531107291991325
+    delta_final_roc_auc: 0.012020828139464812
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.26239560062446776
+    context_encoder_final_window_mean_grad_norm: 0.10012740276681316
 - order: 2
   delta_id: delta_training_task_batch8
-  status: ready
+  status: completed
   dimension_family: training
   family: batch_size
   binary_applicable: true
@@ -314,16 +358,61 @@ rows:
   - Use this row as the gatekeeper for larger task-batch rungs before reopening optimizer,
     LR, clipping, or budget questions.
   execution_policy: benchmark_full
-  run_id: null
+  run_id: sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Run second as the highest unconditional manifest task-batch rung on
-    the settled TF-RD-013 medium surface.
-  notes: []
+  next_action: Stop the ladder here because this row kept singleton fallback at `0.0%`
+    but finished in `1109.3s`, so `task_batch_size=16` and `32` stay blocked and issues
+    `#137`, `#138`, and `#139` should rebase onto the kept four-task rung.
+  notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Reused the saved nanoTabPFN curve from row 1 rather than running a fresh external
+    helper benchmark.
+  - This row missed the `<=900s` promotion gate at `1109.3s` even though singleton
+    fallback stayed at `0.0%` and no recorded OOM mitigation was needed.
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 50
+    max_grad_norm: 4.467634201049805
+    clipped_step_fraction: 0.1944
+    primary_external_benchmark: nanotabpfn
+    primary_external_label: nanoTabPFN
+    best_log_loss: 0.5590177645879071
+    primary_external_best_log_loss: 0.4510985126422435
+    nanotabpfn_best_log_loss: 0.4510985126422435
+    final_log_loss: 5.036488042435719
+    primary_external_final_log_loss: 0.453973433403279
+    nanotabpfn_final_log_loss: 0.453973433403279
+    best_brier_score: 0.37726591278755156
+    primary_external_best_brier_score: 0.2928541132979815
+    nanotabpfn_best_brier_score: 0.2928541132979815
+    final_brier_score: 0.6119107587117542
+    primary_external_final_brier_score: 0.29490909093072887
+    nanotabpfn_final_brier_score: 0.29490909093072887
+    best_roc_auc: 0.6246323098943156
+    primary_external_best_roc_auc: 0.7482958403555632
+    nanotabpfn_best_roc_auc: 0.7482958403555632
+    final_roc_auc: 0.5508072490756942
+    primary_external_final_roc_auc: 0.7446752311186746
+    nanotabpfn_final_roc_auc: 0.7446752311186746
+    final_minus_best_log_loss: 4.477470277847813
+    final_minus_best_brier_score: 0.2346448459242026
+    final_minus_best_roc_auc: -0.07382506081862139
+    drift: -0.07382506081862139
+    primary_external_best: 0.7482958403555632
+    primary_external_final: 0.7446752311186746
+    nanotabpfn_best: 0.7482958403555632
+    nanotabpfn_final: 0.7446752311186746
+    delta_final_log_loss: 2.7761113696599784
+    delta_final_brier_score: 0.12072468230888839
+    delta_final_roc_auc: -0.011742408837009055
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.008151133608001574
+    context_encoder_final_window_mean_grad_norm: 0.004102957921600735
 - order: 3
   delta_id: delta_training_task_batch16
   status: blocked
@@ -418,10 +507,13 @@ rows:
   decision: null
   interpretation_status: blocked
   confounders: []
-  next_action: Wait for the `task_batch_size=8` rung to clear the runtime, OOM, and
-    singleton-fallback gate before running this row.
+  next_action: Do not run this row in the current ladder; row 2 finished in `1109.3s`
+    and failed the `<=900s` promotion gate, so issues `#137`, `#138`, and `#139` should
+    continue from the kept `task_batch_size=4` surface instead.
   notes:
   - This row is intentionally blocked pending the row-2 gate.
+  - Row 2 completed in `1109.3s` with `0.0%` singleton fallback and no recorded OOM
+    mitigation, so the ladder stops before this rung.
   screen_metrics: null
   benchmark_metrics: null
   parent_delta_ref: delta_training_task_batch8
@@ -518,10 +610,13 @@ rows:
   decision: null
   interpretation_status: blocked
   confounders: []
-  next_action: Wait for the `task_batch_size=16` rung to clear the runtime, OOM, and
-    singleton-fallback gate before running this row.
+  next_action: Keep this rung blocked because the current ladder stopped when row
+    2 missed the row-3 promotion gate; only reopen larger task batches if later runtime
+    work changes the economics.
   notes:
   - This row is intentionally blocked pending the row-3 gate.
+  - Row 3 never unblocked because the eight-task rung already failed the runtime promotion
+    gate.
   screen_metrics: null
   benchmark_metrics: null
   parent_delta_ref: delta_training_task_batch16

--- a/reference/system_delta_sweeps/row_first_training_adequacy_v1/matrix.md
+++ b/reference/system_delta_sweeps/row_first_training_adequacy_v1/matrix.md
@@ -44,17 +44,17 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_training_task_batch4` | batch_size | yes | ready | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface. | Run first as the opening manifest task-batch rung on the settled TF-RD-013 medium surface. |
-| 2 | `delta_training_task_batch8` | batch_size | yes | ready | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface. | Run second as the highest unconditional manifest task-batch rung on the settled TF-RD-013 medium surface. |
-| 3 | `delta_training_task_batch16` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to sixteen at a time on the TF-RD-013 medium corpus surface. | Wait for the `task_batch_size=8` rung to clear the runtime, OOM, and singleton-fallback gate before running this row. |
-| 4 | `delta_training_task_batch32` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to thirty-two at a time on the TF-RD-013 medium corpus surface. | Wait for the `task_batch_size=16` rung to clear the runtime, OOM, and singleton-fallback gate before running this row. |
+| 1 | `delta_training_task_batch4` | batch_size | yes | completed | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface. | Lock `task_batch_size=4` as the preferred TF-RD-018 batch rung and rebase issues `#137`, `#138`, and `#139` onto this manifest-batched surface instead of reopening singleton updates. |
+| 2 | `delta_training_task_batch8` | batch_size | yes | completed | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface. | Stop the ladder here because this row kept singleton fallback at `0.0%` but finished in `1109.3s`, so `task_batch_size=16` and `32` stay blocked and issues `#137`, `#138`, and `#139` should rebase onto the kept four-task rung. |
+| 3 | `delta_training_task_batch16` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to sixteen at a time on the TF-RD-013 medium corpus surface. | Do not run this row in the current ladder; row 2 finished in `1109.3s` and failed the `<=900s` promotion gate, so issues `#137`, `#138`, and `#139` should continue from the kept `task_batch_size=4` surface instead. |
+| 4 | `delta_training_task_batch32` | batch_size | yes | blocked | none | Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to thirty-two at a time on the TF-RD-013 medium corpus surface. | Keep this rung blocked because the current ladder stopped when row 2 missed the row-3 promotion gate; only reopen larger task batches if later runtime work changes the economics. |
 
 ## Detailed Rows
 
 ### 1. `delta_training_task_batch4`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `none`
 - Description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface.
@@ -64,6 +64,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=4`.
 - Expected effect: A four-task manifest batch should improve dataset-throughput efficiency with lower packing and memory risk than the larger rungs.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_shape_aware_size_medium`, preprocessing=`runtime_default`, training=`linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.2624`); context (grad `0.1001`)
 - Training overrides: `{'apply_schedule': True, 'optimizer': {'name': 'schedulefree_adamw', 'require_requested': True, 'weight_decay': 0.0, 'betas': [0.9, 0.999], 'min_lr': 0.0004, 'muon_per_parameter_lr': False}, 'runtime': {'grad_accum_steps': 1, 'max_steps': 2500, 'target_train_seconds': None, 'eval_every': 25, 'checkpoint_every': 25, 'trace_activations': False, 'val_batches': 0}, 'schedule': {'stages': [{'name': 'stage1', 'steps': 2500, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.05}]}}`
 - Parameter adequacy plan:
   - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
@@ -74,16 +75,20 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - batched_update_count
   - train_elapsed_seconds
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `keep`
+- Notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Locked as the preferred rung because it finished in `699.4s`, avoided recorded OOM mitigation, and kept singleton fallback at `0.0%` while the eight-task rung missed the `<=900s` gate.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1` with final log loss `4.4473`, delta final log loss `+2.1869`, final Brier score `0.6465`, delta final Brier score `+0.1553`, best ROC AUC `0.5958`, final ROC AUC `0.5746`, final-minus-best `-0.0213`, delta final ROC AUC `+0.0120`, delta drift `-0.0127`, delta final training time `+472.7s`
 
 ### 2. `delta_training_task_batch8`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `True`
 - Recipe alias: `none`
 - Description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface.
@@ -93,6 +98,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Anchor delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=8`.
 - Expected effect: An eight-task manifest batch may improve wall-clock efficiency further if the medium corpus still spends too much time on singleton task dispatch.
 - Effective labels: model=`delta_qass_no_column_v3`, data=`tf_rd_013_dagzoo_shape_aware_size_medium`, preprocessing=`runtime_default`, training=`linear_warmup_decay`
+- Stage-local stability: column (grad `0.0000`); row (grad `0.0082`); context (grad `0.0041`)
 - Training overrides: `{'apply_schedule': True, 'optimizer': {'name': 'schedulefree_adamw', 'require_requested': True, 'weight_decay': 0.0, 'betas': [0.9, 0.999], 'min_lr': 0.0004, 'muon_per_parameter_lr': False}, 'runtime': {'grad_accum_steps': 1, 'max_steps': 2500, 'target_train_seconds': None, 'eval_every': 25, 'checkpoint_every': 25, 'trace_activations': False, 'val_batches': 0}, 'schedule': {'stages': [{'name': 'stage1', 'steps': 2500, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.05}]}}`
 - Parameter adequacy plan:
   - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
@@ -103,11 +109,16 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
   - batched_update_count
   - train_elapsed_seconds
 - Execution policy: `benchmark_full`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
+- Notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Reused the saved nanoTabPFN curve from row 1 rather than running a fresh external helper benchmark.
+  - This row missed the `<=900s` promotion gate at `1109.3s` even though singleton fallback stayed at `0.0%` and no recorded OOM mitigation was needed.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1` with final log loss `5.0365`, delta final log loss `+2.7761`, final Brier score `0.6119`, delta final Brier score `+0.1207`, best ROC AUC `0.6246`, final ROC AUC `0.5508`, final-minus-best `-0.0738`, delta final ROC AUC `-0.0117`, delta drift `-0.0653`, delta final training time `+882.6s`
 
 ### 3. `delta_training_task_batch16`
 
@@ -136,6 +147,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Decision: `None`
 - Notes:
   - This row is intentionally blocked pending the row-2 gate.
+  - Row 2 completed in `1109.3s` with `0.0%` singleton fallback and no recorded OOM mitigation, so the ladder stops before this rung.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch16/result_card.md`
 - Benchmark metrics: pending
@@ -167,6 +179,7 @@ Upstream reference: `nanoTabPFN` from `https://github.com/automl/nanoTabPFN/blob
 - Decision: `None`
 - Notes:
   - This row is intentionally blocked pending the row-3 gate.
+  - Row 3 never unblocked because the eight-task rung already failed the runtime promotion gate.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch32/result_card.md`
 - Benchmark metrics: pending

--- a/reference/system_delta_sweeps/row_first_training_adequacy_v1/queue.yaml
+++ b/reference/system_delta_sweeps/row_first_training_adequacy_v1/queue.yaml
@@ -1,239 +1,364 @@
 schema: tab-foundry-system-delta-sweep-queue-v1
 sweep_id: row_first_training_adequacy_v1
 rows:
-  - order: 1
-    delta_ref: delta_training_task_batch4
-    status: ready
-    rationale: Start TF-RD-018 with the lowest-risk manifest task-batch rung on the settled TF-RD-013 medium corpus surface.
-    hypothesis: Exact-shape task batching at four tasks should improve wall-clock efficiency without reopening architecture, preprocessing, or optimizer-family questions.
-    anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=4`.
-    model:
-      stage: qass_context
-      stage_label: delta_qass_no_column_v3
-      module_overrides:
-        column_encoder: none
-    data:
-      surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
-      source: manifest
-      corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
-      train_row_cap: 512
-      test_row_cap: 256
-    preprocessing:
-      surface_label: runtime_default
-    training:
-      surface_label: linear_warmup_decay
-      task_batch_size: 4
-      overrides:
-        apply_schedule: true
-        optimizer:
-          name: schedulefree_adamw
-          require_requested: true
-          weight_decay: 0.0
-          betas:
-            - 0.9
-            - 0.999
-          min_lr: 0.0004
-          muon_per_parameter_lr: false
-        runtime:
-          grad_accum_steps: 1
-          max_steps: 2500
-          target_train_seconds: null
-          eval_every: 25
-          checkpoint_every: 25
-          trace_activations: false
-          val_batches: 0
-        schedule:
-          stages:
-            - name: stage1
-              steps: 2500
-              lr_max: 0.004
-              lr_schedule: linear
-              warmup_ratio: 0.05
-    parameter_adequacy_plan:
-      - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
-      - Read final log loss, final ROC AUC, train elapsed seconds, and singleton-fallback fraction together before preferring a larger rung.
-    run_id: null
-    followup_run_ids: []
-    decision: null
-    interpretation_status: pending
-    confounders: []
-    next_action: Run first as the opening manifest task-batch rung on the settled TF-RD-013 medium surface.
-    notes: []
-  - order: 2
-    delta_ref: delta_training_task_batch8
-    status: ready
-    rationale: Probe the highest unconditional manifest task-batch rung before TF-RD-018 opens optimizer or schedule-family follow-ups.
-    hypothesis: Exact-shape task batching at eight tasks may further improve throughput while keeping singleton fallback and memory use low enough for iterative reads.
-    anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=8`.
-    model:
-      stage: qass_context
-      stage_label: delta_qass_no_column_v3
-      module_overrides:
-        column_encoder: none
-    data:
-      surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
-      source: manifest
-      corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
-      train_row_cap: 512
-      test_row_cap: 256
-    preprocessing:
-      surface_label: runtime_default
-    training:
-      surface_label: linear_warmup_decay
-      task_batch_size: 8
-      overrides:
-        apply_schedule: true
-        optimizer:
-          name: schedulefree_adamw
-          require_requested: true
-          weight_decay: 0.0
-          betas:
-            - 0.9
-            - 0.999
-          min_lr: 0.0004
-          muon_per_parameter_lr: false
-        runtime:
-          grad_accum_steps: 1
-          max_steps: 2500
-          target_train_seconds: null
-          eval_every: 25
-          checkpoint_every: 25
-          trace_activations: false
-          val_batches: 0
-        schedule:
-          stages:
-            - name: stage1
-              steps: 2500
-              lr_max: 0.004
-              lr_schedule: linear
-              warmup_ratio: 0.05
-    parameter_adequacy_plan:
-      - Keep the model, data surface, preprocessing, optimizer family, and schedule shape fixed so this row isolates manifest task batching only.
-      - Use this row as the gatekeeper for larger task-batch rungs before reopening optimizer, LR, clipping, or budget questions.
-    run_id: null
-    followup_run_ids: []
-    decision: null
-    interpretation_status: pending
-    confounders: []
-    next_action: Run second as the highest unconditional manifest task-batch rung on the settled TF-RD-013 medium surface.
-    notes: []
-  - order: 3
-    delta_ref: delta_training_task_batch16
-    parent_delta_ref: delta_training_task_batch8
-    status: blocked
-    rationale: Keep the larger manifest task-batch ladder explicit, but do not spend the extra runtime or memory budget until the eight-task rung proves it is still on the clean batched path.
-    hypothesis: Exact-shape task batching at sixteen tasks may still improve throughput, but only if the eight-task rung stays fast, avoids OOM, and rarely falls back to singleton dispatch.
-    anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=16`.
-    model:
-      stage: qass_context
-      stage_label: delta_qass_no_column_v3
-      module_overrides:
-        column_encoder: none
-    data:
-      surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
-      source: manifest
-      corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
-      train_row_cap: 512
-      test_row_cap: 256
-    preprocessing:
-      surface_label: runtime_default
-    training:
-      surface_label: linear_warmup_decay
-      task_batch_size: 16
-      overrides:
-        apply_schedule: true
-        optimizer:
-          name: schedulefree_adamw
-          require_requested: true
-          weight_decay: 0.0
-          betas:
-            - 0.9
-            - 0.999
-          min_lr: 0.0004
-          muon_per_parameter_lr: false
-        runtime:
-          grad_accum_steps: 1
-          max_steps: 2500
-          target_train_seconds: null
-          eval_every: 25
-          checkpoint_every: 25
-          trace_activations: false
-          val_batches: 0
-        schedule:
-          stages:
-            - name: stage1
-              steps: 2500
-              lr_max: 0.004
-              lr_schedule: linear
-              warmup_ratio: 0.05
-    parameter_adequacy_plan:
-      - Leave blocked until the `task_batch_size=8` row finishes in `<=900s`, avoids OOM, and keeps singleton fallback at `<=10%` of updates.
-      - If unblocked, compare against the eight-task rung first and stop the ladder if runtime exceeds `1800s` or singleton fallback rises above `10%`.
-    run_id: null
-    followup_run_ids: []
-    decision: null
-    interpretation_status: blocked
-    confounders: []
-    next_action: Wait for the `task_batch_size=8` rung to clear the runtime, OOM, and singleton-fallback gate before running this row.
-    notes:
-      - This row is intentionally blocked pending the row-2 gate.
-  - order: 4
-    delta_ref: delta_training_task_batch32
-    parent_delta_ref: delta_training_task_batch16
-    status: blocked
-    rationale: Keep the highest manifest task-batch rung visible in the queue, but leave it dormant unless the sixteen-task rung remains fast and mostly batched.
-    hypothesis: Exact-shape task batching at thirty-two tasks will only be useful if the sixteen-task rung still avoids OOM and singleton fallback on the settled medium corpus.
-    anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing, and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=32`.
-    model:
-      stage: qass_context
-      stage_label: delta_qass_no_column_v3
-      module_overrides:
-        column_encoder: none
-    data:
-      surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
-      source: manifest
-      corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
-      train_row_cap: 512
-      test_row_cap: 256
-    preprocessing:
-      surface_label: runtime_default
-    training:
-      surface_label: linear_warmup_decay
-      task_batch_size: 32
-      overrides:
-        apply_schedule: true
-        optimizer:
-          name: schedulefree_adamw
-          require_requested: true
-          weight_decay: 0.0
-          betas:
-            - 0.9
-            - 0.999
-          min_lr: 0.0004
-          muon_per_parameter_lr: false
-        runtime:
-          grad_accum_steps: 1
-          max_steps: 2500
-          target_train_seconds: null
-          eval_every: 25
-          checkpoint_every: 25
-          trace_activations: false
-          val_batches: 0
-        schedule:
-          stages:
-            - name: stage1
-              steps: 2500
-              lr_max: 0.004
-              lr_schedule: linear
-              warmup_ratio: 0.05
-    parameter_adequacy_plan:
-      - Leave blocked until the `task_batch_size=16` row finishes in `<=900s`, avoids OOM, and keeps singleton fallback at `<=10%` of updates.
-      - If unblocked, compare against the sixteen-task rung first and stop the ladder if runtime exceeds `1800s` or singleton fallback rises above `10%`.
-    run_id: null
-    followup_run_ids: []
-    decision: null
-    interpretation_status: blocked
-    confounders: []
-    next_action: Wait for the `task_batch_size=16` rung to clear the runtime, OOM, and singleton-fallback gate before running this row.
-    notes:
-      - This row is intentionally blocked pending the row-3 gate.
+- order: 1
+  delta_ref: delta_training_task_batch4
+  status: completed
+  rationale: Start TF-RD-018 with the lowest-risk manifest task-batch rung on the
+    settled TF-RD-013 medium corpus surface.
+  hypothesis: Exact-shape task batching at four tasks should improve wall-clock efficiency
+    without reopening architecture, preprocessing, or optimizer-family questions.
+  anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing,
+    and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=4`.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
+    source: manifest
+    corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
+    train_row_cap: 512
+    test_row_cap: 256
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: linear_warmup_decay
+    task_batch_size: 4
+    overrides:
+      apply_schedule: true
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      runtime:
+        grad_accum_steps: 1
+        max_steps: 2500
+        target_train_seconds: null
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Keep the model, data surface, preprocessing, optimizer family, and schedule shape
+    fixed so this row isolates manifest task batching only.
+  - Read final log loss, final ROC AUC, train elapsed seconds, and singleton-fallback
+    fraction together before preferring a larger rung.
+  run_id: sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1
+  followup_run_ids: []
+  decision: keep
+  interpretation_status: completed
+  confounders: []
+  next_action: Lock `task_batch_size=4` as the preferred TF-RD-018 batch rung and
+    rebase issues `#137`, `#138`, and `#139` onto this manifest-batched surface
+    instead of reopening singleton updates.
+  notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Locked as the preferred rung because it finished in `699.4s`, avoided recorded
+    OOM mitigation, and kept singleton fallback at `0.0%` while the eight-task
+    rung missed the `<=900s` gate.
+  benchmark_metrics:
+    best_step: 125
+    max_grad_norm: 11.365192413330078
+    clipped_step_fraction: 0.366
+    primary_external_benchmark: nanotabpfn
+    primary_external_label: nanoTabPFN
+    best_log_loss: 0.5552691711984782
+    primary_external_best_log_loss: 0.4510985126422435
+    nanotabpfn_best_log_loss: 0.4510985126422435
+    final_log_loss: 4.447267230712592
+    primary_external_final_log_loss: 0.453973433403279
+    nanotabpfn_final_log_loss: 0.453973433403279
+    best_brier_score: 0.37513787610088556
+    primary_external_best_brier_score: 0.2928541132979815
+    nanotabpfn_best_brier_score: 0.2928541132979815
+    final_brier_score: 0.646497149322779
+    primary_external_final_brier_score: 0.29490909093072887
+    nanotabpfn_final_brier_score: 0.29490909093072887
+    best_roc_auc: 0.595822713367738
+    primary_external_best_roc_auc: 0.7482958403555632
+    nanotabpfn_best_roc_auc: 0.7482958403555632
+    final_roc_auc: 0.5745704860521681
+    primary_external_final_roc_auc: 0.7446752311186746
+    nanotabpfn_final_roc_auc: 0.7446752311186746
+    final_minus_best_log_loss: 3.891998059514114
+    final_minus_best_brier_score: 0.27135927322189346
+    final_minus_best_roc_auc: -0.02125222731556986
+    drift: -0.02125222731556986
+    primary_external_best: 0.7482958403555632
+    primary_external_final: 0.7446752311186746
+    nanotabpfn_best: 0.7482958403555632
+    nanotabpfn_final: 0.7446752311186746
+    delta_final_log_loss: 2.1868905579368514
+    delta_final_brier_score: 0.15531107291991325
+    delta_final_roc_auc: 0.012020828139464812
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.26239560062446776
+    context_encoder_final_window_mean_grad_norm: 0.10012740276681316
+- order: 2
+  delta_ref: delta_training_task_batch8
+  status: completed
+  rationale: Probe the highest unconditional manifest task-batch rung before TF-RD-018
+    opens optimizer or schedule-family follow-ups.
+  hypothesis: Exact-shape task batching at eight tasks may further improve throughput
+    while keeping singleton fallback and memory use low enough for iterative reads.
+  anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing,
+    and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=8`.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
+    source: manifest
+    corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
+    train_row_cap: 512
+    test_row_cap: 256
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: linear_warmup_decay
+    task_batch_size: 8
+    overrides:
+      apply_schedule: true
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      runtime:
+        grad_accum_steps: 1
+        max_steps: 2500
+        target_train_seconds: null
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Keep the model, data surface, preprocessing, optimizer family, and schedule shape
+    fixed so this row isolates manifest task batching only.
+  - Use this row as the gatekeeper for larger task-batch rungs before reopening optimizer,
+    LR, clipping, or budget questions.
+  run_id: sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1
+  followup_run_ids: []
+  decision: defer
+  interpretation_status: completed
+  confounders: []
+  next_action: Stop the ladder here because this row kept singleton fallback at
+    `0.0%` but finished in `1109.3s`, so `task_batch_size=16` and `32` stay blocked
+    and issues `#137`, `#138`, and `#139` should rebase onto the kept four-task
+    rung.
+  notes:
+  - Canonical rerun registered as `sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
+  - Reused the saved nanoTabPFN curve from row 1 rather than running a fresh external
+    helper benchmark.
+  - This row missed the `<=900s` promotion gate at `1109.3s` even though singleton
+    fallback stayed at `0.0%` and no recorded OOM mitigation was needed.
+  benchmark_metrics:
+    best_step: 50
+    max_grad_norm: 4.467634201049805
+    clipped_step_fraction: 0.1944
+    primary_external_benchmark: nanotabpfn
+    primary_external_label: nanoTabPFN
+    best_log_loss: 0.5590177645879071
+    primary_external_best_log_loss: 0.4510985126422435
+    nanotabpfn_best_log_loss: 0.4510985126422435
+    final_log_loss: 5.036488042435719
+    primary_external_final_log_loss: 0.453973433403279
+    nanotabpfn_final_log_loss: 0.453973433403279
+    best_brier_score: 0.37726591278755156
+    primary_external_best_brier_score: 0.2928541132979815
+    nanotabpfn_best_brier_score: 0.2928541132979815
+    final_brier_score: 0.6119107587117542
+    primary_external_final_brier_score: 0.29490909093072887
+    nanotabpfn_final_brier_score: 0.29490909093072887
+    best_roc_auc: 0.6246323098943156
+    primary_external_best_roc_auc: 0.7482958403555632
+    nanotabpfn_best_roc_auc: 0.7482958403555632
+    final_roc_auc: 0.5508072490756942
+    primary_external_final_roc_auc: 0.7446752311186746
+    nanotabpfn_final_roc_auc: 0.7446752311186746
+    final_minus_best_log_loss: 4.477470277847813
+    final_minus_best_brier_score: 0.2346448459242026
+    final_minus_best_roc_auc: -0.07382506081862139
+    drift: -0.07382506081862139
+    primary_external_best: 0.7482958403555632
+    primary_external_final: 0.7446752311186746
+    nanotabpfn_best: 0.7482958403555632
+    nanotabpfn_final: 0.7446752311186746
+    delta_final_log_loss: 2.7761113696599784
+    delta_final_brier_score: 0.12072468230888839
+    delta_final_roc_auc: -0.011742408837009055
+    column_encoder_final_window_mean_grad_norm: 0.0
+    row_pool_final_window_mean_grad_norm: 0.008151133608001574
+    context_encoder_final_window_mean_grad_norm: 0.004102957921600735
+- order: 3
+  delta_ref: delta_training_task_batch16
+  parent_delta_ref: delta_training_task_batch8
+  status: blocked
+  rationale: Keep the larger manifest task-batch ladder explicit, but do not spend
+    the extra runtime or memory budget until the eight-task rung proves it is still
+    on the clean batched path.
+  hypothesis: Exact-shape task batching at sixteen tasks may still improve throughput,
+    but only if the eight-task rung stays fast, avoids OOM, and rarely falls back
+    to singleton dispatch.
+  anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing,
+    and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=16`.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
+    source: manifest
+    corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
+    train_row_cap: 512
+    test_row_cap: 256
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: linear_warmup_decay
+    task_batch_size: 16
+    overrides:
+      apply_schedule: true
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      runtime:
+        grad_accum_steps: 1
+        max_steps: 2500
+        target_train_seconds: null
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Leave blocked until the `task_batch_size=8` row finishes in `<=900s`, avoids OOM,
+    and keeps singleton fallback at `<=10%` of updates.
+  - If unblocked, compare against the eight-task rung first and stop the ladder if
+    runtime exceeds `1800s` or singleton fallback rises above `10%`.
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: blocked
+  confounders: []
+  next_action: Do not run this row in the current ladder; row 2 finished in `1109.3s`
+    and failed the `<=900s` promotion gate, so issues `#137`, `#138`, and `#139`
+    should continue from the kept `task_batch_size=4` surface instead.
+  notes:
+  - This row is intentionally blocked pending the row-2 gate.
+  - Row 2 completed in `1109.3s` with `0.0%` singleton fallback and no recorded
+    OOM mitigation, so the ladder stops before this rung.
+- order: 4
+  delta_ref: delta_training_task_batch32
+  parent_delta_ref: delta_training_task_batch16
+  status: blocked
+  rationale: Keep the highest manifest task-batch rung visible in the queue, but leave
+    it dormant unless the sixteen-task rung remains fast and mostly batched.
+  hypothesis: Exact-shape task batching at thirty-two tasks will only be useful if
+    the sixteen-task rung still avoids OOM and singleton fallback on the settled medium
+    corpus.
+  anchor_delta: Keep the settled `row_cls + qass + no tfcol` anchor, preprocessing,
+    and warmup-decay family fixed, but replace singleton manifest updates with `training.task_batch_size=32`.
+  model:
+    stage: qass_context
+    stage_label: delta_qass_no_column_v3
+    module_overrides:
+      column_encoder: none
+  data:
+    surface_label: tf_rd_013_dagzoo_shape_aware_size_medium
+    source: manifest
+    corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
+    train_row_cap: 512
+    test_row_cap: 256
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: linear_warmup_decay
+    task_batch_size: 32
+    overrides:
+      apply_schedule: true
+      optimizer:
+        name: schedulefree_adamw
+        require_requested: true
+        weight_decay: 0.0
+        betas:
+        - 0.9
+        - 0.999
+        min_lr: 0.0004
+        muon_per_parameter_lr: false
+      runtime:
+        grad_accum_steps: 1
+        max_steps: 2500
+        target_train_seconds: null
+        eval_every: 25
+        checkpoint_every: 25
+        trace_activations: false
+        val_batches: 0
+      schedule:
+        stages:
+        - name: stage1
+          steps: 2500
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.05
+  parameter_adequacy_plan:
+  - Leave blocked until the `task_batch_size=16` row finishes in `<=900s`, avoids
+    OOM, and keeps singleton fallback at `<=10%` of updates.
+  - If unblocked, compare against the sixteen-task rung first and stop the ladder
+    if runtime exceeds `1800s` or singleton fallback rises above `10%`.
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: blocked
+  confounders: []
+  next_action: Keep this rung blocked because the current ladder stopped when row
+    2 missed the row-3 promotion gate; only reopen larger task batches if later
+    runtime work changes the economics.
+  notes:
+  - This row is intentionally blocked pending the row-3 gate.
+  - Row 3 never unblocked because the eight-task rung already failed the runtime
+    promotion gate.

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -11365,6 +11365,384 @@
         "wall_elapsed_seconds": 279.7133572716266
       }
     },
+    "sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch4/sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.02472303874773174,
+          "best_training_time_delta": -6.931602919939905,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.15531107291991325,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 2.1868905579368514,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.012020828139464812,
+          "final_training_time_delta": 472.6831313674338,
+          "reference_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.02472303874773174,
+          "best_training_time_delta": -6.931602919939905,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.15531107291991325,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 2.1868905579368514,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.012020828139464812,
+          "final_training_time_delta": 472.6831313674338,
+          "reference_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged_corpus",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged_corpus",
+      "lineage": {
+        "anchor_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+      },
+      "manifest_path": "outputs/corpora/tf_rd_013_dagzoo_shape_aware_size_medium_v1/tf_rd_013_dagzoo_shape_aware_size_medium_v1__f635c43eaba1/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_qass_no_column_v3",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": true,
+            "ff_expansion": 2,
+            "n_heads": 4,
+            "n_layers": 3,
+            "name": "qass",
+            "norm_type": "layernorm",
+            "use_qass": true
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": 4,
+            "n_heads": 8,
+            "n_layers": 3,
+            "name": "row_cls",
+            "norm_type": "layernorm"
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "qass",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "row_cls",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "shifted_grouped"
+        },
+        "stage": "qass_context",
+        "stage_label": "delta_qass_no_column_v3",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 868706,
+        "trainable_params": 868706
+      },
+      "registered_at_utc": "2026-03-24T18:48:00Z",
+      "run_id": "sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_013_dagzoo_shape_aware_size_medium",
+        "model": "delta_qass_no_column_v3",
+        "preprocessing": "runtime_default",
+        "training": "linear_warmup_decay"
+      },
+      "sweep": {
+        "delta_id": "delta_training_task_batch4",
+        "parent_sweep_id": "tf_rd_013_dagzoo_size_ladder_v1",
+        "queue_order": 1,
+        "run_kind": "primary",
+        "sweep_id": "row_first_training_adequacy_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.37513787610088556,
+        "best_crps": null,
+        "best_log_loss": 0.5552691711984782,
+        "best_picp_90": null,
+        "best_roc_auc": 0.595822713367738,
+        "best_step": 125.0,
+        "best_training_time": 38.54288080101833,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.646497149322779,
+        "final_crps": null,
+        "final_log_loss": 4.447267230712592,
+        "final_picp_90": null,
+        "final_roc_auc": 0.5745704860521681,
+        "final_step": 2500.0,
+        "final_training_time": 699.3667461932637
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.0338197685778141,
+        "final_val_loss": null,
+        "max_grad_norm": 11.365192413330078,
+        "mean_grad_norm": 0.9659513855909114,
+        "post_warmup_train_loss_var": 0.055040517918309446,
+        "train_elapsed_seconds": 699.3667461932637,
+        "wall_elapsed_seconds": 708.9214782449417
+      }
+    },
+    "sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1": {
+      "artifacts": {
+        "benchmark_dir": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/row_first_training_adequacy_v1/delta_training_task_batch8/sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_binary_medium",
+        "source_path": "src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json",
+        "task_count": 10,
+        "task_ids": [
+          42,
+          3638,
+          3777,
+          9958,
+          10091,
+          10093,
+          146230,
+          363613,
+          363621,
+          363629
+        ],
+        "version": 1
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": 0.053532635274309404,
+          "best_training_time_delta": -20.22946519497782,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.12072468230888839,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 2.7761113696599784,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.011742408837009055,
+          "final_training_time_delta": 882.6329214121215,
+          "reference_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": 0.053532635274309404,
+          "best_training_time_delta": -20.22946519497782,
+          "final_avg_pinball_loss_delta": null,
+          "final_brier_score_delta": 0.12072468230888839,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 2.7761113696599784,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.011742408837009055,
+          "final_training_time_delta": 882.6329214121215,
+          "reference_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+        }
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_staged_corpus",
+      "decision": "defer",
+      "experiment": "cls_benchmark_staged_corpus",
+      "lineage": {
+        "anchor_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1",
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "parent_run_id": "sd_tf_rd_013_dagzoo_size_ladder_v1_03_delta_data_manifest_root_dagzoo_shape_aware_size_medium_v1"
+      },
+      "manifest_path": "outputs/corpora/tf_rd_013_dagzoo_shape_aware_size_medium_v1/tf_rd_013_dagzoo_shape_aware_size_medium_v1__f635c43eaba1/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_staged",
+        "benchmark_profile": "delta_qass_no_column_v3",
+        "d_icl": 96,
+        "head_hidden_dim": 192,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 2,
+        "module_hyperparameters": {
+          "column_encoder": {
+            "n_heads": null,
+            "n_inducing": null,
+            "n_layers": null,
+            "name": "none",
+            "norm_type": null
+          },
+          "context_encoder": {
+            "allow_test_self_attention": true,
+            "ff_expansion": 2,
+            "n_heads": 4,
+            "n_layers": 3,
+            "name": "qass",
+            "norm_type": "layernorm",
+            "use_qass": true
+          },
+          "post_encoder_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "post_stack_norm": {
+            "name": "none",
+            "norm_type": null
+          },
+          "row_pool": {
+            "cls_tokens": 4,
+            "n_heads": 8,
+            "n_layers": 3,
+            "name": "row_cls",
+            "norm_type": "layernorm"
+          },
+          "staged_dropout": 0.0,
+          "table_block": {
+            "allow_test_self_attention": true,
+            "mlp_hidden_dim": 192,
+            "n_heads": 4,
+            "norm_type": "layernorm",
+            "residual_branch_gain": 1.0,
+            "residual_scale": "none",
+            "style": "prenorm"
+          }
+        },
+        "module_selection": {
+          "allow_test_self_attention": true,
+          "column_encoder": "none",
+          "context_encoder": "qass",
+          "feature_encoder": "shared",
+          "head": "small_class",
+          "post_encoder_norm": "none",
+          "post_stack_norm": "none",
+          "row_pool": "row_cls",
+          "table_block_residual_scale": "none",
+          "table_block_style": "prenorm",
+          "target_conditioner": "label_token",
+          "tokenizer": "shifted_grouped"
+        },
+        "stage": "qass_context",
+        "stage_label": "delta_qass_no_column_v3",
+        "tficl_n_heads": 4,
+        "tficl_n_layers": 3
+      },
+      "model_size": {
+        "total_params": 868706,
+        "trainable_params": 868706
+      },
+      "registered_at_utc": "2026-03-24T19:09:11Z",
+      "run_id": "sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1",
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_013_dagzoo_shape_aware_size_medium",
+        "model": "delta_qass_no_column_v3",
+        "preprocessing": "runtime_default",
+        "training": "linear_warmup_decay"
+      },
+      "sweep": {
+        "delta_id": "delta_training_task_batch8",
+        "parent_sweep_id": "tf_rd_013_dagzoo_size_ladder_v1",
+        "queue_order": 2,
+        "run_kind": "primary",
+        "sweep_id": "row_first_training_adequacy_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_brier_score": 0.37726591278755156,
+        "best_crps": null,
+        "best_log_loss": 0.5590177645879071,
+        "best_picp_90": null,
+        "best_roc_auc": 0.6246323098943156,
+        "best_step": 50.0,
+        "best_training_time": 25.245018525980413,
+        "final_avg_pinball_loss": null,
+        "final_brier_score": 0.6119107587117542,
+        "final_crps": null,
+        "final_log_loss": 5.036488042435719,
+        "final_picp_90": null,
+        "final_roc_auc": 0.5508072490756942,
+        "final_step": 2500.0,
+        "final_training_time": 1109.3165362379514
+      },
+      "track": "system_delta_binary_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.004979324992746115,
+        "final_val_loss": null,
+        "max_grad_norm": 4.467634201049805,
+        "mean_grad_norm": 0.5056245589435566,
+        "post_warmup_train_loss_var": 0.031730049873623836,
+        "train_elapsed_seconds": 1109.3165362379514,
+        "wall_elapsed_seconds": 1118.1356538259424
+      }
+    },
     "sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1": {
       "artifacts": {
         "benchmark_dir": "outputs/staged_ladder/research/shared_surface_bridge_v1/delta_architecture_screen_nano_exact_replay/sd_shared_surface_bridge_v1_01_delta_architecture_screen_nano_exact_replay_v1/benchmark",

--- a/tests/research/test_row_first_training_adequacy_v1.py
+++ b/tests/research/test_row_first_training_adequacy_v1.py
@@ -80,8 +80,23 @@ def test_row_first_training_adequacy_v1_rebases_the_queue_on_task_batch_rungs() 
     rows = queue["rows"]
     assert isinstance(rows, list)
     assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
-    assert [row["status"] for row in rows] == ["ready", "ready", "blocked", "blocked"]
-    assert [row["interpretation_status"] for row in rows] == ["pending", "pending", "blocked", "blocked"]
+    assert [row["status"] for row in rows] == ["completed", "completed", "blocked", "blocked"]
+    assert [row["interpretation_status"] for row in rows] == ["completed", "completed", "blocked", "blocked"]
+    assert [row["decision"] for row in rows] == ["keep", "defer", None, None]
+
+    row1 = _row_by_ref(queue, "delta_training_task_batch4")
+    assert "#137" in row1["next_action"]
+    assert "#138" in row1["next_action"]
+    assert "#139" in row1["next_action"]
+    assert any("699.4s" in note for note in row1["notes"])
+
+    row2 = _row_by_ref(queue, "delta_training_task_batch8")
+    assert any("Reused the saved nanoTabPFN curve" in note for note in row2["notes"])
+    assert any("1109.3s" in note for note in row2["notes"])
+
+    row3 = _row_by_ref(queue, "delta_training_task_batch16")
+    assert "#137" in row3["next_action"]
+    assert any("1109.3s" in note for note in row3["notes"])
 
     for delta_ref, task_batch_size in (
         ("delta_training_task_batch4", 4),
@@ -170,7 +185,8 @@ def test_row_first_training_adequacy_v1_materialized_queue_preserves_task_batch_
 
     rows = queue["rows"]
     assert [row["delta_id"] for row in rows] == EXPECTED_ROWS
-    assert [row["status"] for row in rows] == ["ready", "ready", "blocked", "blocked"]
+    assert [row["status"] for row in rows] == ["completed", "completed", "blocked", "blocked"]
+    assert [row["decision"] for row in rows] == ["keep", "defer", None, None]
 
     for delta_id, task_batch_size in (
         ("delta_training_task_batch4", 4),
@@ -201,6 +217,10 @@ def test_row_first_training_adequacy_v1_matrix_records_the_task_batch_rebase() -
     assert "delta_training_task_batch8" in matrix
     assert "delta_training_task_batch16" in matrix
     assert "delta_training_task_batch32" in matrix
+    assert "sd_row_first_training_adequacy_v1_01_delta_training_task_batch4_v1" in matrix
+    assert "sd_row_first_training_adequacy_v1_02_delta_training_task_batch8_v1" in matrix
+    assert "#137" in matrix
+    assert "1109.3s" in matrix
     assert "tf_rd_013_dagzoo_shape_aware_size_medium_v1" in matrix
     assert "nanotabpfn_openml_binary_medium_v1.json" in matrix
     assert "delta_training_linear_decay" not in matrix


### PR DESCRIPTION
Closes #109.

Part of #107.

## Summary
- execute and record the TF-RD-018 task-batch ladder on `row_first_training_adequacy_v1`
- keep `task_batch_size=4` as the preferred rung; `task_batch_size=8` completed in `1109.3s` and blocks rows 3/4
- reuse the saved row-1 nanoTabPFN curve for row 2 and refresh the registry, queue, matrix, and evidence artifacts

## Testing
- `tab-foundry research sweep validate --sweep-id row_first_training_adequacy_v1`
- `pytest tests/research/test_row_first_training_adequacy_v1.py`
- `./scripts/dev verify paths reference/system_delta_sweeps/row_first_training_adequacy_v1 reference/system_delta_matrix.md reference/system_delta_queue.yaml`
