### PR TITLE
[codex] Advance TF-RD-010 benchmark evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-03-29
+
+### Changed
+
+- User-facing note: `tabfoundry_sandwich` now supports the TF-RD-010 evolved
+  multiclass benchmark surface with a direct multiclass head, FiLM feature-type
+  conditioning, `many_class_base=10`, and
+  `sandwich_summary_tokens_per_axis=3`.
+- User-facing note: added the draft TF-RD-010 medium and large multiclass
+  benchmark packages, which keep `dagzoo` as the synthetic training owner and
+  `tab-realdata-hub` as the validation-bundle and manifest owner.
+
 ## [0.15.1] - 2026-03-29
 
 ### Changed

--- a/configs/experiment/cls_benchmark_sandwich_classification_evolution_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_classification_evolution_v1.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+
+defaults:
+  - _shared/compact_binary_prior
+  - _self_
+
+model:
+  arch: tabfoundry_sandwich
+  d_icl: 60
+  input_normalization: train_zscore_clip
+  many_class_base: 10
+  head_hidden_dim: 96
+  sandwich_latents: 24
+  sandwich_layers: 2
+  sandwich_heads: 4
+  sandwich_ff_expansion: 2
+  sandwich_summary_tokens_per_axis: 3
+  sandwich_self_attention_per_cross: 4
+  sandwich_pre_row_attention_layers: 1
+  sandwich_pre_column_attention_layers: 1
+  sandwich_pre_column_inducing_tokens: 16
+  feature_type_conditioning: film
+  floating_likelihood: single_gaussian
+  integer_likelihood: hybrid_mixture
+training:
+  loss_surface: cell_bpc
+runtime:
+  output_dir: outputs/cls_benchmark_sandwich_classification_evolution_v1
+  trace_activations: false
+logging:
+  run_name: cls-benchmark-sandwich-classification-evolution-v1

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -85,33 +85,32 @@ Important non-goals for this roadmap:
   tested on harder post-008 regimes.
 - The next useful architecture evidence should come from coherent sandwich
   surfaces, not from extending the older staged line.
-- After sandwich-parent simplification, the next deliberate front should make
-  the research surface less saturating and more realistic: a dagzoo-backed
-  many-class plus missingness regime on the frozen sandwich parent, followed by
-  steering-derived corpus fronts, then bounded runtime/kernel tuning, then
-  scaling.
+- After TF-RD-016 closeout, the next deliberate front should make the research
+  surface less saturating and more realistic: a benchmark-defined multiclass
+  regime where `dagzoo` owns synthetic training fronts, `tab-realdata-hub`
+  owns medium and large validation manifests, and `tab-foundry` owns the
+  evolved sandwich model and sweep contracts.
 - If those harder or broader surfaces still leave the model hard to separate or
   obviously underfit, open a later architecture-surface adequacy pass before
   relying on scaling-law work as the main next source of evidence.
 - Class imbalance is still not sufficiently tested on the current benchmark
-  surfaces because the bundles only enforce `min_minority_class_pct = 2.5`
-  rather than defining an explicit skew ladder.
+  surfaces because the bundles still only enforce
+  `min_minority_class_pct = 2.5` rather than defining an explicit skew ladder.
 - Harder real-data ladders should keep one canonical OpenML baseline where the
-  benchmark tooling is already native, allow manifest-backed external
-  real-data augmentations when they add regimes OpenML does not cover cleanly,
-  and require completed review records before those datasets enter curated
-  bundles or manifests; `dagzoo` remains the synthetic-data lane under
-  TF-RD-013 rather than an external real-data source.
+  benchmark tooling is already native, but the validation-bundle source of
+  truth now lives in `tab-realdata-hub` rather than in local `tab-foundry`
+  fixtures. `dagzoo` remains the synthetic-data lane under TF-RD-013 rather
+  than an external real-data source.
 - The deliberate post-008 execution order is now:
-  TF-RD-021B under TF-RD-016 ablates and freezes one simplified sandwich
-  parent; that frozen parent is then carried onto dagzoo; TF-RD-010 uses that
-  dagzoo-backed sandwich family on the first many-class plus missingness slice
-  so the first scaling target does not saturate too early on binary data;
-  TF-RD-017 class-imbalance work proceeds as a side robustness lane on the same
-  family; TF-RD-021 then tests whether steering-derived dagzoo corpus fronts
-  improve that carried slice; TF-RD-022 performs the kernel, runtime, and VRAM
-  tuning needed for reliable scaling on the kept front; TF-RD-009 then fits the
-  first scaling law on that carried multiclass slice.
+  TF-RD-016 closes on the modest sandwich evolution and benchmark-definition
+  handoff; TF-RD-010 then freezes the first medium and large multiclass
+  validation program, with `dagzoo` synthetic training fronts feeding
+  `tab-realdata-hub` materialized manifests; TF-RD-017 class-imbalance work
+  proceeds as a side robustness lane on the same family; TF-RD-021 then tests
+  whether steering-derived dagzoo corpus fronts improve that benchmark-defined
+  slice; TF-RD-022 performs the kernel, runtime, and VRAM tuning needed for
+  reliable scaling on the kept front; TF-RD-009 then fits the first scaling law
+  on that carried multiclass slice.
 - Low-level questions such as norm family or placement, learned special-token
   initialization scale, QASS scaler capacity, and activation family belong
   under TF-RD-016 after the earlier adequacy and harder-surface gates are in
@@ -133,15 +132,14 @@ summarized later instead of occupying the active queue.
 
 | Rank | Roadmap ID | Item | Status | Milestone |
 | ---- | ---------- | ---- | ------ | --------- |
-| 1 | TF-RD-016 | Architecture surface adequacy, sandwich simplification, and selective expansion | planned | Next |
-| 2 | TF-RD-010 | First many-class + missingness dagzoo gate on the classification-first sandwich target | planned | Next |
-| 3 | TF-RD-021 | Steering-derived dagzoo corpus fronts on the classification-first sandwich target | planned | Next |
-| 4 | TF-RD-017 | Class-imbalance robustness on the classification-first sandwich target | planned | Next |
-| 5 | TF-RD-022 | Training runtime and VRAM efficiency before classification scaling | planned | Next |
-| 6 | TF-RD-009 | Scaling-law design and measurement on the classification-first sandwich target | planned | Next |
-| 7 | TF-RD-014 | Missingness robustness on the classification-first sandwich target | planned | Next |
-| 8 | TF-RD-015 | Regression rebuild deferred from the classification-first scaling plan | research | Later |
-| 9 | TF-RD-012 | Inference handoff and later modalities | research | Later |
+| 1 | TF-RD-010 | Benchmark-defined multiclass evolution on the classification-first sandwich target | planned | Next |
+| 2 | TF-RD-021 | Steering-derived dagzoo corpus fronts on the classification-first sandwich target | planned | Next |
+| 3 | TF-RD-017 | Class-imbalance robustness on the classification-first sandwich target | planned | Next |
+| 4 | TF-RD-022 | Training runtime and VRAM efficiency before classification scaling | planned | Next |
+| 5 | TF-RD-009 | Scaling-law design and measurement on the classification-first sandwich target | planned | Next |
+| 6 | TF-RD-014 | Missingness robustness on the classification-first sandwich target | planned | Next |
+| 7 | TF-RD-015 | Regression rebuild deferred from the classification-first scaling plan | research | Later |
+| 8 | TF-RD-012 | Inference handoff and later modalities | research | Later |
 
 ## Dependency Graph
 
@@ -181,17 +179,22 @@ flowchart TD
     class RD012,RD015 later;
 ```
 
-Current path: **TF-RD-016 / TF-RD-021B → sandwich-on-dagzoo carry-forward → TF-RD-010 → TF-RD-021 → TF-RD-022 → TF-RD-009**.
+Current path: **TF-RD-016 closeout → TF-RD-010 benchmark evolution → TF-RD-021 → TF-RD-022 → TF-RD-009**.
 
-- TF-RD-016, through TF-RD-021B, is the first active gate: finish the bounded
-  sandwich ablation package and freeze one simplified parent.
-- Then switch that frozen sandwich parent onto dagzoo as the carried synthetic
-  classification family rather than continuing to tune the staged-control lane.
-- TF-RD-010 then evaluates the first dagzoo-backed many-class plus missingness
-  classification slice on that frozen sandwich parent, with multiclass log
-  loss as the primary objective.
+- TF-RD-016 is now completed historical context: issue
+  [#178](https://github.com/bensonlee5/tab-foundry/issues/178) closes on the
+  decision to evaluate the next sandwich phase through benchmark definition and
+  modest head evolution rather than more simplification-only evidence.
+- TF-RD-010 now defines the first benchmark-backed multiclass program:
+  `dagzoo` training fronts, `tab-realdata-hub` validation manifests, and the
+  evolved sandwich architecture with FiLM, `sandwich_summary_tokens_per_axis=3`,
+  `many_class_base=10`, and a direct multiclass head.
+- TF-RD-010 ranks candidate rows by `final_bpc_at_matched_regime_budget`,
+  treating BPC as the normalized log-loss view while calibration, runtime, and
+  stability remain guardrails.
 - TF-RD-021 then decides whether any steering-derived dagzoo corpus front
-  replaces the carried sandwich dagzoo slice before runtime/kernel tuning.
+  replaces the carried sandwich dagzoo training front before runtime/kernel
+  tuning.
 - TF-RD-022 is the next hard pre-scaling gate after steering: it must hand back
   one measured kernel/runtime policy before broader scaling fits.
 - TF-RD-009 only starts after those gates are closed and fits the first law on
@@ -212,13 +215,13 @@ Parallel/later lanes are intentionally off that main path:
 | Objective / Claim | Current State | Evidence In Repo | Current Gap | Roadmap IDs |
 | --- | --- | --- | --- | --- |
 | Frozen PFN-style control exists | `implemented` | `tabfoundry_simple`, `stage=nano_exact`, and the prior-trained PFN-facing benchmark lane are all stable | Keep that lane clearly separate from the architecture target | `TF-RD-001` |
-| Sandwich is the primary classification candidate | `partial` | `tabfoundry_sandwich` is landed, the compact hybrid replay is benchmarked, the first knob screen plus bounded width/head follow-up both kept the compact control, and the completed removal-first package under [#184](https://github.com/bensonlee5/tab-foundry/issues/184) also retained that anchor | Carry the retained compact hybrid anchor onto harder-surface and scaling-prep work | `TF-RD-016`, `TF-RD-021A`, `TF-RD-021B` |
-| Harder synthetic classification fronts are runnable | `implemented` | Dagzoo manifest/export fidelity is complete, TF-RD-013 settled the representative medium surface, and TF-RD-020 settled harder-front winners that can seed sandwich-on-dagzoo carry-forward work | Carry the frozen sandwich parent onto dagzoo, then choose whether steering improves that first carried slice | `TF-RD-011`, `TF-RD-013`, `TF-RD-020`, `TF-RD-016`, `TF-RD-010`, `TF-RD-021` |
+| Sandwich is the primary classification candidate | `implemented` | `tabfoundry_sandwich` is landed, the compact hybrid replay is benchmarked, the first knob screen plus bounded width/head follow-up both kept the compact control, the completed removal-first package under [#184](https://github.com/bensonlee5/tab-foundry/issues/184) retained that anchor, and TF-RD-016 now closes on a bounded direct-multiclass head evolution | Judge the evolved sandwich family on the TF-RD-010 benchmark program rather than reopening simplification-first work | `TF-RD-016`, `TF-RD-021A`, `TF-RD-021B`, `TF-RD-010` |
+| Harder synthetic classification fronts are runnable | `implemented` | Dagzoo manifest/export fidelity is complete, TF-RD-013 settled the representative medium surface, and TF-RD-020 settled harder-front winners that can seed the new sandwich benchmark program | Freeze the benchmark-defined dagzoo training fronts, then choose whether steering improves that first carried slice | `TF-RD-011`, `TF-RD-013`, `TF-RD-020`, `TF-RD-016`, `TF-RD-010`, `TF-RD-021` |
 | Runtime and VRAM are measurable | `partial` | Training and registry artifacts now preserve runtime-summary and regime-budget fields, and the repo already has bf16/checkpointing-capable runtime plumbing | TF-RD-022 still needs to turn that into one explicit 80 GB A100-safe kernel/runtime policy on the carried sandwich dagzoo slice | `TF-RD-022` |
-| Many-class + missingness is now the first anti-saturation carried slice | `partial` | `many_class` is implemented, the small multiclass bundle already exists, and the roadmap now treats a dagzoo-backed many-class plus missingness slice as the first harder classification gate | The repo still needs one explicit carried many-class plus missingness dagzoo slice on the frozen sandwich parent | `TF-RD-010` |
+| Benchmark-backed multiclass validation is the next anti-saturation slice | `partial` | `many_class` is implemented, the sandwich evolution config now fixes FiLM plus `sandwich_summary_tokens_per_axis=3`, and `tab-realdata-hub` issue [#1](https://github.com/bensonlee5/tab-realdata-hub/issues/1) now tracks the medium and large multiclass validation manifests | The repo still needs the hub-owned medium/large manifests and frozen multiclass control baselines before the first TF-RD-010 runs execute | `TF-RD-010` |
 | Follow-on missingness and imbalance robustness remain open | `partial` | Missing-permitting binary bundles exist, and the current bundle policy already excludes degenerate minority-class cases | TF-RD-014 remains later missingness follow-up, while TF-RD-017 still needs an explicit side-lane imbalance ladder on the same sandwich family | `TF-RD-014`, `TF-RD-017` |
 | Regression and later modalities are deferred | `research` | Partial bundle/runtime scaffolding exists | They should not absorb attention from the classification-first path | `TF-RD-015`, `TF-RD-012` |
-| Scaling-law work has the needed metadata path | `planned` | Artifacts now preserve resolved sandwich specs plus runtime/regime-budget metadata | TF-RD-009 still waits on one fixed dagzoo many-class plus missingness slice, one steering decision, and the runtime gate | `TF-RD-009` |
+| Scaling-law work has the needed metadata path | `planned` | Artifacts now preserve resolved sandwich specs plus runtime/regime-budget metadata | TF-RD-009 still waits on one fixed benchmark-defined multiclass program, one steering decision, and the runtime gate | `TF-RD-009` |
 
 ## Current Implementation Baseline
 
@@ -259,38 +262,49 @@ Legacy wording note:
 - the dependency order, current-state bullets, and required-work bullets below
   are the authoritative description of the active sandwich-first path
 
-### TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
+### TF-RD-010: Benchmark-Defined Multiclass Evolution On The Classification-First Sandwich Target
 
 - Status: `planned`
 - Milestone: `Next`
-- Goal: use a dagzoo-backed many-class plus missingness regime as the first
-  harder post-simplification classification gate so the first scaling target
-  does not saturate too early on binary data
+- Goal: define the first benchmark-backed multiclass evaluation program for the
+  evolved sandwich family so the first scaling target does not saturate too
+  early on binary data
 - Current state:
-  - the staged family already contains `many_class`
-  - the hierarchical many-class machinery already exists
-  - `nanotabpfn_openml_classification_small_v1.json` already exists as a
-    benchmark-facing multiclass bundle
-  - issue [#52](https://github.com/bensonlee5/tab-foundry/issues/52) is now
-    the epic for this lane, and issue
+  - issue [#52](https://github.com/bensonlee5/tab-foundry/issues/52) is the
+    epic for this lane, and issue
     [#99](https://github.com/bensonlee5/tab-foundry/issues/99) is the first
     execution issue
-  - this lane now sits on the first classification-scaling path after the
-    simplified-parent phase of TF-RD-016 rather than as a later extension
+  - `tab-realdata-hub` issue
+    [#1](https://github.com/bensonlee5/tab-realdata-hub/issues/1) is now the
+    upstream dependency for medium and large multiclass validation bundles and
+    materialized manifests
+  - the evolved sandwich benchmark config uses FiLM,
+    `sandwich_summary_tokens_per_axis=3`, `many_class_base=10`, and a direct
+    multiclass head
+  - this lane now sits on the first classification-scaling path after TF-RD-016
+    closes rather than as a later extension
 - Required work:
-  - confirm one carried dagzoo-backed many-class plus missingness slice and the
-    frozen sandwich parent that will read it
-  - keep the lane on the same carried sandwich family rather than opening a
-    separate
-    architecture track
-  - evaluate this first gate by multiclass log loss first, with runtime,
-    stability, and calibration-oriented metrics as guardrails
-  - record one explicit keep/defer decision on the carried many-class plus
-    missingness slice before TF-RD-009 starts
+  - keep the lane on the sandwich family rather than opening a separate
+    multiclass architecture program, but allow bounded head/output evolution
+    where the benchmark contract requires it
+  - define one clean medium validation rung and one harder large allow-missing
+    validation rung, both owned by `tab-realdata-hub`
+  - keep `dagzoo` as the synthetic training owner and use TF-RD-010-specific
+    control, MCAR, MAR, and MNAR fronts as the first benchmark rows
+  - freeze new explicit multiclass control baselines for the medium and large
+    rungs before execution
+  - rank by `final_bpc_at_matched_regime_budget`, treating BPC as the
+    normalized log-loss view while calibration, runtime, and stability remain
+    guardrails
+  - make class-count coverage, feature-count coverage, missingness allowance,
+    minority-class floor, and task diversity explicit parts of the benchmark
+    charter
 - Exit criteria:
-  - the repo has one explicit carried dagzoo many-class plus missingness slice
-    on the frozen sandwich parent
+  - the repo has one explicit medium-plus-large multiclass benchmark program on
+    the evolved sandwich family
   - multiclass is no longer only untested scaffolding on the first scaling path
+  - later lanes can inherit a fixed dagzoo-to-hub benchmark contract instead of
+    reopening regime definition
 
 ### TF-RD-012: Inference Handoff And Later Modalities
 
@@ -554,8 +568,8 @@ Legacy wording note:
     corpus rows produced from named steering policies or presets
   - hold architecture, many-class plus missingness regime definition, and
     benchmark contract fixed across every row
-  - interpret multiclass log loss first, with runtime, clipped-step fraction,
-    and stability telemetry as guardrails
+  - interpret `final_bpc_at_matched_regime_budget` first, with raw log loss,
+    runtime, clipped-step fraction, and stability telemetry as guardrails
   - keep exactly one steering-derived carry-forward surface only if it clearly
     beats the incumbent control; otherwise keep the original carried slice
   - keep this epic synthetic-data-only rather than absorbing imbalance,
@@ -595,55 +609,40 @@ Legacy wording note:
 
 ### TF-RD-016: Architecture Surface Adequacy, Sandwich Simplification, And Selective Expansion
 
-- Status: `planned`
-- Milestone: `Next`
-- Goal: simplify the sandwich classification parent before broader harder-surface
-  work, then decide whether any additional architecture-surface expansion is
-  justified once harder classification surfaces are in place
+- Status: `completed`
+- Milestone: `Completed`
+- Goal: determine whether the sandwich family needed more simplification-first
+  work before broader harder-surface evaluation
 - Current state:
-  - `tabfoundry_sandwich` is now the primary classification candidate under
-    umbrella issue [#178](https://github.com/bensonlee5/tab-foundry/issues/178).
-  - The earlier summary-bottleneck replay is closed negative evidence under
+  - issue [#178](https://github.com/bensonlee5/tab-foundry/issues/178) now
+    closes as a historical handoff issue rather than an active lane
+  - the earlier summary-bottleneck replay is closed negative evidence under
     [#179](https://github.com/bensonlee5/tab-foundry/issues/179), while the
     compact hybrid replay and the first two follow-up screens under
     [#181](https://github.com/bensonlee5/tab-foundry/issues/181),
     [#182](https://github.com/bensonlee5/tab-foundry/issues/182), and
     [#183](https://github.com/bensonlee5/tab-foundry/issues/183) all kept the
-    compact hybrid control unchanged.
-  - Issue [#184](https://github.com/bensonlee5/tab-foundry/issues/184) ran the
+    compact hybrid control unchanged
+  - issue [#184](https://github.com/bensonlee5/tab-foundry/issues/184) ran the
     four-row removal-first package and kept the compact hybrid control
-    unchanged as the carry-forward parent.
-  - The existing public staged/sandwich surface is already broad enough that
-    the next step should be carry-forward on the retained anchor, not immediate
-    new-knob expansion.
-- Required work:
-  - Record the compact hybrid control as the kept parent from
-    [#184](https://github.com/bensonlee5/tab-foundry/issues/184), and carry
-    that unchanged non-shape sandwich surface onto dagzoo immediately so later
-    many-class, steering, runtime, and scaling work all reuse the same
-    sandwich family.
-  - Keep the retained compact hybrid non-shape values fixed for follow-on work:
-    `sandwich_self_attention_per_cross=4`,
-    `sandwich_ff_expansion=2`, and
-    `sandwich_summary_tokens_per_axis=4`.
-  - Then use that dagzoo-backed sandwich family on one many-class plus
-    missingness slice under
-    [#52](https://github.com/bensonlee5/tab-foundry/issues/52) and
-    [#99](https://github.com/bensonlee5/tab-foundry/issues/99) before treating
-    deeper missingness or imbalance as follow-on robustness work.
-  - Prefer already-exposed choices such as norm placement, tokenizer/grouping,
-    and width/depth/capacity controls before adding new public fields.
-  - Only if the simplified harder-surface reads remain low-signal, consider a
-    small bounded set of new architecture knobs rather than a general
-    “everything configurable” expansion.
+    unchanged as the historical predecessor surface
+  - TF-RD-016 now records that the next useful evidence is benchmark definition
+    plus a modest head/output evolution, not more simplification-only replay
+- Completed outcomes:
+  - the repo now has a bounded decision that the sandwich backbone is coherent
+    enough to move into medium and large multiclass benchmark formulation
+  - the follow-on family is explicitly FiLM-conditioned, uses
+    `sandwich_summary_tokens_per_axis=3`, raises `many_class_base` to `10`, and
+    uses a direct multiclass head rather than reopening the staged line
+  - TF-RD-010 now owns the active benchmark program, with `dagzoo` synthetic
+    training fronts feeding `tab-realdata-hub` validation manifests before any
+    steering, runtime, or scaling work continues
 - Exit criteria:
-  - the repo has one explicit kept sandwich parent for classification and a
-    frozen non-shape knob surface for follow-on harder-surface work
-  - the repo has an explicit keep/defer decision on whether the current public
-    architecture surfaces, including the fixed-latent sandwich candidate, are
-    sufficient on harder post-008 regimes
-  - any newly exposed architecture knobs are bounded, justified, and tied to a
-    coherent comparison surface rather than broad config expansion
+  - satisfied: the repo has an explicit keep/defer decision that the sandwich
+    architecture surface is adequate enough to move into benchmark-defined
+    multiclass evaluation
+  - satisfied: later work now reuses one coherent sandwich family instead of
+    reopening general simplification or staged-family divergence
 
 ### TF-RD-009: Scaling-Law Design And Measurement On The Classification-First Sandwich Target
 
@@ -684,8 +683,9 @@ Legacy wording note:
     before using scaling results as architecture evidence
   - keep the other sandwich knobs frozen at the retained compact hybrid anchor
     values while fitting the first width-depth classification laws
-  - use multiclass log loss as the primary ranking objective on the carried
-    many-class plus missingness slice
+  - use `final_bpc_at_matched_regime_budget` as the primary ranking objective
+    on the carried multiclass slice, treating BPC as the normalized log-loss
+    view
   - run optimizer-transfer and model-size scaling together rather than as
     separate programs
   - keep the eventual `sandwich_scale` interface internal-only until the law is
@@ -695,9 +695,9 @@ Legacy wording note:
   - the repo can fit width-depth classification laws on the simplified sandwich
     architecture under a fixed dagzoo many-class plus missingness slice that is
     harder or broader than the current simple binary regime
-  - scaling artifacts compare runs by matched regime budget with final
-    multiclass log loss as the primary objective and stability, calibration,
-    and runtime as guardrails
+  - scaling artifacts compare runs by matched regime budget with final BPC as
+    the primary objective, raw log loss as supporting context, and stability,
+    calibration, and runtime as guardrails
   - any later single-knob scaling interface is explicitly derived from those
     law fits and remains internal until cross-surface validation is complete
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.15.1"
+version = "0.15.2"
 description = "Tabular foundation model that generates its own training data via dagzoo, trains on it, and predicts on new tasks"
 readme = "README.md"
 license = "Apache-2.0"

--- a/reference/evidence.md
+++ b/reference/evidence.md
@@ -39,9 +39,9 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
   runtime and VRAM efficiency evidence plus the measured-policy pre-scaling
   handoff
 - [`TF-RD-016`](roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md):
-  existing-surface adequacy and selective expansion evidence
+  architecture-surface closeout evidence and benchmark-evolution handoff
 - [`TF-RD-010`](roadmap_evidence/tf_rd_010_many_class_promotion.md):
-  first many-class plus missingness dagzoo gate evidence on the
+  benchmark-defined multiclass evolution evidence on the
   classification-first sandwich target
 - [`TF-RD-009`](roadmap_evidence/tf_rd_009_scaling_law_measurement.md):
   classification-first scaling-law design evidence and the runtime plus
@@ -374,17 +374,23 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
     under one harder dagzoo slice, one inherited runtime policy, and one
     matched regime-budget contract
 
-### TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
+### TF-RD-010: Benchmark-Defined Multiclass Evolution On The Classification-First Sandwich Target
 
 - External evidence:
   - label-conditioning work such as EquiTabPFN matters more after the backbone
     is coherent
 - Repo-local evidence:
-  - the staged family already includes `many_class`
-  - many-class should inherit the frozen sandwich dagzoo backbone rather than
-    become its own architecture lane
+  - `dagzoo` is now the explicit owner of the synthetic training fronts
+  - `tab-realdata-hub` issue `#1` is now the upstream owner of the medium and
+    large multiclass validation bundles and manifest materialization flow
+  - the evolved sandwich benchmark config fixes FiLM,
+    `sandwich_summary_tokens_per_axis=3`, `many_class_base=10`, and a direct
+    multiclass head
+  - TF-RD-010 now has explicit draft medium and large sweep contracts rather
+    than only a conceptual carried slice
 - Success signal:
-  - many-class is evaluated as an extension of the frozen sandwich parent
+  - multiclass is evaluated through a fixed dagzoo-to-hub benchmark contract on
+    the evolved sandwich family
 
 ### TF-RD-011: Repo-Wide Enablers And Contract Fidelity
 

--- a/reference/roadmap_evidence/README.md
+++ b/reference/roadmap_evidence/README.md
@@ -30,7 +30,7 @@ Conventions:
 1. [TF-RD-021A: Fixed-Latent Sandwich Candidate And NanoTabPFN Screen](tf_rd_021a_latent_bank_sandwich_prototype.md)
 1. [TF-RD-021B: Hybrid Full-Cell Sandwich Successor, Simplification, And Classification-First Scaling Prep](tf_rd_021b_hybrid_full_cell_sandwich_successor.md)
 1. [TF-RD-016: Architecture Surface Adequacy, Sandwich Simplification, And Selective Expansion](tf_rd_016_architecture_surface_adequacy.md)
-1. [TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Row-First Base](tf_rd_010_many_class_promotion.md)
+1. [TF-RD-010: Benchmark-Defined Multiclass Evolution On The Classification-First Sandwich Target](tf_rd_010_many_class_promotion.md)
 1. [TF-RD-009: Scaling-Law Design And Measurement On The Classification-First Sandwich Target](tf_rd_009_scaling_law_measurement.md)
 1. [TF-RD-014: Missingness Robustness On The Promoted Anchor](tf_rd_014_missingness_robustness.md)
 1. [TF-RD-017: Class-Imbalance Robustness On The Promoted Anchor](tf_rd_017_class_imbalance_robustness.md)
@@ -44,4 +44,5 @@ Notes:
   epic and continues forward.
 - Some note titles still mirror legacy roadmap labels for stable cross-links;
   the dependency text inside each note is authoritative about the carried
-  sandwich family and the current sandwich-first queue.
+  sandwich family, the benchmark-definition handoff, and the current
+  sandwich-first queue.

--- a/reference/roadmap_evidence/tf_rd_010_many_class_promotion.md
+++ b/reference/roadmap_evidence/tf_rd_010_many_class_promotion.md
@@ -1,63 +1,85 @@
-# TF-RD-010: First Many-Class + Missingness Dagzoo Gate On The Classification-First Sandwich Target
+# TF-RD-010: Benchmark-Defined Multiclass Evolution On The Classification-First Sandwich Target
 
 This is the canonical long-form evidence note for
-[TF-RD-010](../../docs/development/roadmap.md).
+[TF-RD-010](../../docs/development/roadmap.md#tf-rd-010-benchmark-defined-multiclass-evolution-on-the-classification-first-sandwich-target).
 
 - Status: `planned`
 - Milestone: `Next`
 - Dependency position: follows
-  [TF-RD-016](tf_rd_016_architecture_surface_adequacy.md) in the current
-  roadmap ordering, establishes the first carried many-class plus missingness
-  dagzoo slice, and feeds
-  [TF-RD-009](tf_rd_009_scaling_law_measurement.md) rather than opening a
-  separate architecture lane
+  [TF-RD-016](tf_rd_016_architecture_surface_adequacy.md), feeds
+  [TF-RD-021](tf_rd_021_steering_derived_dagzoo_corpus_fronts.md),
+  [TF-RD-017](tf_rd_017_class_imbalance_robustness.md),
+  [TF-RD-022](tf_rd_022_training_runtime_vram_efficiency.md), and
+  [TF-RD-009](tf_rd_009_scaling_law_measurement.md), and does so through a
+  benchmark program rather than a separate architecture family
 
 ## External Evidence
 
 - Shared bibliography: [reference/papers.md](../papers.md)
-- Current curated context is primarily `EquiTabPFN` plus the broader tabular
+- Current curated context is primarily `EquiTabPFN` plus broader tabular
   foundation-model references that keep label conditioning modular
-- Dedicated many-class literature is not yet curated beyond that shared context
-- External evidence to curate next: multiclass calibration, hierarchical
-  prediction, many-class efficiency, and missingness-aware multiclass
-  evaluation references for the first carried dagzoo slice
+- Dedicated many-class benchmark literature remains thin inside the repo; the
+  next sources to curate are multiclass calibration, missingness-aware
+  evaluation, class-imbalance reporting, and many-class efficiency references
 
 ## Repo-Local Evidence
 
-- the staged family already contains `many_class`
-- the hierarchical many-class machinery already exists
-- `nanotabpfn_openml_classification_small_v1.json` already exists as a
-  benchmark-facing multiclass bundle
-- issue [#52](https://github.com/bensonlee5/tab-foundry/issues/52) is the epic
-  for this lane, and issue
+- issue [#52](https://github.com/bensonlee5/tab-foundry/issues/52) is the
+  umbrella for this lane, and issue
   [#99](https://github.com/bensonlee5/tab-foundry/issues/99) is the first
   execution issue
-- the roadmap now treats a dagzoo-backed many-class plus missingness slice as
-  the first anti-saturation classification gate before the first scaling fit
+- `tab-realdata-hub` issue
+  [#1](https://github.com/bensonlee5/tab-realdata-hub/issues/1) is the
+  canonical upstream dependency for medium and large multiclass validation
+  bundles and materialized manifests
+- the first draft sweep contracts now exist in
+  `reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/`
+  and
+  `reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/`
+- the evolved sandwich benchmark config fixes:
+  - `feature_type_conditioning=film`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `many_class_base=10`
+  - `training.loss_surface=cell_bpc`
+  - direct multiclass head
+- `dagzoo` remains the owner of the synthetic training fronts used by these
+  sweeps
+- `tab-foundry` benchmark execution already expects materialized manifest
+  parquet for validation surfaces, which makes the hub-owned manifest contract
+  the right long-term boundary
 
 ## Current Interpretation
 
-- keep this lane on the classification-first sandwich family rather than
-  opening a
-  separate multiclass model track
-- use one dagzoo-backed many-class plus missingness slice as the first carried
-  harder classification regime
-- interpret the lane by multiclass log loss first, with runtime, stability,
-  and calibration-oriented metrics as guardrails
+- This lane should be benchmark-first, not anchor-first
+- Prior TF-RD-021B evidence is historical context only; the active target is an
+  evolved sandwich classification surface
+- The benchmark program should make the repo-to-repo linkage explicit:
+  - `dagzoo` defines synthetic training fronts
+  - `tab-realdata-hub` defines medium and large real-data validation bundles
+    plus materialized manifests
+  - `tab-foundry` consumes those manifests and ranks rows by
+    `final_bpc_at_matched_regime_budget`
+- BPC is the normalized log-loss view for the first expanded multiclass regime;
+  raw log loss, calibration, runtime, and stability remain supporting guardrails
+- Missingness should be addressed in both places:
+  - synthetic training fronts via control, MCAR, MAR, and MNAR corpora
+  - validation via the large allow-missing benchmark rung
+- Class imbalance should be made explicit in benchmark coverage and reporting,
+  but a dedicated imbalance ladder remains TF-RD-017 follow-on work
 
 ## Open Evidence Gaps
 
-- there is no dedicated many-class literature subset yet beyond the shared
-  foundation-model references
-- the repo does not yet have one explicit carried dagzoo many-class plus
-  missingness slice on the frozen sandwich parent
-- the first benchmark-facing many-class plus missingness sweep and decision
-  package do not exist yet
+- `tab-realdata-hub` still needs to land the medium and large multiclass bundle
+  ownership and materialization flow
+- the multiclass medium and large control baselines are not yet frozen
+- the first medium and large benchmark runs have not executed yet
 
 ## Exit Signals
 
-- the repo has one explicit carried dagzoo many-class plus missingness slice on
-  the frozen sandwich parent
-- multiclass is no longer only untested scaffolding on the first scaling path
-- TF-RD-009 can inherit a fixed anti-saturation classification target instead
-  of reopening regime selection
+- the repo has one explicit medium-plus-large multiclass benchmark program on
+  the evolved sandwich family
+- medium and large validation manifests are owned upstream in
+  `tab-realdata-hub` and referenced directly by `tab-foundry`
+- later steering, imbalance, runtime, and scaling lanes inherit a fixed
+  `dagzoo -> tab-realdata-hub -> tab-foundry` contract rather than reopening
+  regime selection

--- a/reference/roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md
+++ b/reference/roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md
@@ -3,70 +3,75 @@
 This is the canonical long-form evidence note for
 [TF-RD-016](../../docs/development/roadmap.md#tf-rd-016-architecture-surface-adequacy-sandwich-simplification-and-selective-expansion).
 
-- Status: `planned`
-- Milestone: `Next`
-- Dependency position: now includes an earlier simplified-parent phase before
-  the main harder-surface ladders, then gates
-  [TF-RD-010](tf_rd_010_many_class_promotion.md) as the first carried
-  many-class plus missingness slice before follow-on robustness lanes such as
-  [TF-RD-014](tf_rd_014_missingness_robustness.md) and
-  [TF-RD-017](tf_rd_017_class_imbalance_robustness.md), plus
-  [TF-RD-015](tf_rd_015_regression_rebuild.md),
-  [TF-RD-012](tf_rd_012_inference_handoff_and_later_modalities.md), and
+- Status: `completed`
+- Milestone: `Completed`
+- Dependency position: historical closeout gate that now hands active work to
+  [TF-RD-010](tf_rd_010_many_class_promotion.md), followed by
+  [TF-RD-021](tf_rd_021_steering_derived_dagzoo_corpus_fronts.md),
+  [TF-RD-022](tf_rd_022_training_runtime_vram_efficiency.md),
+  [TF-RD-017](tf_rd_017_class_imbalance_robustness.md), and
   [TF-RD-009](tf_rd_009_scaling_law_measurement.md)
 
 ## External Evidence
 
 - Shared bibliography: [reference/papers.md](../papers.md)
 - Current curated context is broad rather than knob-specific: `TabICLv2`,
-  `FT-Transformer`, `Deep Sets`, `Set Transformer`, and compact-transformer
-  recipe references from `nanochat`
-- Dedicated micro-architecture adequacy literature is not yet curated as its
-  own repo section
-- External evidence to curate next: norm-placement, initialization, activation,
-  and compact-capacity papers only if the existing-surface ladder remains
-  low-signal
+  `FT-Transformer`, `Deep Sets`, `Set Transformer`, `PerceiverIO`, and compact
+  transformer recipe references from `nanochat`
+- Dedicated micro-architecture adequacy literature remains secondary because the
+  repo now has enough local simplification evidence to move on to benchmark
+  definition
 
 ## Repo-Local Evidence
 
-- the current public architecture surface already exposes tokenization choice,
-  `feature_group_size`, norm family and placement, widths, depths, row CLS
-  count, TFCol inducing count, context FF expansion, dropout, and clipping
-- TF-RD-021B now makes sandwich-parent simplification the first explicit
-  architecture task before broader harder-surface adequacy work
-- TF-RD-010 is now the first carried harder regime after that simplification:
-  many-class plus missingness on a dagzoo-backed slice
-- learned special-token and inducing-token initialization scale remains
-  hardcoded
-- optimizer adequacy work, including `muon`, is already scoped out of this epic
-  and belongs to [TF-RD-018](tf_rd_018_training_surface_adequacy.md)
+- `tabfoundry_sandwich` remains the primary classification architecture family
+- TF-RD-021A and TF-RD-021B closed the immediate sandwich replay and bounded
+  simplification passes
+- issue [#184](https://github.com/bensonlee5/tab-foundry/issues/184) kept the
+  compact hybrid control, but TF-RD-016 does not interpret that as a reason to
+  freeze the full benchmark contract around the historical four-token surface
+- issue [#178](https://github.com/bensonlee5/tab-foundry/issues/178) now closes
+  on the decision that the next useful evidence is benchmark definition plus a
+  bounded head/output evolution
+- the follow-on benchmark config now fixes:
+  - `feature_type_conditioning=film`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `many_class_base=10`
+  - direct multiclass head
+- the follow-on benchmark program is explicitly repo-linked:
+  - `dagzoo` owns synthetic training corpora
+  - `tab-realdata-hub` owns real-data validation bundles and manifest
+    materialization
+  - `tab-foundry` owns the evolved sandwich model and sweep contracts
 
 ## Current Interpretation
 
-- Phase 0 should choose and freeze a simplified sandwich parent before broader
-  harder-surface adequacy work
-- Phase 1 should then read the frozen parent on one dagzoo-backed many-class
-  plus missingness slice before adding new config fields
-- Phase 2 should use TF-RD-014 and TF-RD-017 as follow-on robustness lanes
-  rather than as blockers to the first scaling target
-- tokenizer and norm-family or placement choices are the first explicit
-  subtracks because they are already exposed and could matter across multiple
-  future regimes
-- selective surface expansion belongs only in Phase 3, and only if the carried
-  harder-surface reads remain low-signal
+- The sandwich backbone is coherent enough that more simplification-only replay
+  is no longer the highest-value next step
+- The next decision surface should be a benchmark program, not another local
+  ablation ladder
+- The selected architecture evolution is intentionally modest:
+  - keep the backbone, tokenizer family, and Perceiver stack intact
+  - replace the “small-class only” framing with a direct multiclass head
+  - use FiLM and `3` summary tokens per axis as the new default benchmark
+    contract
+- Class imbalance remains important, but TF-RD-016 treats it as a benchmark
+  coverage/reporting requirement for TF-RD-010 rather than a blocker that must
+  open its own ladder before closeout
 
 ## Open Evidence Gaps
 
-- there is no explicit keep or defer decision yet on whether the current
-  sandwich surface is sufficient on harder post-008 regimes
-- the repo has not yet shown whether the remaining hardcoded choices are
-  decision-relevant enough to expose
-- the knob-specific literature set is intentionally deferred until Phase 1 says
-  it is needed
+- TF-RD-016 itself is closed, but the benchmark program it hands off still
+  depends on:
+  - `tab-realdata-hub` medium and large multiclass bundle ownership
+  - frozen multiclass control baselines
+  - first executed medium and large benchmark runs
 
 ## Exit Signals
 
-- the repo has an explicit keep or defer decision on whether the current
-  sandwich architecture surface is sufficient on harder post-008 regimes
-- any newly exposed architecture knobs are bounded, justified, and tied to one
-  coherent sandwich comparison surface
+- satisfied: the repo records one explicit decision that the sandwich family is
+  ready for benchmark-defined multiclass evaluation
+- satisfied: the active follow-on lane is now TF-RD-010 rather than another
+  simplification-first pass
+- satisfied: the `dagzoo -> tab-realdata-hub -> tab-foundry` linkage is the
+  authoritative handoff model for the next classification phase

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -4707,6 +4707,150 @@ deltas:
     default_next_action: Run third under issue `#148`, then select exactly one missingness nominee for cross-front comparison.
     applicability_guards: []
 
+  delta_data_manifest_root_tf_rd_010_dagzoo_medium_control:
+    dimension_family: data
+    family: provenance
+    binary_applicable: false
+    description: Point training at the TF-RD-010 dagzoo multiclass control corpus while the evolved sandwich benchmark contract is defined against hub-owned validation manifests.
+    upstream_delta: Not applicable; this is a repo-local synthetic training-front contract tied to the first benchmark-evolution lane.
+    expected_effect: Establish the clean multiclass dagzoo control corpus that both the medium and large TF-RD-010 validation rungs will compare against.
+    adequacy_knobs:
+      - explicit dagzoo provenance for the multiclass control corpus
+      - medium and large real-data validation separation via `tab-realdata-hub` manifests
+      - class-count coverage, feature-count coverage, missingness policy, and minority-class floor on the validation side
+    parameter_adequacy_policy:
+      default_plan:
+        - Keep the evolved sandwich architecture fixed at FiLM plus `sandwich_summary_tokens_per_axis=3` with the direct multiclass head.
+        - Treat `dagzoo` as the synthetic training owner and `tab-realdata-hub` as the validation-manifest owner.
+        - Rank rows by `final_bpc_at_matched_regime_budget`, with raw log loss, calibration, runtime, and stability reported as guardrails.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_validation_manifests_and_control_baselines
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model: {}
+      data:
+        surface_label: tf_rd_010_dagzoo_medium_control
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_dagzoo_medium_control_v1
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Wait for `tab-realdata-hub#1` plus frozen multiclass control baselines before executing the first clean TF-RD-010 benchmark rung.
+    applicability_guards: []
+
+  delta_data_manifest_root_tf_rd_010_missingness_mcar:
+    dimension_family: data
+    family: missingness
+    binary_applicable: false
+    description: Point training at the TF-RD-010 MCAR multiclass corpus while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
+    expected_effect: Moderate MCAR should test whether the evolved sandwich target benefits from missingness exposure before any larger benchmark-front escalation.
+    adequacy_knobs:
+      - explicit MCAR provenance in the dagzoo training front
+      - fixed medium and large hub-owned validation manifests
+      - BPC/log-loss ranking under the direct multiclass head contract
+    parameter_adequacy_policy:
+      default_plan:
+        - Compare against the multiclass control corpus before preferring any missingness variant.
+        - Treat the large allow-missing validation rung as the primary benchmark context for missingness transfer, with the medium rung as the clean reference.
+        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_validation_manifests_and_control_baselines
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model: {}
+      data:
+        surface_label: tf_rd_010_missingness_mcar
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_missingness_mcar_v1
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Wait for `tab-realdata-hub#1` and the multiclass baseline freeze, then compare directly against the control, MAR, and MNAR rows.
+    applicability_guards: []
+
+  delta_data_manifest_root_tf_rd_010_missingness_mar:
+    dimension_family: data
+    family: missingness
+    binary_applicable: false
+    description: Point training at the TF-RD-010 MAR multiclass corpus while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
+    expected_effect: Structured MAR may provide a harder but still interpretable missingness front for the first multiclass benchmark program.
+    adequacy_knobs:
+      - explicit MAR provenance in the dagzoo training front
+      - fixed medium and large hub-owned validation manifests
+      - BPC/log-loss ranking under the direct multiclass head contract
+    parameter_adequacy_policy:
+      default_plan:
+        - Compare against the multiclass control corpus plus the MCAR and MNAR rows before preferring structured missingness.
+        - Treat the large allow-missing validation rung as the primary benchmark context for missingness transfer, with the medium rung as the clean reference.
+        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_validation_manifests_and_control_baselines
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model: {}
+      data:
+        surface_label: tf_rd_010_missingness_mar
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_missingness_mar_v1
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Wait for `tab-realdata-hub#1` and the multiclass baseline freeze, then compare directly against the control, MCAR, and MNAR rows.
+    applicability_guards: []
+
+  delta_data_manifest_root_tf_rd_010_missingness_mnar:
+    dimension_family: data
+    family: missingness
+    binary_applicable: false
+    description: Point training at the TF-RD-010 MNAR multiclass corpus while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
+    expected_effect: Structured MNAR may be the strongest synthetic missingness perturbation, but it risks a less interpretable first benchmark-evolution read than MCAR or MAR.
+    adequacy_knobs:
+      - explicit MNAR provenance in the dagzoo training front
+      - fixed medium and large hub-owned validation manifests
+      - BPC/log-loss ranking under the direct multiclass head contract
+    parameter_adequacy_policy:
+      default_plan:
+        - Compare against the multiclass control corpus plus the MCAR and MAR rows before preferring the strongest self-masking option.
+        - Treat the large allow-missing validation rung as the primary benchmark context for missingness transfer, with the medium rung as the clean reference.
+        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_validation_manifests_and_control_baselines
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model: {}
+      data:
+        surface_label: tf_rd_010_missingness_mnar
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_missingness_mnar_v1
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Wait for `tab-realdata-hub#1` and the multiclass baseline freeze, then compare directly against the control, MCAR, and MAR rows.
+    applicability_guards: []
+
   delta_data_manifest_root_tf_rd_020_shift_graph_drift:
     dimension_family: data
     family: shift

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -233,3 +233,19 @@ sweeps:
     benchmark_manifest_path: src/tab_foundry/bench/nanotabpfn_openml_binary_medium_v1.json
     control_baseline_id: cls_benchmark_linear_v2
     external_benchmarks: []
+  tf_rd_010_classification_evolution_medium_v1:
+    parent_sweep_id: tf_rd_021b_sandwich_feature_removal_v1
+    status: draft
+    anchor_run_id: null
+    complexity_level: classification_md
+    benchmark_manifest_path: data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+    external_benchmarks: []
+  tf_rd_010_classification_evolution_large_v1:
+    parent_sweep_id: tf_rd_010_classification_evolution_medium_v1
+    status: draft
+    anchor_run_id: null
+    complexity_level: classification_lg
+    benchmark_manifest_path: data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_large_v1
+    external_benchmarks: []

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/matrix.md
@@ -1,0 +1,42 @@
+# System Delta Matrix
+
+- Sweep id: `tf_rd_010_classification_evolution_large_v1`
+- Sweep status: `draft`
+- Anchor run id: `none`
+- Locked validation bundle: `nanotabpfn_openml_classification_large_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_large_v1`
+- External benchmarks: `none`
+
+## Purpose
+
+- Extend the TF-RD-010 benchmark-definition package onto the harder allow-missing validation rung.
+- Keep the sandwich backbone family intact while evaluating the evolved classification contract:
+  - `feature_type_conditioning=film`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `many_class_base=10`
+  - direct multiclass head
+- Keep `dagzoo` as the synthetic training owner and `tab-realdata-hub` as the real-data validation owner.
+
+## Validation Contract
+
+- Large validation surface: hub-materialized manifest for `nanotabpfn_openml_classification_large_v1`
+- Validation owner: `tab-realdata-hub` issue `bensonlee5/tab-realdata-hub#1`
+- Benchmark intent: harder allow-missing multiclass rung
+- Ranking metric: `final_bpc_at_matched_regime_budget`
+- Supporting guardrails: raw log loss, calibration, runtime, stability, feature-count coverage, class-count coverage, and minority-class reporting
+
+## Rows
+
+| Order | Delta | Training Front | Draft Purpose |
+| --- | --- | --- | --- |
+| 1 | `delta_data_manifest_root_tf_rd_010_dagzoo_medium_control` | `tf_rd_010_dagzoo_medium_control_v1` | Clean multiclass control |
+| 2 | `delta_data_manifest_root_tf_rd_010_missingness_mcar` | `tf_rd_010_missingness_mcar_v1` | Random missingness comparison |
+| 3 | `delta_data_manifest_root_tf_rd_010_missingness_mar` | `tf_rd_010_missingness_mar_v1` | Structured observed-feature missingness |
+| 4 | `delta_data_manifest_root_tf_rd_010_missingness_mnar` | `tf_rd_010_missingness_mnar_v1` | Strongest self-masking missingness |
+
+## Linkages
+
+- `dagzoo` defines the synthetic training fronts.
+- `tab-realdata-hub` defines the medium and large multiclass validation bundles and materialized manifests.
+- `tab-foundry` consumes those manifests for BPC-ranked benchmark evaluation.
+- Missingness is first-class on this rung because validation explicitly allows missing values, while class imbalance is addressed through explicit benchmark coverage and reporting and left for stronger ladder work under TF-RD-017.

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/queue.yaml
@@ -1,0 +1,155 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_010_classification_evolution_large_v1
+rows:
+- order: 1
+  delta_ref: delta_data_manifest_root_tf_rd_010_dagzoo_medium_control
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Establish the clean multiclass dagzoo control front before reading any missingness harder-front effect on the large allow-missing benchmark rung.
+  hypothesis: The evolved sandwich family should first be judged on a clean multiclass dagzoo control corpus against the harder allow-missing large hub manifest.
+  anchor_delta: Use the evolved FiLM plus 3-summary-token sandwich contract and train on `tf_rd_010_dagzoo_medium_control_v1` while validating on the hub-owned large multiclass manifest.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Confirm `tab-realdata-hub#1` has materialized the allow-missing large multiclass manifest before execution.
+  - Freeze the multiclass large control baseline before treating any row outcome as a promotion or defer decision.
+  - Rank by `final_bpc_at_matched_regime_budget`, then inspect raw log loss, calibration, runtime, and stability as guardrails.
+  next_action: Wait for the hub-owned large manifest and the multiclass large control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "This row is the clean multiclass reference for missingness transfer and class-imbalance reporting on the large rung."
+- order: 2
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mcar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Test whether moderate MCAR exposure improves robustness on the harder allow-missing large benchmark rung before structured missingness is considered.
+  hypothesis: MCAR may improve BPC/log-loss behavior on the evolved sandwich family under allow-missing validation without adding the stronger structure of MAR or MNAR.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mcar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mcar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mcar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control row before preferring missingness exposure.
+  - Treat the large allow-missing rung as the primary benchmark context for missingness transfer.
+  - Keep class-imbalance reporting explicit on the large rung, but defer any dedicated skew ladder to TF-RD-017.
+  next_action: Wait for the hub-owned large manifest and the multiclass large control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The large rung is explicitly allow-missing, so this row reads the cleanest first transfer case for synthetic MCAR training."
+- order: 3
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Add a structured missingness row so TF-RD-010 can distinguish random masking from observed-feature-linked masking under the harder allow-missing benchmark contract.
+  hypothesis: MAR may provide a clearer harder front than MCAR while remaining more interpretable than MNAR on the large rung.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control plus MCAR and MNAR before preferring structured missingness.
+  - Treat the large allow-missing rung as the primary benchmark context for missingness transfer.
+  - Keep class-imbalance reporting explicit on the large rung, but defer any dedicated skew ladder to TF-RD-017.
+  next_action: Wait for the hub-owned large manifest and the multiclass large control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The large rung is explicitly allow-missing, so this row reads structured observed-feature missingness transfer directly."
+- order: 4
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mnar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Keep one strongest missingness row in the first draft package so TF-RD-010 can compare MCAR, MAR, and MNAR under the same allow-missing benchmark contract.
+  hypothesis: MNAR may be the hardest missingness front, but it may also be the least interpretable candidate for the first evolved benchmark package.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mnar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mnar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mnar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control plus MCAR and MAR before preferring the strongest self-masking option.
+  - Treat the large allow-missing rung as the primary benchmark context for missingness transfer.
+  - Keep class-imbalance reporting explicit on the large rung, but defer any dedicated skew ladder to TF-RD-017.
+  next_action: Wait for the hub-owned large manifest and the multiclass large control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The large rung is explicitly allow-missing, so this row reads the strongest self-masking missingness transfer directly."

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1/sweep.yaml
@@ -1,0 +1,63 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_010_classification_evolution_large_v1
+parent_sweep_id: tf_rd_010_classification_evolution_medium_v1
+status: draft
+complexity_level: classification_lg
+anchor_run_id: null
+benchmark_manifest_path: data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_large_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_v1
+surface_role: custom
+comparison_policy: anchor_only
+upstream_reference:
+  name: EquiTabPFN
+  model_source: https://arxiv.org/abs/2502.06684
+anchor_surface:
+  notes:
+  - "This draft TF-RD-010 large sweep extends the medium benchmark-definition package onto the harder allow-missing validation rung."
+  - "Treat TF-RD-021B as historical context only; this package defines a modest sandwich architecture evolution rather than a frozen four-token carry-forward."
+  - "`dagzoo` owns the synthetic training corpora for every row in this sweep."
+  - "`tab-realdata-hub` issue `bensonlee5/tab-realdata-hub#1` owns the medium and large multiclass validation bundles plus their materialized manifest parquet outputs."
+  - "The evolved sandwich contract is FiLM-conditioned, uses `sandwich_summary_tokens_per_axis=3`, `many_class_base=10`, and a direct multiclass head."
+  - "Rank rows by `final_bpc_at_matched_regime_budget`, treating BPC as the normalized log-loss view while still reporting raw log loss, calibration, runtime, and stability guardrails."
+  - "The large rung is the allow-missing multiclass benchmark surface; missingness transfer is first-class here while class imbalance remains covered through bundle minority-floor policy and explicit reporting rather than a separate TF-RD-010 skew ladder."
+  - "Do not execute this sweep until the hub-backed validation manifest and the multiclass large control baseline are both frozen."
+  dimension_table:
+  - dimension: benchmark ownership
+    upstream: Not applicable.
+    anchor: "`dagzoo` owns the synthetic training fronts while `tab-realdata-hub` owns the real-data validation manifests."
+    interpretation: This sweep defines the harder validation rung for the repo-to-repo benchmark contract.
+  - dimension: classification head
+    upstream: Label-conditioning choices should stay modular so target handling can evolve after the backbone stabilizes.
+    anchor: "Direct multiclass head with `many_class_base=10`."
+    interpretation: Treat this as a bounded head/output evolution, not a staged hierarchical many-class port.
+  - dimension: summary bandwidth
+    upstream: Historical TF-RD-021B evidence used `sandwich_summary_tokens_per_axis=4`.
+    anchor: "The evolved benchmark surface uses `sandwich_summary_tokens_per_axis=3`."
+    interpretation: The new benchmark package should evaluate the evolved contract directly rather than replaying the historical four-token anchor.
+  - dimension: validation surface
+    upstream: Not applicable.
+    anchor: "Hub-backed large multiclass manifest at `data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet`."
+    interpretation: Keep the allow-missing large rung fixed while the synthetic training front changes across rows.
+anchor_context:
+  run_id: null
+  experiment: cls_benchmark_sandwich_classification_evolution_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: sandwich_classification_evolution_v1
+    stage: null
+    stage_label: null
+    module_selection:
+      feature_encoder: shared
+      feature_type_conditioning: film
+      head: direct_multiclass
+      target_conditioner: label_token
+      tokenizer: scalar_per_feature_missingness
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/matrix.md
@@ -1,0 +1,42 @@
+# System Delta Matrix
+
+- Sweep id: `tf_rd_010_classification_evolution_medium_v1`
+- Sweep status: `draft`
+- Anchor run id: `none`
+- Locked validation bundle: `nanotabpfn_openml_classification_medium_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_medium_v1`
+- External benchmarks: `none`
+
+## Purpose
+
+- Close TF-RD-016 by treating the next step as a benchmark-definition and modest head-evolution package rather than a replay of the historical four-token anchor.
+- Keep the sandwich backbone family intact while evaluating the evolved classification contract:
+  - `feature_type_conditioning=film`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `many_class_base=10`
+  - direct multiclass head
+- Keep `dagzoo` as the synthetic training owner and `tab-realdata-hub` as the real-data validation owner.
+
+## Validation Contract
+
+- Medium validation surface: hub-materialized manifest for `nanotabpfn_openml_classification_medium_v1`
+- Validation owner: `tab-realdata-hub` issue `bensonlee5/tab-realdata-hub#1`
+- Benchmark intent: clean no-missing multiclass rung
+- Ranking metric: `final_bpc_at_matched_regime_budget`
+- Supporting guardrails: raw log loss, calibration, runtime, stability, feature-count coverage, class-count coverage, and minority-class reporting
+
+## Rows
+
+| Order | Delta | Training Front | Draft Purpose |
+| --- | --- | --- | --- |
+| 1 | `delta_data_manifest_root_tf_rd_010_dagzoo_medium_control` | `tf_rd_010_dagzoo_medium_control_v1` | Clean multiclass control |
+| 2 | `delta_data_manifest_root_tf_rd_010_missingness_mcar` | `tf_rd_010_missingness_mcar_v1` | Random missingness comparison |
+| 3 | `delta_data_manifest_root_tf_rd_010_missingness_mar` | `tf_rd_010_missingness_mar_v1` | Structured observed-feature missingness |
+| 4 | `delta_data_manifest_root_tf_rd_010_missingness_mnar` | `tf_rd_010_missingness_mnar_v1` | Strongest self-masking missingness |
+
+## Linkages
+
+- `dagzoo` defines the synthetic training fronts.
+- `tab-realdata-hub` defines the medium and large multiclass validation bundles and materialized manifests.
+- `tab-foundry` consumes those manifests for BPC-ranked benchmark evaluation.
+- Class imbalance is addressed through explicit benchmark coverage and reporting, while any stronger skew ladder remains TF-RD-017 follow-on work.

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/queue.yaml
@@ -1,0 +1,155 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_010_classification_evolution_medium_v1
+rows:
+- order: 1
+  delta_ref: delta_data_manifest_root_tf_rd_010_dagzoo_medium_control
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Establish the clean multiclass dagzoo control front before reading any missingness harder-front effect on the new medium benchmark rung.
+  hypothesis: The evolved sandwich family should first be judged on a clean multiclass dagzoo control corpus against the no-missing medium hub manifest.
+  anchor_delta: Use the evolved FiLM plus 3-summary-token sandwich contract and train on `tf_rd_010_dagzoo_medium_control_v1` while validating on the hub-owned medium multiclass manifest.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Confirm `tab-realdata-hub#1` has materialized the no-missing medium multiclass manifest before execution.
+  - Freeze the multiclass medium control baseline before treating any row outcome as a promotion or defer decision.
+  - Rank by `final_bpc_at_matched_regime_budget`, then inspect raw log loss, calibration, runtime, and stability as guardrails.
+  next_action: Wait for the hub-owned medium manifest and the multiclass medium control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "This row is the clean multiclass reference for missingness and class-imbalance reporting on the medium rung."
+- order: 2
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mcar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Test whether moderate MCAR exposure improves robustness before structured missingness is considered on the medium multiclass rung.
+  hypothesis: MCAR may improve BPC/log-loss behavior on the evolved sandwich family without adding the stronger structure of MAR or MNAR.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mcar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mcar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mcar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control row before preferring missingness exposure.
+  - Keep class-imbalance reporting explicit on the medium rung, but defer any dedicated skew ladder to TF-RD-017.
+  - Use the large allow-missing rung later as the main transfer check for any kept missingness front.
+  next_action: Wait for the hub-owned medium manifest and the multiclass medium control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The medium rung stays no-missing even though the training front injects MCAR."
+- order: 3
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Add a structured missingness row so TF-RD-010 can distinguish random masking from observed-feature-linked masking under the evolved benchmark contract.
+  hypothesis: MAR may provide a clearer harder front than MCAR while remaining more interpretable than MNAR.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control plus MCAR and MNAR before preferring structured missingness.
+  - Keep class-imbalance reporting explicit on the medium rung, but defer any dedicated skew ladder to TF-RD-017.
+  - Use the large allow-missing rung later as the main transfer check for any kept missingness front.
+  next_action: Wait for the hub-owned medium manifest and the multiclass medium control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The medium rung stays no-missing even though the training front injects MAR."
+- order: 4
+  delta_ref: delta_data_manifest_root_tf_rd_010_missingness_mnar
+  status: blocked_on_validation_manifests_and_control_baselines
+  rationale: Keep one strongest missingness row in the first draft package so TF-RD-010 can compare MCAR, MAR, and MNAR under the same benchmark contract.
+  hypothesis: MNAR may be the hardest missingness front, but it may also be the least interpretable candidate for the first evolved benchmark package.
+  anchor_delta: Keep the evolved FiLM plus 3-summary-token sandwich contract fixed and replace the control corpus with `tf_rd_010_missingness_mnar_v1`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 60
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 4
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    feature_type_conditioning: film
+  data:
+    surface_label: tf_rd_010_missingness_mnar
+    source: manifest
+    corpus_ref: tf_rd_010_missingness_mnar_v1
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 1
+  parameter_adequacy_plan:
+  - Compare directly against the clean control plus MCAR and MAR before preferring the strongest self-masking option.
+  - Keep class-imbalance reporting explicit on the medium rung, but defer any dedicated skew ladder to TF-RD-017.
+  - Use the large allow-missing rung later as the main transfer check for any kept missingness front.
+  next_action: Wait for the hub-owned medium manifest and the multiclass medium control baseline freeze.
+  notes:
+  - "`dagzoo` owns this synthetic training front; `tab-realdata-hub` owns the validation manifest."
+  - "The medium rung stays no-missing even though the training front injects MNAR."

--- a/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1/sweep.yaml
@@ -1,0 +1,63 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_010_classification_evolution_medium_v1
+parent_sweep_id: tf_rd_021b_sandwich_feature_removal_v1
+status: draft
+complexity_level: classification_md
+anchor_run_id: null
+benchmark_manifest_path: data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_v1
+surface_role: custom
+comparison_policy: anchor_only
+upstream_reference:
+  name: EquiTabPFN
+  model_source: https://arxiv.org/abs/2502.06684
+anchor_surface:
+  notes:
+  - "This draft TF-RD-010 medium sweep is the first benchmark-definition package after TF-RD-016 closes via issue `#178`."
+  - "Treat TF-RD-021B as historical context only; this package defines a modest sandwich architecture evolution rather than a frozen four-token carry-forward."
+  - "`dagzoo` owns the synthetic training corpora for every row in this sweep."
+  - "`tab-realdata-hub` issue `bensonlee5/tab-realdata-hub#1` owns the medium and large multiclass validation bundles plus their materialized manifest parquet outputs."
+  - "The evolved sandwich contract is FiLM-conditioned, uses `sandwich_summary_tokens_per_axis=3`, `many_class_base=10`, and a direct multiclass head."
+  - "Rank rows by `final_bpc_at_matched_regime_budget`, treating BPC as the normalized log-loss view while still reporting raw log loss, calibration, runtime, and stability guardrails."
+  - "The medium rung is the clean no-missing multiclass benchmark surface; class imbalance remains covered through bundle minority-floor policy and explicit reporting rather than a separate TF-RD-010 skew ladder."
+  - "Do not execute this sweep until the hub-backed validation manifest and the multiclass medium control baseline are both frozen."
+  dimension_table:
+  - dimension: benchmark ownership
+    upstream: Not applicable.
+    anchor: "`dagzoo` owns the synthetic training fronts while `tab-realdata-hub` owns the real-data validation manifests."
+    interpretation: This sweep defines the repo-to-repo contract for the first benchmark-evolution lane.
+  - dimension: classification head
+    upstream: Label-conditioning choices should stay modular so target handling can evolve after the backbone stabilizes.
+    anchor: "Direct multiclass head with `many_class_base=10`."
+    interpretation: Treat this as a bounded head/output evolution, not a staged hierarchical many-class port.
+  - dimension: summary bandwidth
+    upstream: Historical TF-RD-021B evidence used `sandwich_summary_tokens_per_axis=4`.
+    anchor: "The evolved benchmark surface uses `sandwich_summary_tokens_per_axis=3`."
+    interpretation: The new benchmark package should evaluate the evolved contract directly rather than replaying the historical four-token anchor.
+  - dimension: validation surface
+    upstream: Not applicable.
+    anchor: "Hub-backed medium multiclass manifest at `data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet`."
+    interpretation: Keep the no-missing medium rung fixed while the synthetic training front changes across rows.
+anchor_context:
+  run_id: null
+  experiment: cls_benchmark_sandwich_classification_evolution_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: sandwich_classification_evolution_v1
+    stage: null
+    stage_label: null
+    module_selection:
+      feature_encoder: shared
+      feature_type_conditioning: film
+      head: direct_multiclass
+      target_conditioner: label_token
+      tokenizer: scalar_per_feature_missingness
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup

--- a/src/tab_foundry/model/architectures/tabfoundry_sandwich/model.py
+++ b/src/tab_foundry/model/architectures/tabfoundry_sandwich/model.py
@@ -25,7 +25,7 @@ from tab_foundry.model.components.attention import (
 from tab_foundry.model.components.non_finite import clip_finite_values
 from tab_foundry.model.components.normalization import build_norm
 from tab_foundry.model.components.tabular_primitives import (
-    DirectClassifierHead,
+    DirectMulticlassHead,
     FeatureTypeFiLM,
     LabelTokenTargetConditioner,
     ScalarPerFeatureMissingnessTokenizer,
@@ -377,7 +377,7 @@ class TabFoundrySandwichClassifier(nn.Module):
             ff_expansion=self.sandwich_ff_expansion,
             norm_type=self.norm_type,
         )
-        self.direct_head = DirectClassifierHead(
+        self.direct_head = DirectMulticlassHead(
             self.d_icl,
             self.head_hidden_dim,
             self.many_class_base,
@@ -999,7 +999,7 @@ class TabFoundrySandwichClassifier(nn.Module):
             )
         if num_classes > self.many_class_base:
             raise RuntimeError(
-                "tabfoundry_sandwich is small-class only and requires "
+                "tabfoundry_sandwich uses a direct multiclass head and requires "
                 f"num_classes <= many_class_base={self.many_class_base}, got {num_classes}"
             )
 

--- a/src/tab_foundry/model/components/tabular_primitives.py
+++ b/src/tab_foundry/model/components/tabular_primitives.py
@@ -76,8 +76,8 @@ class LabelTokenTargetConditioner(nn.Module):
         return torch.cat([train_embed, test_embed], dim=1).unsqueeze(2)
 
 
-class DirectClassifierHead(nn.Module):
-    """Generic small-class MLP head."""
+class DirectMulticlassHead(nn.Module):
+    """Direct multiclass MLP head with fixed output width."""
 
     def __init__(self, embedding_size: int, hidden_size: int, output_width: int) -> None:
         super().__init__()
@@ -92,8 +92,13 @@ class DirectClassifierHead(nn.Module):
         return self.net(rows)
 
 
+class DirectClassifierHead(DirectMulticlassHead):
+    """Backward-compatible alias for staged surfaces that still use the old name."""
+
+
 __all__ = [
     "DirectClassifierHead",
+    "DirectMulticlassHead",
     "FeatureTypeFiLM",
     "LabelTokenTargetConditioner",
     "ScalarPerFeatureMissingnessTokenizer",

--- a/tests/config/test_experiment_resolution.py
+++ b/tests/config/test_experiment_resolution.py
@@ -175,6 +175,38 @@ def test_cls_benchmark_sandwich_hybrid_prior_resolution() -> None:
     )
 
 
+def test_cls_benchmark_sandwich_classification_evolution_v1_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_sandwich_classification_evolution_v1")
+    assert str(cfg.task) == "classification"
+    assert str(cfg.model.arch) == "tabfoundry_sandwich"
+    assert cfg.model.stage is None
+    assert int(cfg.model.d_icl) == 60
+    assert str(cfg.model.input_normalization) == "train_zscore_clip"
+    assert str(cfg.model.feature_type_conditioning) == "film"
+    assert int(cfg.model.many_class_base) == 10
+    assert int(cfg.model.head_hidden_dim) == 96
+    assert int(cfg.model.sandwich_latents) == 24
+    assert int(cfg.model.sandwich_layers) == 2
+    assert int(cfg.model.sandwich_heads) == 4
+    assert int(cfg.model.sandwich_ff_expansion) == 2
+    assert int(cfg.model.sandwich_summary_tokens_per_axis) == 3
+    assert int(cfg.model.sandwich_self_attention_per_cross) == 4
+    assert int(cfg.model.sandwich_pre_row_attention_layers) == 1
+    assert int(cfg.model.sandwich_pre_column_attention_layers) == 1
+    assert int(cfg.model.sandwich_pre_column_inducing_tokens) == 16
+    assert str(cfg.training.loss_surface) == "cell_bpc"
+    assert int(cfg.runtime.max_steps) == 2500
+    assert int(cfg.runtime.eval_every) == 25
+    assert int(cfg.runtime.checkpoint_every) == 25
+    assert bool(cfg.runtime.trace_activations) is False
+    assert str(cfg.runtime.output_dir) == "outputs/cls_benchmark_sandwich_classification_evolution_v1"
+    assert str(cfg.logging.run_name) == "cls-benchmark-sandwich-classification-evolution-v1"
+    assert (
+        str(cfg.logging.history_jsonl_path)
+        == "outputs/cls_benchmark_sandwich_classification_evolution_v1/train_history.jsonl"
+    )
+
+
 def test_cls_benchmark_staged_resolution() -> None:
     cfg = _compose("experiment=cls_benchmark_staged")
     assert str(cfg.task) == "classification"

--- a/tests/model/test_tabfoundry_sandwich.py
+++ b/tests/model/test_tabfoundry_sandwich.py
@@ -85,6 +85,7 @@ def _batched_feature_types() -> list[list[str]]:
 
 def _model(
     *,
+    many_class_base: int = 4,
     sandwich_ff_expansion: int = 2,
     sandwich_summary_tokens_per_axis: int = 4,
     sandwich_self_attention_per_cross: int = 4,
@@ -92,7 +93,7 @@ def _model(
 ) -> TabFoundrySandwichClassifier:
     return TabFoundrySandwichClassifier(
         d_icl=32,
-        many_class_base=4,
+        many_class_base=many_class_base,
         head_hidden_dim=64,
         sandwich_latents=12,
         sandwich_layers=2,
@@ -604,22 +605,38 @@ def test_tabfoundry_sandwich_rejects_missing_task_member_feature_types() -> None
 
 
 def test_tabfoundry_sandwich_rejects_true_many_class_batches() -> None:
-    model = TabFoundrySandwichClassifier(
-        d_icl=32,
-        many_class_base=3,
-        head_hidden_dim=64,
-        sandwich_latents=12,
-        sandwich_layers=1,
-        sandwich_heads=4,
-        sandwich_ff_expansion=2,
-        sandwich_summary_tokens_per_axis=4,
-        sandwich_self_attention_per_cross=4,
-        sandwich_pre_row_attention_layers=1,
-        sandwich_pre_column_attention_layers=1,
+    model = _model(many_class_base=3)
+
+    with pytest.raises(RuntimeError, match="direct multiclass head"):
+        _ = model(_batch(num_classes=5))
+
+
+def test_tabfoundry_sandwich_accepts_five_class_batches_on_evolved_surface() -> None:
+    model = _model(
+        many_class_base=10,
+        sandwich_summary_tokens_per_axis=3,
+        feature_type_conditioning="film",
     )
 
-    with pytest.raises(RuntimeError, match="small-class only"):
-        _ = model(_batch(num_classes=5))
+    output = model(_batch(num_classes=5))
+
+    assert output.logits is not None
+    assert output.num_classes == 5
+    assert tuple(output.logits.shape) == (2, 10)
+
+
+def test_tabfoundry_sandwich_accepts_ten_class_batches_on_evolved_surface() -> None:
+    model = _model(
+        many_class_base=10,
+        sandwich_summary_tokens_per_axis=3,
+        feature_type_conditioning="film",
+    )
+
+    output = model(_batch(num_classes=10))
+
+    assert output.logits is not None
+    assert output.num_classes == 10
+    assert tuple(output.logits.shape) == (2, 10)
 
 
 def test_tabfoundry_sandwich_feature_type_film_changes_encoded_cells() -> None:

--- a/tests/research/test_tf_rd_010_classification_evolution_large_v1.py
+++ b/tests/research/test_tf_rd_010_classification_evolution_large_v1.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from tab_foundry.research.sweep.inspection_targets import inspect_sweep_row
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEP_ID = "tf_rd_010_classification_evolution_large_v1"
+EXPECTED_ROWS = [
+    "delta_data_manifest_root_tf_rd_010_dagzoo_medium_control",
+    "delta_data_manifest_root_tf_rd_010_missingness_mcar",
+    "delta_data_manifest_root_tf_rd_010_missingness_mar",
+    "delta_data_manifest_root_tf_rd_010_missingness_mnar",
+]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tf_rd_010_classification_evolution_large_v1_is_registered() -> None:
+    index = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml")
+
+    assert index["schema"] == "tab-foundry-system-delta-sweep-index-v2"
+    sweeps = index["sweeps"]
+    assert isinstance(sweeps, dict)
+    assert sweeps[SWEEP_ID] == {
+        "parent_sweep_id": "tf_rd_010_classification_evolution_medium_v1",
+        "status": "draft",
+        "anchor_run_id": None,
+        "complexity_level": "classification_lg",
+        "benchmark_manifest_path": "data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet",
+        "control_baseline_id": "cls_benchmark_linear_multiclass_large_v1",
+        "external_benchmarks": [],
+    }
+
+
+def test_tf_rd_010_classification_evolution_large_v1_records_the_draft_large_contract() -> None:
+    sweep_root = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+
+    assert sweep["sweep_id"] == SWEEP_ID
+    assert sweep["status"] == "draft"
+    assert sweep["anchor_run_id"] is None
+    assert sweep["training_experiment"] == "cls_benchmark_sandwich_classification_evolution_v1"
+    assert sweep["training_config_profile"] == "cls_benchmark_sandwich_classification_evolution_v1"
+    assert sweep["benchmark_manifest_path"] == (
+        "data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet"
+    )
+    assert sweep["control_baseline_id"] == "cls_benchmark_linear_multiclass_large_v1"
+    assert sweep["external_benchmarks"] == []
+
+    notes = sweep["anchor_surface"]["notes"]
+    assert isinstance(notes, list)
+    assert any("tab-realdata-hub" in note for note in notes)
+    assert any("allow-missing multiclass benchmark surface" in note for note in notes)
+    assert any("sandwich_summary_tokens_per_axis=3" in note for note in notes)
+    assert any("final_bpc_at_matched_regime_budget" in note for note in notes)
+    assert any("class imbalance" in note.lower() for note in notes)
+
+    anchor_model = sweep["anchor_context"]["model"]
+    assert anchor_model["arch"] == "tabfoundry_sandwich"
+    assert anchor_model["module_selection"] == {
+        "feature_encoder": "shared",
+        "feature_type_conditioning": "film",
+        "head": "direct_multiclass",
+        "target_conditioner": "label_token",
+        "tokenizer": "scalar_per_feature_missingness",
+    }
+
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
+    assert [row["status"] for row in rows] == [
+        "blocked_on_validation_manifests_and_control_baselines"
+    ] * len(EXPECTED_ROWS)
+    assert all(row["model"]["feature_type_conditioning"] == "film" for row in rows)
+    assert all(row["model"]["sandwich_summary_tokens_per_axis"] == 3 for row in rows)
+    assert all(row["model"]["many_class_base"] == 10 for row in rows)
+    assert all(row["training"]["surface_label"] == "prior_cosine_warmup" for row in rows)
+
+    materialized = load_system_delta_queue(
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+    assert materialized["anchor_run_id"] is None
+    assert materialized["benchmark_manifest_path"] == (
+        "data/manifests/bench/nanotabpfn_openml_classification_large_v1/manifest.parquet"
+    )
+    assert materialized["control_baseline_id"] == "cls_benchmark_linear_multiclass_large_v1"
+    assert [row["delta_id"] for row in materialized["rows"]] == EXPECTED_ROWS
+    assert all(row["model"].get("stage_label") is None for row in materialized["rows"])
+
+
+def test_tf_rd_010_classification_evolution_large_v1_matrix_links_dagzoo_and_hub() -> None:
+    matrix = (
+        REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "matrix.md"
+    ).read_text(encoding="utf-8")
+
+    assert "# System Delta Matrix" in matrix
+    assert SWEEP_ID in matrix
+    assert "Sweep status: `draft`" in matrix
+    assert "final_bpc_at_matched_regime_budget" in matrix
+    assert "tab-realdata-hub" in matrix
+    assert "dagzoo" in matrix
+    assert "sandwich_summary_tokens_per_axis=3" in matrix
+    assert "direct multiclass head" in matrix
+    assert "allow-missing" in matrix
+
+
+def test_tf_rd_010_classification_evolution_large_v1_inspection_resolves_sandwich_row() -> None:
+    payload = inspect_sweep_row(
+        sweep_id=SWEEP_ID,
+        order=1,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+
+    resolved_model = payload["target"]["resolved"]["model"]
+    assert resolved_model["arch"] == "tabfoundry_sandwich"
+    assert resolved_model.get("stage_label") is None

--- a/tests/research/test_tf_rd_010_classification_evolution_medium_v1.py
+++ b/tests/research/test_tf_rd_010_classification_evolution_medium_v1.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from tab_foundry.research.sweep.inspection_targets import inspect_sweep_row
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEP_ID = "tf_rd_010_classification_evolution_medium_v1"
+EXPECTED_ROWS = [
+    "delta_data_manifest_root_tf_rd_010_dagzoo_medium_control",
+    "delta_data_manifest_root_tf_rd_010_missingness_mcar",
+    "delta_data_manifest_root_tf_rd_010_missingness_mar",
+    "delta_data_manifest_root_tf_rd_010_missingness_mnar",
+]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tf_rd_010_classification_evolution_medium_v1_is_registered() -> None:
+    index = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml")
+
+    assert index["schema"] == "tab-foundry-system-delta-sweep-index-v2"
+    sweeps = index["sweeps"]
+    assert isinstance(sweeps, dict)
+    assert sweeps[SWEEP_ID] == {
+        "parent_sweep_id": "tf_rd_021b_sandwich_feature_removal_v1",
+        "status": "draft",
+        "anchor_run_id": None,
+        "complexity_level": "classification_md",
+        "benchmark_manifest_path": "data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet",
+        "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+        "external_benchmarks": [],
+    }
+
+
+def test_tf_rd_010_classification_evolution_medium_v1_records_the_draft_medium_contract() -> None:
+    sweep_root = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+
+    assert sweep["sweep_id"] == SWEEP_ID
+    assert sweep["status"] == "draft"
+    assert sweep["anchor_run_id"] is None
+    assert sweep["training_experiment"] == "cls_benchmark_sandwich_classification_evolution_v1"
+    assert sweep["training_config_profile"] == "cls_benchmark_sandwich_classification_evolution_v1"
+    assert sweep["benchmark_manifest_path"] == (
+        "data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet"
+    )
+    assert sweep["control_baseline_id"] == "cls_benchmark_linear_multiclass_medium_v1"
+    assert sweep["external_benchmarks"] == []
+
+    notes = sweep["anchor_surface"]["notes"]
+    assert isinstance(notes, list)
+    assert any("#178" in note for note in notes)
+    assert any("tab-realdata-hub" in note for note in notes)
+    assert any("sandwich_summary_tokens_per_axis=3" in note for note in notes)
+    assert any("final_bpc_at_matched_regime_budget" in note for note in notes)
+    assert any("class imbalance" in note.lower() for note in notes)
+    assert any("medium rung is the clean no-missing multiclass benchmark surface" in note for note in notes)
+
+    anchor_model = sweep["anchor_context"]["model"]
+    assert anchor_model["arch"] == "tabfoundry_sandwich"
+    assert anchor_model["module_selection"] == {
+        "feature_encoder": "shared",
+        "feature_type_conditioning": "film",
+        "head": "direct_multiclass",
+        "target_conditioner": "label_token",
+        "tokenizer": "scalar_per_feature_missingness",
+    }
+    assert sweep["anchor_context"]["surface_labels"] == {
+        "data": "tf_rd_010_dagzoo_medium_control",
+        "model": "tabfoundry_sandwich",
+        "preprocessing": "runtime_default",
+        "training": "prior_cosine_warmup",
+    }
+
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    assert [row["delta_ref"] for row in rows] == EXPECTED_ROWS
+    assert [row["status"] for row in rows] == [
+        "blocked_on_validation_manifests_and_control_baselines"
+    ] * len(EXPECTED_ROWS)
+    assert all(row["model"]["feature_type_conditioning"] == "film" for row in rows)
+    assert all(row["model"]["sandwich_summary_tokens_per_axis"] == 3 for row in rows)
+    assert all(row["model"]["many_class_base"] == 10 for row in rows)
+    assert all(row["training"]["surface_label"] == "prior_cosine_warmup" for row in rows)
+
+    materialized = load_system_delta_queue(
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+    assert materialized["anchor_run_id"] is None
+    assert materialized["benchmark_manifest_path"] == (
+        "data/manifests/bench/nanotabpfn_openml_classification_medium_v1/manifest.parquet"
+    )
+    assert materialized["control_baseline_id"] == "cls_benchmark_linear_multiclass_medium_v1"
+    assert [row["delta_id"] for row in materialized["rows"]] == EXPECTED_ROWS
+    assert all(row["model"].get("stage_label") is None for row in materialized["rows"])
+
+
+def test_tf_rd_010_classification_evolution_medium_v1_matrix_links_dagzoo_and_hub() -> None:
+    matrix = (
+        REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "matrix.md"
+    ).read_text(encoding="utf-8")
+
+    assert "# System Delta Matrix" in matrix
+    assert SWEEP_ID in matrix
+    assert "Sweep status: `draft`" in matrix
+    assert "final_bpc_at_matched_regime_budget" in matrix
+    assert "tab-realdata-hub" in matrix
+    assert "dagzoo" in matrix
+    assert "sandwich_summary_tokens_per_axis=3" in matrix
+    assert "direct multiclass head" in matrix
+    assert "class imbalance is addressed through explicit benchmark coverage and reporting" in matrix.lower()
+
+
+def test_tf_rd_010_classification_evolution_medium_v1_inspection_resolves_sandwich_row() -> None:
+    payload = inspect_sweep_row(
+        sweep_id=SWEEP_ID,
+        order=1,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+
+    resolved_model = payload["target"]["resolved"]["model"]
+    assert resolved_model["arch"] == "tabfoundry_sandwich"
+    assert resolved_model.get("stage_label") is None


### PR DESCRIPTION
## What changed

- add the evolved sandwich classification profile for TF-RD-010 with FiLM feature-type conditioning, `sandwich_summary_tokens_per_axis=3`, `many_class_base=10`, `training.loss_surface=cell_bpc`, and a direct multiclass head
- add draft medium and large TF-RD-010 sweep contracts plus new dagzoo training-front catalog deltas
- update roadmap and evidence docs to close TF-RD-016 on benchmark-definition plus modest head evolution and to make the `dagzoo -> tab-realdata-hub -> tab-foundry` contract explicit
- add research/config/model tests covering the new profile and sweep inspection path
- bump the package version to `0.15.2` and add a changelog entry

## Why

TF-RD-016 should end on an architectural evolution of the sandwich model and a new benchmark definition, not on another simplification-only carry-forward. TF-RD-010 now becomes the active program for medium and large multiclass validation, with real-data manifests owned upstream in `tab-realdata-hub`.

## Impact

- `tabfoundry_sandwich` now supports the evolved direct-multiclass benchmark surface without the old small-class-only framing
- the repo now has draft TF-RD-010 sweep packages ready for medium and large multiclass validation once upstream hub manifests and multiclass control baselines are frozen
- GitHub issue tracking is aligned with the new execution order and upstream dependency

## Validation

- `.venv/bin/pytest tests/config/test_experiment_resolution.py tests/model/test_tabfoundry_sandwich.py tests/research/test_tf_rd_010_classification_evolution_medium_v1.py tests/research/test_tf_rd_010_classification_evolution_large_v1.py`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_medium_v1 --order 1`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_medium_v1 --order 2`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_medium_v1 --order 3`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_medium_v1 --order 4`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_large_v1 --order 1`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_large_v1 --order 2`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_large_v1 --order 3`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_010_classification_evolution_large_v1 --order 4`
- `./scripts/dev verify paths configs/experiment/cls_benchmark_sandwich_classification_evolution_v1.yaml docs/development/roadmap.md reference/evidence.md reference/roadmap_evidence/README.md reference/roadmap_evidence/tf_rd_010_many_class_promotion.md reference/roadmap_evidence/tf_rd_016_architecture_surface_adequacy.md reference/system_delta_catalog.yaml reference/system_delta_sweeps/index.yaml reference/system_delta_sweeps/tf_rd_010_classification_evolution_medium_v1 reference/system_delta_sweeps/tf_rd_010_classification_evolution_large_v1 src/tab_foundry/model/architectures/tabfoundry_sandwich/model.py src/tab_foundry/model/components/tabular_primitives.py tests/config/test_experiment_resolution.py tests/model/test_tabfoundry_sandwich.py tests/research/test_tf_rd_010_classification_evolution_medium_v1.py tests/research/test_tf_rd_010_classification_evolution_large_v1.py`

## Issue linkage

- closes out the already-updated TF-RD-016 umbrella: #178
- advances the active TF-RD-010 umbrella: #52
- advances the first TF-RD-010 execution issue: #99
- depends on upstream validation-data work: bensonlee5/tab-realdata-hub#1