### PR TITLE
Fix stale docs deploy repo overview check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,7 +115,7 @@ jobs:
               ),
               (
                   f"{SITE_URL}/docs/",
-                  ("Start Here", "/docs/repo-overview/"),
+                  ("Start Here", "/docs/getting-started/repo-overview/"),
                   ("Jekyll v3.10.0",),
               ),
               (


### PR DESCRIPTION
## Summary
- update the Pages post-deploy verifier to look for the current Repo Overview route on `/docs/`
- keep the fix scoped to the workflow check only

## Root cause
The docs landing page links to `/docs/getting-started/repo-overview/`, but the deploy verifier was still asserting the older `/docs/repo-overview/` token. That made the `deploy` job fail even though the live site content was correct.

## Verification
- confirmed the failing run was `docs` on push to `main`: https://github.com/bensonlee5/tab-foundry/actions/runs/23861541914
- fetched the live `/docs/` page and verified it already contains `/docs/getting-started/repo-overview/`
