### PR TITLE
Split sweep inspect rendering from materialization and execution state

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -136,12 +136,12 @@ summarized later instead of occupying the active queue.
 | Rank | Roadmap ID | Item | Status | Milestone |
 | ---- | ---------- | ---- | ------ | --------- |
 | 1 | TF-RD-016 | Architecture surface adequacy, sandwich simplification, and selective expansion | planned | Next |
-| 2 | TF-RD-010 | First many-class + missingness dagzoo gate on the row-first base | planned | Next |
-| 3 | TF-RD-021 | Steering-derived dagzoo corpus fronts on the promoted anchor | planned | Next |
-| 4 | TF-RD-017 | Class-imbalance robustness on the promoted anchor | planned | Next |
+| 2 | TF-RD-010 | First many-class + missingness dagzoo gate on the classification-first sandwich target | planned | Next |
+| 3 | TF-RD-021 | Steering-derived dagzoo corpus fronts on the classification-first sandwich target | planned | Next |
+| 4 | TF-RD-017 | Class-imbalance robustness on the classification-first sandwich target | planned | Next |
 | 5 | TF-RD-022 | Training runtime and VRAM efficiency before classification scaling | planned | Next |
 | 6 | TF-RD-009 | Scaling-law design and measurement on the classification-first sandwich target | planned | Next |
-| 7 | TF-RD-014 | Missingness robustness on the promoted anchor | planned | Next |
+| 7 | TF-RD-014 | Missingness robustness on the classification-first sandwich target | planned | Next |
 | 8 | TF-RD-015 | Regression rebuild deferred from the classification-first scaling plan | research | Later |
 | 9 | TF-RD-012 | Inference handoff and later modalities | research | Later |
 
@@ -254,7 +254,14 @@ This roadmap assumes the following repo truths:
   and [reference/evidence.md](../../reference/evidence.md); the sections below
   focus on active sandwich development and later follow-up lanes.
 
-### TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Row-First Base
+Legacy wording note:
+
+- some TF-RD item titles still use earlier row-first or promoted-anchor
+  phrasing so existing roadmap links remain stable
+- the dependency order, current-state bullets, and required-work bullets below
+  are the authoritative description of the active sandwich-first path
+
+### TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
 
 - Status: `planned`
 - Milestone: `Next`
@@ -274,8 +281,9 @@ This roadmap assumes the following repo truths:
     simplified-parent phase of TF-RD-016 rather than as a later extension
 - Required work:
   - confirm one carried dagzoo-backed many-class plus missingness slice and the
-    promoted backbone that will read it
-  - keep the lane on the same promoted family rather than opening a separate
+    frozen sandwich parent that will read it
+  - keep the lane on the same carried sandwich family rather than opening a
+    separate
     architecture track
   - evaluate this first gate by multiclass log loss first, with runtime,
     stability, and calibration-oriented metrics as guardrails
@@ -283,7 +291,7 @@ This roadmap assumes the following repo truths:
     missingness slice before TF-RD-009 starts
 - Exit criteria:
   - the repo has one explicit carried dagzoo many-class plus missingness slice
-    on the promoted backbone
+    on the frozen sandwich parent
   - multiclass is no longer only untested scaffolding on the first scaling path
 
 ### TF-RD-012: Inference Handoff And Later Modalities
@@ -291,7 +299,7 @@ This roadmap assumes the following repo truths:
 - Status: `research`
 - Milestone: `Later`
 - Goal: advance separate-runtime handoff and genuinely later modalities only
-  after the promoted row-first classification base is stable
+  after the classification-first sandwich base is stable
 - Current state:
   - classification remains the only active supported prediction mode
   - runtime handoff and later modalities remain deferred
@@ -300,18 +308,19 @@ This roadmap assumes the following repo truths:
   - keep time series, text-conditioned inputs, and other later modalities out
     of the current path
 - Exit criteria:
-  - inference handoff and later modalities build on the promoted staged base
+  - inference handoff and later modalities build on the classification-first
+    sandwich base
     rather than running ahead of it
 
-### TF-RD-014: Missingness Robustness On The Promoted Anchor
+### TF-RD-014: Missingness Robustness On The Classification-First Sandwich Target
 
 - Status: `planned`
 - Milestone: `Next`
 - Goal: deepen missingness robustness after the first many-class plus
-  missingness gate is established on the promoted family
+  missingness gate is established on the carried sandwich family
 - Current state:
   - `missingness_followup` exists, but it is anchored on the older stabilized
-    prenorm hybrid surface rather than the row-first line
+    prenorm hybrid surface rather than the carried sandwich family
   - the repo already has separate no-missing and allow-missing benchmark bundle
     contracts
   - issue [#97](https://github.com/bensonlee5/tab-foundry/issues/97) remains
@@ -320,11 +329,10 @@ This roadmap assumes the following repo truths:
   - issue [#146](https://github.com/bensonlee5/tab-foundry/issues/146) now
     occupies the adjacent synthetic harder-dagzoo slot and does not replace
     this benchmark-front missingness lane
-  - there is no explicit row-first missingness-mechanism recommendation yet;
-    TF-RD-008 only settled the default row-first anchor on the allow-missing
-    benchmark surface
+  - there is no explicit carried-sandwich missingness recommendation yet; the
+    older TF-RD-008 row-first settlement remains historical context only
 - Required work:
-  - re-anchor missingness work on the promoted row-first base after the carried
+  - re-anchor missingness work on the carried sandwich family after the carried
     many-class plus missingness slice is established under TF-RD-010
   - keep one pinned OpenML missingness ladder as the canonical benchmark
     baseline and allow license-cleared manifest-backed external augmentations
@@ -336,17 +344,18 @@ This roadmap assumes the following repo truths:
     pass
   - focus this lane on deeper missingness mechanism, severity, and benchmark
     coverage rather than on establishing the first anti-saturation regime
-  - decide whether explicit missingness handling belongs in the default
-    promoted line or remains an optional robustness variant after TF-RD-010
+  - decide whether explicit missingness handling belongs in the default carried
+    sandwich family or remains an optional robustness variant after TF-RD-010
 - Exit criteria:
   - the repo has a benchmark-backed follow-on missingness recommendation for
-    the promoted family beyond the first many-class plus missingness gate
+    the carried sandwich family beyond the first many-class plus missingness
+    gate
 
-### TF-RD-017: Class-Imbalance Robustness On The Promoted Anchor
+### TF-RD-017: Class-Imbalance Robustness On The Classification-First Sandwich Target
 
 - Status: `planned`
 - Milestone: `Next`
-- Goal: decide how the promoted row-first family behaves under materially
+- Goal: decide how the carried sandwich family behaves under materially
   skewed class priors
 - Current state:
   - current benchmark bundles only enforce `min_minority_class_pct = 2.5`
@@ -360,7 +369,7 @@ This roadmap assumes the following repo truths:
     Brier score
 - Required work:
   - define the canonical imbalance-focused binary bundle or bundle-selection
-    ladder on the promoted row-first anchor
+    ladder on the carried sandwich family
   - keep one pinned OpenML imbalance ladder as the canonical benchmark
     baseline and allow license-cleared manifest-backed external augmentations
     when they add skew regimes OpenML does not cover cleanly
@@ -371,13 +380,13 @@ This roadmap assumes the following repo truths:
     pass
   - define benchmark-facing comparison and reporting that includes PR AUC,
     average precision, and balanced accuracy alongside ROC/log loss/Brier
-  - measure the promoted anchor first without class reweighting or focal-style
-    loss changes
+  - measure the carried sandwich family first without class reweighting or
+    focal-style loss changes
   - only if the baseline read is weak, run bounded weighted-loss or focal-loss
     follow-up work
 - Exit criteria:
   - the repo has a benchmark-backed keep/defer decision on the promoted
-    row-first line under class imbalance
+    sandwich family under class imbalance
   - the repo has an explicit imbalance metric and reporting contract rather
     than relying only on the current general binary bundle metrics
 
@@ -468,10 +477,10 @@ This roadmap assumes the following repo truths:
   - encode the winning runtime policy as a first-class config and sweep surface
     under issue [#170](https://github.com/bensonlee5/tab-foundry/issues/170)
     rather than relying on per-run overrides
-  - keep sandwich architecture work on
-    [#174](https://github.com/bensonlee5/tab-foundry/issues/174),
-    [#178](https://github.com/bensonlee5/tab-foundry/issues/178), and
-    [#179](https://github.com/bensonlee5/tab-foundry/issues/179) rather than
+  - keep sandwich architecture ownership under historical implementation issue
+    [#174](https://github.com/bensonlee5/tab-foundry/issues/174) and active
+    issues [#178](https://github.com/bensonlee5/tab-foundry/issues/178) and
+    [#184](https://github.com/bensonlee5/tab-foundry/issues/184) rather than
     reopening this runtime epic as the sandwich owner; MPS OOMs should not be
     part of the quantitative CUDA decision record
   - only after the runtime policy is explicit, reopen harder-surface batching
@@ -497,7 +506,7 @@ This roadmap assumes the following repo truths:
 - Milestone: `Completed`
 - Goal: once the first TF-RD-018 dataset-batch ladder is complete, turn harder
   dagzoo-generated corpus fronts into the next explicit synthetic harder-surface
-  decision lane on the promoted row-first anchor
+  decision lane on the historical staged-control line
 - Current state:
   - TF-RD-020 is now historical handoff material rather than an active lane.
   - It closed on one kept harder-front winner in each family, with
@@ -519,7 +528,7 @@ This roadmap assumes the following repo truths:
   - satisfied: the relationship to TF-RD-010, TF-RD-017, and TF-RD-021 is
     explicit and non-overlapping
 
-### TF-RD-021: Steering-Derived Dagzoo Corpus Fronts On The Promoted Anchor
+### TF-RD-021: Steering-Derived Dagzoo Corpus Fronts On The Classification-First Sandwich Target
 
 - Status: `planned`
 - Milestone: `Next`
@@ -611,7 +620,7 @@ This roadmap assumes the following repo truths:
   - Run the bounded simplification package under
     [#184](https://github.com/bensonlee5/tab-foundry/issues/184) on the locked
     compact control:
-    `sandwich_self_attention_per_cross=1`,
+    `sandwich_self_attention_per_cross=0`,
     `sandwich_ff_expansion=1`, both together, and both together plus
     `sandwich_summary_tokens_per_axis=1`.
   - Choose the smallest parent that stays inside the bounded final-log-loss,

--- a/docs/development/tabfoundry-sandwich.md
+++ b/docs/development/tabfoundry-sandwich.md
@@ -222,7 +222,7 @@ architecture.
 
 | Name | Default | What it controls | Notes |
 | ---- | ------- | ---------------- | ----- |
-| `model.arch` | global model default is `tabfoundry_staged` | Selects the model family. Set this to `tabfoundry_sandwich` to build the sandwich architecture. | Required to use this model. |
+| `model.arch` | global model default is `tabfoundry_sandwich` | Selects the model family. Set this to `tabfoundry_sandwich` to build the sandwich architecture. | Required to use this model. |
 | `d_icl` | `512` | Shared working width for cell tokens, summary tokens, latent blocks, and head input. | The current sandwich experiment presets override this to `60`. |
 | `input_normalization` | `none` | Shared train/test feature normalization mode before tokenization. | Accepted values are `none`, `train_zscore`, `train_zscore_clip`, `train_rankgauss`, `train_robust`, `train_winsorize_zscore`, `train_zscore_tanh`, and `train_robust_tanh`. Common sandwich presets use `train_zscore_clip`. |
 | `many_class_base` | `10` | Output width of the direct classifier head. | This also sets the small-class limit, so sandwich requires `2 <= num_classes <= many_class_base`. |

--- a/reference/README.md
+++ b/reference/README.md
@@ -48,17 +48,24 @@ cross-epic map.
 - [`roadmap_evidence/tf_rd_018_training_surface_adequacy.md`](roadmap_evidence/tf_rd_018_training_surface_adequacy.md):
   canonical TF-RD-018 batch-size, LR, optimizer, and training-surface note
 - [`roadmap_evidence/tf_rd_020_harder_dagzoo_corpus_fronts.md`](roadmap_evidence/tf_rd_020_harder_dagzoo_corpus_fronts.md):
-  canonical TF-RD-020 harder-front handoff note on the promoted anchor
+  canonical TF-RD-020 harder-front handoff note on the historical
+  staged-control line
 - [`roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md`](roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md):
-  canonical TF-RD-021 steering-derived synthetic follow-on note
+  canonical TF-RD-021 steering-derived synthetic follow-on note on the carried
+  sandwich dagzoo slice
 - [`roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md`](roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md):
-  canonical TF-RD-022 runtime-and-VRAM efficiency note on the promoted anchor
+  canonical TF-RD-022 runtime-and-VRAM efficiency note for the carried
+  sandwich classification family before scaling
 - [`roadmap_evidence/tf_rd_021a_latent_bank_sandwich_prototype.md`](roadmap_evidence/tf_rd_021a_latent_bank_sandwich_prototype.md):
   fixed-latent sandwich candidate note and closed immediate nanoTabPFN screen
 - [`roadmap_evidence/tf_rd_021b_hybrid_full_cell_sandwich_successor.md`](roadmap_evidence/tf_rd_021b_hybrid_full_cell_sandwich_successor.md):
-  hybrid full-cell sandwich successor note and locked-prior replay handoff
+  hybrid full-cell sandwich successor note and simplified-parent handoff
+- [`roadmap_evidence/tf_rd_010_many_class_promotion.md`](roadmap_evidence/tf_rd_010_many_class_promotion.md):
+  canonical TF-RD-010 carried-slice note for the first sandwich many-class plus
+  missingness gate
 - [`roadmap_evidence/tf_rd_009_scaling_law_measurement.md`](roadmap_evidence/tf_rd_009_scaling_law_measurement.md):
-  canonical TF-RD-009 scaling-specific note and TF-RD-018 handoff target
+  canonical TF-RD-009 scaling-specific note and classification-first sandwich
+  handoff target
 
 Keeping this material under one indexed home gives architecture and benchmark
 work a stable citation surface without mixing research notes into the

--- a/reference/evidence.md
+++ b/reference/evidence.md
@@ -30,7 +30,7 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
 - [`TF-RD-020`](roadmap_evidence/tf_rd_020_harder_dagzoo_corpus_fronts.md):
   harder dagzoo corpus-front evidence and v1 carry-forward decisions
 - [`TF-RD-021`](roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md):
-  steering-derived corpus-front evidence and conditional Muon retry framing
+  steering-derived corpus-front evidence and carried-slice handoff
 - [`TF-RD-021A`](roadmap_evidence/tf_rd_021a_latent_bank_sandwich_prototype.md):
   fixed-latent sandwich candidate note and closed immediate nanoTabPFN screen
 - [`TF-RD-021B`](roadmap_evidence/tf_rd_021b_hybrid_full_cell_sandwich_successor.md):
@@ -42,7 +42,8 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
 - [`TF-RD-016`](roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md):
   existing-surface adequacy and selective expansion evidence
 - [`TF-RD-010`](roadmap_evidence/tf_rd_010_many_class_promotion.md):
-  first many-class plus missingness dagzoo gate evidence on the row-first base
+  first many-class plus missingness dagzoo gate evidence on the
+  classification-first sandwich target
 - [`TF-RD-009`](roadmap_evidence/tf_rd_009_scaling_law_measurement.md):
   classification-first scaling-law design evidence and the runtime plus
   harder-surface handoff
@@ -79,13 +80,13 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
 | Islamov et al. (2603.21191) | Recent theory and experiments reinforce regime-dependent batch-size gains and diminishing returns under a fixed-budget lens | `TF-RD-018` | Next | medium |
 | SGDR (1608.03983) | Schedule work remains relevant, but should support the promoted architecture rather than substitute for it | `TF-RD-001`, `TF-RD-009` | Next | medium-high |
 | muP (2203.03466) | Hyperparameter transfer across model sizes matters once one coherent row-first anchor exists | `TF-RD-009` | Next | high |
-| Chinchilla (2203.15556) | Compute-optimal reasoning belongs on the promoted anchor, not on transient hybrid bridge surfaces | `TF-RD-009` | Next | high |
+| Chinchilla (2203.15556) | Compute-optimal reasoning belongs on the classification-first sandwich target, not on transient hybrid bridge surfaces | `TF-RD-009` | Next | high |
 | Kaplan et al. (2001.08361) | Scaling trends should be measured on one coherent family rather than across mixed architectural lines | `TF-RD-009` | Next | high |
 | Power Lines (2505.13738) | Small-scale scaling fits need explicit artifact paths and careful interpretation | `TF-RD-009` | Next | medium-high |
 | Broken Neural Scaling Laws (2210.14891) | Knees and plateaus must be treated as expected outcomes when the architecture target is still moving | `TF-RD-009` | Next | medium |
 | SAINT (2106.01342) | Row/column interaction changes should be benchmarked as explicit structural choices rather than imported as defaults | `TF-RD-005`, `TF-RD-006` | Next | medium |
 | Perceiver (2103.03206) | Latent bottlenecks remain a later alternative if row/column token count becomes the limiting factor | `TF-RD-006`, `TF-RD-012` | Later | medium |
-| EquiTabPFN (2502.06684) | Label-conditioning choices should stay modular so target handling can evolve after the row-first base stabilizes | `TF-RD-010`, `TF-RD-012` | Next | medium |
+| EquiTabPFN (2502.06684) | Label-conditioning choices should stay modular so target handling can evolve after the classification-first sandwich family stabilizes | `TF-RD-010`, `TF-RD-012` | Next | medium |
 | TabDPT (2410.18164) | Prior/source changes are a later scaling lever and should not displace the core architecture migration prematurely | `TF-RD-011`, `TF-RD-012` | Later | medium |
 | Sentence-BERT (D19-1410) | Text-conditioned columns should remain an external-embedding later lane rather than a distraction from the classification-first backbone plan | `TF-RD-012` | Later | high |
 | nanochat (repo) | Compact-transformer training and residual-layout ideas are valid donors, but only when they preserve the tabular set-structured goal | `TF-RD-002`, `TF-RD-007`, `TF-RD-009` | Now | high |
@@ -260,12 +261,14 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
   - the existing TabPFN-v2 analysis note implies that meta-feature sensitivity
     should be tested structurally rather than inferred from one frozen surface
 - Repo-local evidence:
-  - TF-RD-020 kept `tf_rd_020_shift_noise_drift_v1` as the current synthetic
-    harder-surface control under `#146/#149`
-  - TF-RD-018 issue `#137` deferred Muon on that inherited control rather than
-    keeping it as an optimizer fallback
+  - TF-RD-020 closed as historical staged-control harder-front context under
+    `#146/#149`; it is no longer the active carried classification slice
+  - TF-RD-010 now owns the first carried sandwich dagzoo many-class plus
+    missingness slice that steering will attempt to improve
   - dagzoo issue `bensonlee5/dagzoo#246` now defines the upstream steering
     implementation, metadata, and diagnostics lane
+  - tab-foundry issues `#165` and `#167` now own the local steering-derived
+    continuation and first sweep contract
   - the canonical long-form note now lives in
     `reference/roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md`
 - Success signal:
@@ -285,10 +288,10 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
     runtime lane an explicit roadmap home
   - the canonical long-form note now lives in
     `reference/roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md`
-  - sandwich architecture work now lives under implementation issue `#174`,
-    umbrella issue `#178`, and immediate nanoTabPFN screen issue `#179`; this
-    runtime lane is now a dependency surface for later sandwich hard-surface
-    reads rather than the owner of that architecture line
+  - sandwich architecture ownership now lives under the historical
+    implementation record `#174`, active umbrella `#178`, and current
+    simplification follow-up `#184`; this runtime lane is a dependency surface
+    for later classification work rather than the owner of sandwich planning
   - training telemetry and benchmark-registry artifacts now preserve runtime
     summaries and regime-budget metadata needed for later runtime-policy and
     scaling comparisons
@@ -370,7 +373,7 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
     under one harder dagzoo slice, one inherited runtime policy, and one
     matched regime-budget contract
 
-### TF-RD-010: Many-Class Promotion On The Row-First Base
+### TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
 
 - External evidence:
   - label-conditioning work such as EquiTabPFN matters more after the backbone
@@ -380,7 +383,7 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
   - many-class should inherit the frozen sandwich dagzoo backbone rather than
     become its own architecture lane
 - Success signal:
-  - many-class is evaluated as an extension of the promoted anchor
+  - many-class is evaluated as an extension of the frozen sandwich parent
 
 ### TF-RD-011: Repo-Wide Enablers And Contract Fidelity
 
@@ -395,17 +398,19 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
   - the architecture program can rely on data and contract surfaces that are
     trustworthy enough for promotion decisions
 
-### TF-RD-012: Regression, Inference Handoff, And Later Modalities
+### TF-RD-012: Inference Handoff And Later Modalities
 
 - External evidence:
   - text-conditioning references and later modality papers belong to a later
     lane once the classification anchor is stable
 - Repo-local evidence:
   - regression is intentionally removed today
-  - runtime handoff remains partial and should follow the promoted staged base
+  - runtime handoff remains partial and should follow the classification-first
+    sandwich base
 - Success signal:
-  - later prediction modes and downstream handoff build on the promoted
-    row-first base instead of competing with the main architecture program
+  - later prediction modes and downstream handoff build on the
+    classification-first sandwich base instead of competing with the main
+    architecture program
 
 ## Evidence Limits And Assumptions
 

--- a/reference/papers.md
+++ b/reference/papers.md
@@ -138,15 +138,15 @@ Default filter for this section:
 |----------|-------|-------------------------------|--------|
 | 2203.15556 | Training Compute-Optimal Large Language Models (Chinchilla) | Core reference for the repo's primary goal of scaling predictability. Defines the methodology for fitting compute-optimal curves across model sizes. | https://arxiv.org/abs/2203.15556 |
 | 2001.08361 | Scaling Laws for Neural Language Models | Foundational scaling law methodology; establishes the power-law relationships between compute, data, and model size that this repo aims to replicate for tabular models. | https://arxiv.org/abs/2001.08361 |
-| 2203.03466 | Tensor Programs V: Tuning Large Neural Networks via Zero-Shot Hyperparameter Transfer (muP) | Width-independent hyperparameter transfer across model sizes. Directly relevant to scaling-law measurement on the promoted anchor (`TF-RD-009`). | https://arxiv.org/abs/2203.03466 |
-| 1608.03983 | SGDR: Stochastic Gradient Descent with Warm Restarts | Cosine annealing with warm restarts; relevant to training-recipe work that supports the promoted anchor rather than replacing architecture migration (`TF-RD-009`). | https://arxiv.org/abs/1608.03983 |
+| 2203.03466 | Tensor Programs V: Tuning Large Neural Networks via Zero-Shot Hyperparameter Transfer (muP) | Width-independent hyperparameter transfer across model sizes. Directly relevant to scaling-law measurement on the classification-first sandwich target (`TF-RD-009`). | https://arxiv.org/abs/2203.03466 |
+| 1608.03983 | SGDR: Stochastic Gradient Descent with Warm Restarts | Cosine annealing with warm restarts; relevant to training-recipe work that supports the classification-first sandwich target rather than replacing architecture migration (`TF-RD-009`). | https://arxiv.org/abs/1608.03983 |
 | 2412.19437 | DeepSeek-V3 Technical Report | Multi-token prediction and modern training recipe details for compact transformers. Informs architecture choices for cross-feature dependency modeling. | https://arxiv.org/abs/2412.19437 |
 
 ## Training-Surface Adequacy And Batch/LR Scaling
 
 These references anchor the TF-RD-018 literature note and the later handoff
-from training-surface adequacy into scaling work on the promoted row-first
-anchor.
+from historical training-surface adequacy into scaling work on the
+classification-first sandwich target.
 
 | arXiv ID | Title | Why it matters for tab-foundry | Source |
 |----------|-------|-------------------------------|--------|
@@ -179,7 +179,7 @@ Adjacent repo references that inform architecture and training decisions. Detail
 |------|------|---------------|
 | nanoTabPFN | https://github.com/automl/nanoTabPFN | Benchmark comparison target; training recipe choices and model sizing decisions provide direct baseline for tab-foundry. |
 | nanochat | https://github.com/karpathy/nanochat | Optimizer, LR schedule, model sizing, and clean training loop patterns. Reference for compact transformer training infrastructure. |
-| Muon optimizer | https://github.com/KellerJordan/Muon | Modern optimizer treating weights as orthogonal matrices. Relevant to later training-recipe work on the promoted anchor (`TF-RD-009`). |
+| Muon optimizer | https://github.com/KellerJordan/Muon | Modern optimizer treating weights as orthogonal matrices. Relevant to later training-recipe work on the classification-first sandwich target (`TF-RD-009`). |
 
 ## External Baseline Borrowing Rules
 
@@ -214,7 +214,7 @@ Success signal:
 ### nanochat
 
 - **URL:** https://github.com/karpathy/nanochat
-- **Roadmap relevance:** TF-RD-002 (measurement surfaces), TF-RD-007 (QASS attribution), TF-RD-009 (training and scaling work on the promoted anchor)
+- **Roadmap relevance:** TF-RD-002 (measurement surfaces), TF-RD-007 (QASS attribution), TF-RD-009 (training and scaling work on the classification-first sandwich target)
 
 What it does well:
 
@@ -272,7 +272,7 @@ Success signal:
 ### Muon Optimizer
 
 - **URL:** https://github.com/KellerJordan/Muon
-- **Roadmap relevance:** TF-RD-009 (training work on the promoted anchor)
+- **Roadmap relevance:** TF-RD-009 (training work on the classification-first sandwich target)
 
 What it does well:
 

--- a/reference/roadmap_evidence/README.md
+++ b/reference/roadmap_evidence/README.md
@@ -42,3 +42,6 @@ Notes:
 - Earlier implemented and completed roadmap items remain summarized in
   [reference/evidence.md](../evidence.md); this directory starts at the current
   epic and continues forward.
+- Some note titles still mirror legacy roadmap labels for stable cross-links;
+  the dependency text inside each note is authoritative about the carried
+  sandwich family and the current sandwich-first queue.

--- a/reference/roadmap_evidence/tf_rd_010_many_class_promotion.md
+++ b/reference/roadmap_evidence/tf_rd_010_many_class_promotion.md
@@ -1,4 +1,4 @@
-# TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Row-First Base
+# TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
 
 This is the canonical long-form evidence note for
 [TF-RD-010](../../docs/development/roadmap.md).
@@ -37,7 +37,8 @@ This is the canonical long-form evidence note for
 
 ## Current Interpretation
 
-- keep this lane on the promoted classification family rather than opening a
+- keep this lane on the classification-first sandwich family rather than
+  opening a
   separate multiclass model track
 - use one dagzoo-backed many-class plus missingness slice as the first carried
   harder classification regime
@@ -56,7 +57,7 @@ This is the canonical long-form evidence note for
 ## Exit Signals
 
 - the repo has one explicit carried dagzoo many-class plus missingness slice on
-  the promoted backbone
+  the frozen sandwich parent
 - multiclass is no longer only untested scaffolding on the first scaling path
 - TF-RD-009 can inherit a fixed anti-saturation classification target instead
   of reopening regime selection

--- a/reference/roadmap_evidence/tf_rd_012_inference_handoff_and_later_modalities.md
+++ b/reference/roadmap_evidence/tf_rd_012_inference_handoff_and_later_modalities.md
@@ -6,9 +6,13 @@ This is the canonical long-form evidence note for
 - Status: `research`
 - Milestone: `Later`
 - Dependency position: follows
-  [TF-RD-016](tf_rd_016_architecture_surface_adequacy.md) and the earlier
-  post-008 training-surface gates, and stays behind the classification-first
-  roadmap
+  [TF-RD-016](tf_rd_016_architecture_surface_adequacy.md) plus the later
+  classification-first gates under
+  [TF-RD-010](tf_rd_010_many_class_promotion.md),
+  [TF-RD-021](tf_rd_021_steering_derived_dagzoo_corpus_fronts.md),
+  [TF-RD-022](tf_rd_022_training_runtime_vram_efficiency.md), and
+  [TF-RD-009](tf_rd_009_scaling_law_measurement.md), and stays behind the
+  classification-first roadmap
 
 ## External Evidence
 
@@ -25,16 +29,17 @@ This is the canonical long-form evidence note for
 
 - classification remains the only active supported prediction mode
 - runtime handoff and later modalities remain deferred
-- the roadmap requires TF-RD-013, TF-RD-018, at least one harder post-008
-  ladder, and TF-RD-016 before runtime feedback should become a clean
-  architecture constraint
+- the roadmap now requires a frozen simplified sandwich parent plus the first
+  carried dagzoo, steering, runtime-policy, and scaling-law decisions before
+  runtime feedback should become a clean architecture constraint
 
 ## Current Interpretation
 
 - advance separate-runtime handoff only after classification and export
   contracts settle
 - keep time series, text-conditioned inputs, and other later modalities off the
-  critical path while the promoted classification base is still stabilizing
+  critical path while the classification-first sandwich base is still
+  stabilizing
 - treat runtime feedback as a later constraint on a settled classification base,
   not as an early driver of architecture shape
 
@@ -47,7 +52,8 @@ This is the canonical long-form evidence note for
 
 ## Exit Signals
 
-- inference handoff and later modalities build on the promoted staged base
+- inference handoff and later modalities build on the classification-first
+  sandwich base
   rather than running ahead of it
 - runtime or modality expansion decisions are made only after the classification
   base is stable enough to interpret cost tradeoffs cleanly

--- a/reference/roadmap_evidence/tf_rd_014_missingness_robustness.md
+++ b/reference/roadmap_evidence/tf_rd_014_missingness_robustness.md
@@ -1,4 +1,4 @@
-# TF-RD-014: Missingness Robustness On The Promoted Anchor
+# TF-RD-014: Missingness Robustness On The Classification-First Sandwich Target
 
 This is the canonical long-form evidence note for
 [TF-RD-014](../../docs/development/roadmap.md#tf-rd-014-missingness-robustness-on-the-promoted-anchor).
@@ -24,7 +24,7 @@ This is the canonical long-form evidence note for
 ## Repo-Local Evidence
 
 - `missingness_followup` already exists, but it is anchored on the older
-  stabilized prenorm hybrid surface rather than the promoted row-first base
+  stabilized prenorm hybrid surface rather than the carried sandwich family
 - the repo already maintains separate no-missing and allow-missing benchmark
   bundle contracts
 - TF-RD-008 settled the row-first default on the allow-missing benchmark
@@ -34,7 +34,7 @@ This is the canonical long-form evidence note for
 
 ## Current Interpretation
 
-- re-anchor missingness work on the promoted row-first base rather than
+- re-anchor missingness work on the carried sandwich family rather than
   reopening hybrid diagnostic lines
 - treat this as deeper missingness robustness after the first carried
   many-class plus missingness slice is established
@@ -47,7 +47,7 @@ This is the canonical long-form evidence note for
 ## Open Evidence Gaps
 
 - the repo still lacks a benchmark-backed missingness recommendation for the
-  promoted family beyond the first many-class plus missingness gate
+  carried sandwich family beyond the first many-class plus missingness gate
 - there is no curated missingness-specific literature set yet
 - review-ledger coverage for any future external missingness augmentations is
   still prospective rather than settled
@@ -55,6 +55,6 @@ This is the canonical long-form evidence note for
 ## Exit Signals
 
 - the repo has a benchmark-backed follow-on missingness recommendation for the
-  promoted row-first family after TF-RD-010
+  carried sandwich family after TF-RD-010
 - regime identity remains explicit in task-source, bundle, manifest, and
   curation artifacts instead of being hidden inside benchmark schema changes

--- a/reference/roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md
+++ b/reference/roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md
@@ -29,9 +29,9 @@ This is the canonical long-form evidence note for
 
 ## Repo-Local Evidence
 
-- the staged surface already exposes tokenization choice, `feature_group_size`,
-  norm family and placement, widths, depths, row CLS count, TFCol inducing
-  count, context FF expansion, dropout, and clipping
+- the current public architecture surface already exposes tokenization choice,
+  `feature_group_size`, norm family and placement, widths, depths, row CLS
+  count, TFCol inducing count, context FF expansion, dropout, and clipping
 - TF-RD-021B now makes sandwich-parent simplification the first explicit
   architecture task before broader harder-surface adequacy work
 - TF-RD-010 is now the first carried harder regime after that simplification:
@@ -57,8 +57,8 @@ This is the canonical long-form evidence note for
 
 ## Open Evidence Gaps
 
-- there is no explicit keep or defer decision yet on whether the current staged
-  surface is sufficient on harder post-008 regimes
+- there is no explicit keep or defer decision yet on whether the current
+  sandwich surface is sufficient on harder post-008 regimes
 - the repo has not yet shown whether the remaining hardcoded choices are
   decision-relevant enough to expose
 - the knob-specific literature set is intentionally deferred until Phase 1 says
@@ -66,7 +66,7 @@ This is the canonical long-form evidence note for
 
 ## Exit Signals
 
-- the repo has an explicit keep or defer decision on whether the current staged
-  architecture surface is sufficient on harder post-008 regimes
+- the repo has an explicit keep or defer decision on whether the current
+  sandwich architecture surface is sufficient on harder post-008 regimes
 - any newly exposed architecture knobs are bounded, justified, and tied to one
-  coherent staged comparison surface
+  coherent sandwich comparison surface

--- a/reference/roadmap_evidence/tf_rd_017_class_imbalance_robustness.md
+++ b/reference/roadmap_evidence/tf_rd_017_class_imbalance_robustness.md
@@ -1,4 +1,4 @@
-# TF-RD-017: Class-Imbalance Robustness On The Promoted Anchor
+# TF-RD-017: Class-Imbalance Robustness On The Classification-First Sandwich Target
 
 This is the canonical long-form evidence note for
 [TF-RD-017](../../docs/development/roadmap.md#tf-rd-017-class-imbalance-robustness-on-the-promoted-anchor).
@@ -35,17 +35,17 @@ This is the canonical long-form evidence note for
 
 ## Current Interpretation
 
-- define the canonical imbalance-focused binary ladder on the promoted row-first
-  anchor before changing losses
-- measure the promoted anchor first without class reweighting or focal-style
-  loss changes
+- define the canonical imbalance-focused binary ladder on the carried sandwich
+  family before changing losses
+- measure the carried sandwich family first without class reweighting or
+  focal-style loss changes
 - only if the baseline read is weak should weighted-loss or focal-loss follow-up
   work become decision-relevant
 
 ## Open Evidence Gaps
 
-- there is no benchmark-backed keep or defer decision on the promoted row-first
-  line under materially skewed priors
+- there is no benchmark-backed keep or defer decision on the carried sandwich
+  family under materially skewed priors
 - the imbalance-specific literature set still needs to be curated
 - the canonical imbalance reporting contract does not yet exist in benchmark
   outputs
@@ -53,6 +53,6 @@ This is the canonical long-form evidence note for
 ## Exit Signals
 
 - the repo has a benchmark-backed keep or defer decision on the promoted
-  row-first line under class imbalance
+  sandwich family under class imbalance
 - benchmark-facing outputs include explicit imbalance metrics rather than
   relying only on the current general binary bundle surface

--- a/reference/roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md
+++ b/reference/roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md
@@ -1,4 +1,4 @@
-# TF-RD-021: Steering-Derived Dagzoo Corpus Fronts On The Promoted Anchor
+# TF-RD-021: Steering-Derived Dagzoo Corpus Fronts On The Classification-First Sandwich Target
 
 This is the canonical long-form evidence note for
 [TF-RD-021](../../docs/development/roadmap.md#tf-rd-021-steering-derived-dagzoo-corpus-fronts-on-the-promoted-anchor).
@@ -64,11 +64,11 @@ This is the canonical long-form evidence note for
   tab-foundry
 - The repo still needs a practical stop rule for how much steering movement and
   metric gain counts as a genuinely new carry-forward surface rather than a
-  noisy variant of TF-RD-020 row `06`
+  noisy variant of the incumbent carried control slice
 
 ## Exit Signals
 
 - The repo has one explicit keep/defer decision on whether any steering-derived
-  corpus front replaces `tf_rd_020_shift_noise_drift_v1`
+  corpus front replaces the incumbent carried sandwich control slice
 - TF-RD-022 can inherit a documented synthetic carry-forward decision without
   reopening TF-RD-010 or blurring the completed TF-RD-020 ladder

--- a/reference/roadmap_evidence/tf_rd_021b_hybrid_full_cell_sandwich_successor.md
+++ b/reference/roadmap_evidence/tf_rd_021b_hybrid_full_cell_sandwich_successor.md
@@ -42,6 +42,10 @@ architecture-adequacy workstream.
 - child issue [#184](https://github.com/bensonlee5/tab-foundry/issues/184)
   now owns the post-screen simplified-parent and classification-scaling-prep
   follow-up
+- the queued TF-RD-021B removal-first follow-up is
+  `tf_rd_021b_sandwich_feature_removal_v1`, which recasts the earlier
+  self-attention shrink idea as full removal and keeps the follow-up package
+  bounded
 - `tabfoundry_sandwich` now uses:
   - one fixed learned latent bank
   - a stage-`0` hybrid input stream of `full cells + row summaries + column summaries`
@@ -71,8 +75,9 @@ architecture-adequacy workstream.
   sandwich alive as the primary classification architecture target
 - the completed bounded sensitivity screens argue for simplification first, not
   for keeping many free architecture knobs alive during scaling
-- the next bounded read is therefore a simplification package centered on:
-  - `sandwich_self_attention_per_cross=1`
+- the next bounded read is therefore a removal-first simplification package
+  centered on:
+  - `sandwich_self_attention_per_cross=0`
   - `sandwich_ff_expansion=1`
   - the combined row
   - the combined row plus `sandwich_summary_tokens_per_axis=1`

--- a/reference/roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md
+++ b/reference/roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md
@@ -32,11 +32,13 @@ This is the canonical long-form evidence note for
   [#169](https://github.com/bensonlee5/tab-foundry/issues/169),
   [#170](https://github.com/bensonlee5/tab-foundry/issues/170), and
   [#171](https://github.com/bensonlee5/tab-foundry/issues/171)
-- sandwich architecture work still lives under implementation issue
-  [#174](https://github.com/bensonlee5/tab-foundry/issues/174) and umbrella
-  issue [#178](https://github.com/bensonlee5/tab-foundry/issues/178); TF-RD-022
-  is a dependency surface for later classification work, not the owner of
-  sandwich planning
+- sandwich architecture ownership now lives under the historical
+  implementation record [#174](https://github.com/bensonlee5/tab-foundry/issues/174),
+  umbrella issue [#178](https://github.com/bensonlee5/tab-foundry/issues/178),
+  and active simplification follow-up
+  [#184](https://github.com/bensonlee5/tab-foundry/issues/184); TF-RD-022 is a
+  dependency surface for later classification work, not the owner of sandwich
+  planning
 - training telemetry and benchmark-registry records now preserve:
   - `peak_vram_allocated`
   - `peak_vram_reserved`
@@ -52,8 +54,8 @@ This is the canonical long-form evidence note for
   - `scm_complexity_summary`
 - canonical benchmark prior configs still inherit `runtime.mixed_precision: "no"` from `configs/experiment/_shared/compact_binary_prior.yaml` unless a
   higher-level experiment overrides it
-- `tabfoundry_staged` already supports `runtime.activation_checkpointing`, and
-  benchmark-facing exact-prior runs still default to
+- the shared runtime surface already supports `runtime.activation_checkpointing`,
+  and benchmark-facing exact-prior runs still default to
   `runtime.trace_activations: true`
 
 ## Current Interpretation


### PR DESCRIPTION
## Summary
- refactor sweep inspection into separate rendering, queue, target, artifact, and execution-state modules
- update research sweep inspect and diff flows to use the new split inspection pipeline
- adjust prior training/config plumbing and sweep validation/materialization paths to match the new inspection surface
- bump package metadata and document the change in `CHANGELOG.md`

## Testing
- `tests/cli/test_research_inspect.py`
- `tests/research/test_sweep_inspect.py`
- `tests/training/test_prior_settings.py`