### PR TITLE
docs: reorder post-TF-RD-010 roadmap sequencing

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -106,12 +106,15 @@ Important non-goals for this roadmap:
   TF-RD-016 closes on the modest sandwich evolution and benchmark-definition
   handoff; TF-RD-010 then freezes the first medium and large classification
   validation program, with `dagzoo` synthetic training fronts feeding
-  `tab-realdata-hub` materialized manifests; TF-RD-017 class-imbalance work
-  proceeds as a side robustness lane on the same family; TF-RD-021 then tests
-  whether steering-derived dagzoo corpus fronts improve that benchmark-defined
-  slice; TF-RD-022 performs the kernel, runtime, and VRAM tuning needed for
-  reliable scaling on the kept front; TF-RD-009 then fits the first scaling law
-  on that carried classification slice.
+  `tab-realdata-hub` materialized manifests; TF-RD-021 then expands the
+  admissible dagzoo candidate surface through RD-002 and RD-005, freezes one
+  evaluation-ready synthetic candidate set, and runs one bounded keep/defer
+  carry-forward sweep on that benchmark-defined slice; TF-RD-022 performs the
+  kernel, runtime, and VRAM tuning needed for reliable scaling on the kept
+  front; TF-RD-009 then writes the scaling-law design note and fits the first
+  scaling law on that carried classification slice; TF-RD-014 remains the
+  next follow-on missingness lane, while TF-RD-017 moves to later imbalance
+  work outside the current critical path.
 - Low-level questions such as norm family or placement, learned special-token
   initialization scale, QASS scaler capacity, and activation family belong
   under TF-RD-016 after the earlier adequacy and harder-surface gates are in
@@ -134,10 +137,10 @@ summarized later instead of occupying the active queue.
 | Rank | Roadmap ID | Item | Status | Milestone |
 | ---- | ---------- | ---- | ------ | --------- |
 | 1 | TF-RD-021 | Steering-derived dagzoo corpus fronts on the classification-first sandwich target | planned | Next |
-| 2 | TF-RD-017 | Class-imbalance robustness on the classification-first sandwich target | planned | Next |
-| 3 | TF-RD-022 | Training runtime and VRAM efficiency before classification scaling | planned | Next |
-| 4 | TF-RD-009 | Scaling-law design and measurement on the classification-first sandwich target | planned | Next |
-| 5 | TF-RD-014 | Missingness robustness on the classification-first sandwich target | planned | Next |
+| 2 | TF-RD-022 | Training runtime and VRAM efficiency before classification scaling | planned | Next |
+| 3 | TF-RD-009 | Scaling-law design and measurement on the classification-first sandwich target | planned | Next |
+| 4 | TF-RD-014 | Missingness robustness on the classification-first sandwich target | planned | Next |
+| 5 | TF-RD-017 | Class-imbalance robustness on the classification-first sandwich target | planned | Later |
 | 6 | TF-RD-015 | Regression rebuild deferred from the classification-first scaling plan | research | Later |
 | 7 | TF-RD-012 | Inference handoff and later modalities | research | Later |
 
@@ -149,7 +152,9 @@ flowchart TD
     RD016["TF-RD-016 / TF-RD-021B<br/>Freeze simplified<br/>sandwich parent"]
     DAG["Carry frozen sandwich<br/>parent onto dagzoo"]
     RD010["TF-RD-010<br/>Many-class + missingness<br/>dagzoo gate"]
-    RD021["TF-RD-021<br/>Steering-derived<br/>corpus fronts"]
+    DZ002["dagzoo RD-002<br/>Interventional + counterfactual<br/>generation expansion"]
+    DZ005["dagzoo RD-005<br/>Robustness stress profiles<br/>and carried regimes"]
+    RD021["TF-RD-021<br/>Phase 1 freeze + Phase 2<br/>carry-forward decision"]
     RD017["TF-RD-017<br/>Class-imbalance<br/>side lane"]
     RD022["TF-RD-022<br/>Kernel/runtime & VRAM<br/>pre-scaling gate"]
     RD014["TF-RD-014<br/>Missingness<br/>follow-up"]
@@ -160,6 +165,10 @@ flowchart TD
     HIST --> RD016
     RD016 --> DAG
     DAG --> RD010
+    RD010 --> DZ002
+    RD010 --> DZ005
+    DZ002 --> RD021
+    DZ005 --> RD021
     RD010 --> RD021
     RD010 --> RD014
     RD010 --> RD017
@@ -176,11 +185,11 @@ flowchart TD
 
     class HIST hist;
     class RD010,RD016 done;
-    class RD009,RD021,RD022,RD014,RD017 readyNow;
-    class RD012,RD015 later;
+    class DZ002,DZ005,RD021,RD022,RD009,RD014 readyNow;
+    class RD012,RD015,RD017 later;
 ```
 
-Current path: **TF-RD-010 synthetic adequacy gate → TF-RD-021 → TF-RD-022 → TF-RD-009**.
+Current path: **TF-RD-010 synthetic adequacy gate → TF-RD-021 phase 1 (RD-002 + RD-005 dagzoo expansion) → TF-RD-021 phase 2 (bounded carry-forward decision) → TF-RD-022 → TF-RD-009**.
 
 - TF-RD-016 is now completed historical context: issue
   [#178](https://github.com/bensonlee5/tab-foundry/issues/178) closes on the
@@ -221,22 +230,26 @@ Current path: **TF-RD-010 synthetic adequacy gate → TF-RD-021 → TF-RD-022 �
   label-target log loss per test cell. The older `cell_bpc` / BPC lane is
   preserved only for historical reruns while calibration, runtime, and
   stability remain guardrails on the active CE-based path.
-- TF-RD-021 then decides whether any steering-derived dagzoo corpus front
-  replaces the carried sandwich dagzoo training front before runtime/kernel
-  tuning.
-- TF-RD-022 is the next hard pre-scaling gate after steering: it must hand back
-  one measured kernel/runtime policy before broader scaling fits.
-- TF-RD-009 only starts after those gates are closed and fits the first law on
-  that carried multiclass slice under matched regime budget.
+- TF-RD-021 is now a two-phase synthetic-data lane: it first freezes the
+  admissible post-RD-002/RD-005 dagzoo candidate surface and metadata
+  contract, then runs one bounded keep/defer sweep to decide whether any
+  expanded dagzoo corpus front replaces the carried sandwich training slice
+  before runtime/kernel tuning.
+- TF-RD-022 is the next hard pre-scaling gate after that carry-forward
+  decision: it must hand back one measured kernel/runtime policy before
+  broader scaling fits.
+- TF-RD-009 only starts after the TF-RD-021 carry-forward decision and the
+  TF-RD-022 runtime-policy freeze are closed, and fits the first law on that
+  carried multiclass slice under matched regime budget.
 
 Parallel/later lanes are intentionally off that main path:
 
 - TF-RD-014 is now a follow-on missingness robustness lane after the first
   many-class plus missingness gate rather than a blocker to the first scaling
   fit.
-- TF-RD-017 is the preferred side robustness lane during the many-class plus
-  missingness push now that TF-RD-010 has fixed the first carried contract,
-  but it is still not a blocker for the first scaling fit.
+- TF-RD-017 remains a later imbalance robustness lane on the same family, but
+  it is now explicitly off the current TF-RD-021 → TF-RD-022 → TF-RD-009
+  critical path.
 - TF-RD-015 regression and TF-RD-012 inference handoff/later modalities remain
   later work.
 
@@ -246,12 +259,12 @@ Parallel/later lanes are intentionally off that main path:
 | --- | --- | --- | --- | --- |
 | Frozen PFN-style control exists | `implemented` | `tabfoundry_simple`, `stage=nano_exact`, and the prior-trained PFN-facing benchmark lane are all stable | Keep that lane clearly separate from the architecture target | `TF-RD-001` |
 | Sandwich is the primary classification candidate | `implemented` | `tabfoundry_sandwich` is landed, the compact hybrid replay is benchmarked, the first knob screen plus bounded width/head follow-up both kept the compact control, the completed removal-first package under [#184](https://github.com/bensonlee5/tab-foundry/issues/184) retained that anchor, and TF-RD-016 now closes on a bounded direct-multiclass head evolution | Judge the evolved sandwich family on the TF-RD-010 benchmark program rather than reopening simplification-first work | `TF-RD-016`, `TF-RD-021A`, `TF-RD-021B`, `TF-RD-010` |
-| Harder synthetic classification fronts are runnable | `implemented` | Dagzoo manifest/export fidelity is complete, TF-RD-013 settled the representative medium surface, and TF-RD-020 settled harder-front winners that can seed the new sandwich benchmark program | Freeze the benchmark-defined dagzoo training fronts, then choose whether steering improves that first carried slice | `TF-RD-011`, `TF-RD-013`, `TF-RD-020`, `TF-RD-016`, `TF-RD-010`, `TF-RD-021` |
+| Harder synthetic classification fronts are runnable | `implemented` | Dagzoo manifest/export fidelity is complete, TF-RD-013 settled the representative medium surface, TF-RD-020 settled harder-front winners that can seed the sandwich benchmark program, and dagzoo epics [#249](https://github.com/bensonlee5/dagzoo/issues/249) and [#247](https://github.com/bensonlee5/dagzoo/issues/247) define the next surface-expansion work | Freeze the admissible post-RD-002/RD-005 dagzoo candidate surface, then choose whether the expanded front improves the first carried slice | `TF-RD-011`, `TF-RD-013`, `TF-RD-020`, `TF-RD-016`, `TF-RD-010`, `TF-RD-021` |
 | Runtime and VRAM are measurable | `partial` | Training and registry artifacts now preserve runtime-summary and regime-budget fields, and the repo already has bf16/checkpointing-capable runtime plumbing | TF-RD-022 still needs to turn that into one explicit 80 GB A100-safe kernel/runtime policy on the carried sandwich dagzoo slice | `TF-RD-022` |
 | Benchmark-backed classification validation contract is fixed, `medium_v4` completed the directional medium package, and `medium_v5` now stages the matched sorted-control follow-up | `partial` | `many_class` is implemented, the sandwich evolution config fixes FiLM plus `sandwich_summary_tokens_per_axis=3`, `tab-realdata-hub` issue [#1](https://github.com/bensonlee5/tab-realdata-hub/issues/1) owns the medium and large validation manifests under `min_classes=2`, `max_classes=10`, and `max_missing_pct=20.0`, TF-RD-010 child issues [#197](https://github.com/bensonlee5/tab-foundry/issues/197), [#198](https://github.com/bensonlee5/tab-foundry/issues/198), [#199](https://github.com/bensonlee5/tab-foundry/issues/199), and [#200](https://github.com/bensonlee5/tab-foundry/issues/200) froze the missing baselines plus corpora, `medium_v4` now records a kept medium control anchor plus exploratory MCAR, MAR, and MNAR defer rows, `medium_v5` is registered as the single-row sorted-control successor, and successor issues [#202](https://github.com/bensonlee5/tab-foundry/issues/202), [#205](https://github.com/bensonlee5/tab-foundry/issues/205), [#203](https://github.com/bensonlee5/tab-foundry/issues/203), and [#204](https://github.com/bensonlee5/tab-foundry/issues/204) track the remaining follow-on path | The medium missingness read is still directional until `medium_v5` row 1 executes and is compared against `medium_v4` rows 2 through 4, so TF-RD-010 still lacks promoted sorted-control evidence before any missingness recommendation or reopening `large_v2`. The canonical metric key remains `final_log_loss_at_matched_regime_budget`, interpreted as label-target log loss per test cell | `TF-RD-010`, `TF-RD-021`, `TF-RD-014`, `TF-RD-017` |
-| Follow-on missingness and imbalance robustness remain open | `partial` | Missing-permitting binary bundles exist, and the current bundle policy already excludes degenerate minority-class cases | TF-RD-014 remains later missingness follow-up, while TF-RD-017 still needs an explicit side-lane imbalance ladder on the same sandwich family | `TF-RD-014`, `TF-RD-017` |
+| Follow-on missingness and imbalance robustness remain open | `partial` | Missing-permitting binary bundles exist, and the current bundle policy already excludes degenerate minority-class cases | TF-RD-014 remains the next follow-on missingness lane after the first scaling pass, while TF-RD-017 still needs an explicit later imbalance ladder on the same sandwich family | `TF-RD-014`, `TF-RD-017` |
 | Regression and later modalities are deferred | `research` | Partial bundle/runtime scaffolding exists | They should not absorb attention from the classification-first path | `TF-RD-015`, `TF-RD-012` |
-| Scaling-law work has the needed metadata path | `planned` | Artifacts now preserve resolved sandwich specs plus runtime/regime-budget metadata, and TF-RD-010 has fixed the first benchmark-defined classification contract | TF-RD-009 now waits on the TF-RD-010 trusted rerun, the TF-RD-021 steering decision, and the TF-RD-022 runtime gate on that contract | `TF-RD-009`, `TF-RD-010`, `TF-RD-021`, `TF-RD-022` |
+| Scaling-law work has the needed metadata path | `planned` | Artifacts now preserve resolved sandwich specs plus runtime/regime-budget metadata, and TF-RD-010 has fixed the first benchmark-defined classification contract | TF-RD-009 now waits on the TF-RD-010 trusted rerun, the two-phase TF-RD-021 carry-forward decision, and the TF-RD-022 runtime gate on that contract | `TF-RD-009`, `TF-RD-010`, `TF-RD-021`, `TF-RD-022` |
 
 ## Current Implementation Baseline
 
@@ -422,8 +435,8 @@ Legacy wording note:
 
 - Status: `planned`
 - Milestone: `Next`
-- Goal: deepen missingness robustness after the first many-class plus
-  missingness gate is established on the carried sandwich family
+- Goal: deepen missingness robustness after the first scaling pass has landed
+  on the carried sandwich family
 - Current state:
   - `missingness_followup` exists, but it is anchored on the older stabilized
     prenorm hybrid surface rather than the carried sandwich family
@@ -440,6 +453,9 @@ Legacy wording note:
 - Required work:
   - re-anchor missingness work on the carried sandwich family after the carried
     many-class plus missingness slice is established under TF-RD-010
+  - keep this lane off the immediate TF-RD-021 -> TF-RD-022 -> TF-RD-009 path
+    so it can inherit the first kept synthetic slice and runtime policy rather
+    than compete with the first scaling pass
   - keep one pinned OpenML missingness ladder as the canonical benchmark
     baseline and allow license-cleared manifest-backed external augmentations
     when they add missingness regimes OpenML does not cover cleanly
@@ -460,20 +476,22 @@ Legacy wording note:
 ### TF-RD-017: Class-Imbalance Robustness On The Classification-First Sandwich Target
 
 - Status: `planned`
-- Milestone: `Next`
+- Milestone: `Later`
 - Goal: decide how the carried sandwich family behaves under materially
   skewed class priors
 - Current state:
   - current benchmark bundles only enforce `min_minority_class_pct = 2.5`
   - there is no dedicated imbalance-focused bundle ladder yet
-  - this is now the preferred side robustness lane once TF-RD-010 has
-    established the first sandwich many-class plus missingness dagzoo slice
+  - this now remains a later robustness lane once TF-RD-010 has established
+    the first sandwich many-class plus missingness dagzoo slice
   - issue [#146](https://github.com/bensonlee5/tab-foundry/issues/146) now
     occupies the adjacent synthetic harder-dagzoo slot and does not replace
     this benchmark-front imbalance lane
   - benchmark-facing reporting is still centered on ROC AUC, log loss, and
     Brier score
 - Required work:
+  - keep this lane explicitly behind TF-RD-021, TF-RD-022, and TF-RD-009 so
+    the first scaling pass lands before imbalance-specific follow-up work
   - define the canonical imbalance-focused binary bundle or bundle-selection
     ladder on the carried sandwich family
   - keep one pinned OpenML imbalance ladder as the canonical benchmark
@@ -566,8 +584,9 @@ Legacy wording note:
     `runtime.trace_activations: true`, which is useful for diagnostics but is
     not yet separated cleanly from ordinary benchmark execution
 - this epic now follows the first carried dagzoo many-class slice and the
-  steering decision; it should not reopen sandwich-parent selection or earlier
-  regime-choice work
+  full TF-RD-021 carry-forward decision, including the upstream dagzoo
+  expansion under RD-002 and RD-005; it should not reopen sandwich-parent
+  selection or earlier regime-choice work
 - Required work:
   - land the runtime and VRAM measurement dependency from issue
     [#58](https://github.com/bensonlee5/tab-foundry/issues/58) so sweep and
@@ -594,7 +613,7 @@ Legacy wording note:
     under issue [#171](https://github.com/bensonlee5/tab-foundry/issues/171)
     with a conservative 80 GB A100 memory guardrail and a fixed effective
     optimizer batch
-  - keep architecture, steering/curriculum choice, and law-fitting changes out
+  - keep architecture, synthetic-surface choice, and law-fitting changes out
     of this epic except insofar as TF-RD-016, TF-RD-010, and TF-RD-021 have
     already frozen them for the runtime read
 - Exit criteria:
@@ -640,8 +659,9 @@ Legacy wording note:
 - Status: `planned`
 - Milestone: `Next`
 - Goal: after the first sandwich dagzoo many-class plus missingness gate is in
-  place, test whether steering-derived dagzoo corpus fronts improve that
-  carried slice before runtime or scaling work
+  place, expand the admissible dagzoo candidate surface through RD-002 and
+  RD-005, then test whether one frozen post-expansion corpus front improves
+  the carried slice before runtime or scaling work
 - Current state:
   - issue [#165](https://github.com/bensonlee5/tab-foundry/issues/165) is the
     successor synthetic-data epic after the first carried sandwich dagzoo
@@ -649,30 +669,40 @@ Legacy wording note:
   - TF-RD-020 already records the historical staged-control harder-front
     winners, while TF-RD-010 now records the fixed first sandwich benchmark
     contract with trusted execution still pending
-  - dagzoo issue
-    [#246](https://github.com/bensonlee5/dagzoo/issues/246) now owns the
-    upstream steering implementation, deterministic metadata, and
-    coverage-movement diagnostics
+  - completed dagzoo issue
+    [#246](https://github.com/bensonlee5/dagzoo/issues/246) remains historical
+    steering context, while dagzoo epics
+    [#249](https://github.com/bensonlee5/dagzoo/issues/249) and
+    [#247](https://github.com/bensonlee5/dagzoo/issues/247) now define the
+    upstream surface expansion that TF-RD-021 will inherit
 - Required work:
-  - reuse the TF-RD-010 carried sandwich many-class plus missingness contract
-    once the trusted rerun lands, and wait for dagzoo RD-008 to land enough of
-    issue `#246` to make steering fixed-seed reproducible and auditable
-  - define one bounded first sweep under issue
-    [#167](https://github.com/bensonlee5/tab-foundry/issues/167): one control
-    row on the carried sandwich dagzoo slice plus `3-4` steering-derived
-    corpus rows produced from named steering policies or presets
+  - phase 1: reuse the TF-RD-010 carried sandwich many-class plus missingness
+    contract once the trusted rerun lands, then wait for dagzoo RD-002 and
+    RD-005 under issues
+    [#249](https://github.com/bensonlee5/dagzoo/issues/249) and
+    [#247](https://github.com/bensonlee5/dagzoo/issues/247) to expand the
+    admissible candidate surface and metadata contract
+  - phase 1: freeze one evaluation-ready post-RD-002/RD-005 dagzoo candidate
+    set under a dedicated child of issue
+    [#165](https://github.com/bensonlee5/tab-foundry/issues/165), including
+    named presets, regime identifiers, and the compact metadata needed for
+    matched-regime-budget comparisons
+  - phase 2: run one bounded carry-forward sweep under issue
+    [#167](https://github.com/bensonlee5/tab-foundry/issues/167) on that
+    frozen candidate set: one incumbent control row on the carried sandwich
+    dagzoo slice plus a small set of named post-RD-002/RD-005 corpus rows
   - hold architecture, many-class plus missingness regime definition, and
     benchmark contract fixed across every row
   - interpret `final_log_loss_at_matched_regime_budget` first, with
     calibration, runtime, clipped-step fraction, and stability telemetry as
     guardrails
-  - keep exactly one steering-derived carry-forward surface only if it clearly
+  - keep exactly one expanded dagzoo carry-forward surface only if it clearly
     beats the incumbent control; otherwise keep the original carried slice
   - keep this epic synthetic-data-only rather than absorbing imbalance,
     runtime-kernel, or scaling-law conclusions
 - Exit criteria:
-  - the repo has one explicit keep/defer decision on whether any
-    steering-derived corpus front replaces the carried sandwich dagzoo slice
+  - the repo has one explicit keep/defer decision on whether any frozen
+    post-RD-002/RD-005 corpus front replaces the carried sandwich dagzoo slice
   - the relationship between TF-RD-021 and TF-RD-010, TF-RD-017, TF-RD-022,
     and TF-RD-009 is explicit and non-overlapping
 
@@ -747,8 +777,8 @@ Legacy wording note:
 - Milestone: `Next`
 - Goal: fit the first classification scaling laws on the simplified sandwich
   family only after the repo has one fixed dagzoo many-class plus missingness
-  slice, one steering decision, one runtime policy, and a literature-grounded
-  law-design note
+  slice, one TF-RD-021 carry-forward decision, one runtime policy, and a
+  literature-grounded law-design note
 - Current state:
   - tuning and benchmark-adjacent tooling already exist
   - scaling-law intent is clear, but scaling on the current simple binary regime
@@ -776,8 +806,8 @@ Legacy wording note:
     matched regime budget using token budget, unique-task budget, fixed
     curriculum or SCM-mixture slice, and fixed task-complexity band
   - reuse the TF-RD-010 benchmark contract after the trusted rerun lands, then
-    finish the steering decision under TF-RD-021 and the runtime policy under
-    TF-RD-022 before using scaling results as architecture evidence
+    finish the two-phase TF-RD-021 carry-forward decision and the TF-RD-022
+    runtime policy before using scaling results as architecture evidence
   - keep the other sandwich knobs frozen at the retained compact hybrid anchor
     values while fitting the first width-depth classification laws
   - use `final_log_loss_at_matched_regime_budget` as the primary ranking

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -50,6 +50,9 @@ This is the canonical long-form evidence note for
   pre-scaling step for the family, but it does not satisfy TF-RD-009 by itself
 - the first scaling target is now a fixed dagzoo many-class plus missingness
   slice rather than the earlier binary-only regime
+- TF-RD-021 now supplies that slice through a two-phase lane: freeze the
+  admissible post-RD-002/RD-005 dagzoo candidate surface first, then make one
+  bounded carry-forward decision before runtime or scaling work
 - regression is explicitly deferred from the first scaling program and is not a
   blocker for the first classification law fit
 
@@ -100,8 +103,8 @@ This is the canonical long-form evidence note for
   on the same simplified sandwich trunk
 - the runtime policy is not yet finalized as a hard inherited precondition for
   the scaling ladder
-- the steering-derived corpus-front keep/defer decision is not yet finalized on
-  the carried dagzoo slice
+- the TF-RD-021 carry-forward keep/defer decision is not yet finalized on the carried
+  post-RD-002/RD-005 dagzoo slice
 - sweep/result summaries still need compact presentation of the new
   runtime-summary and regime-budget fields
 

--- a/reference/roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md
+++ b/reference/roadmap_evidence/tf_rd_021_steering_derived_dagzoo_corpus_fronts.md
@@ -7,8 +7,9 @@ This is the canonical long-form evidence note for
 - Milestone: `Next`
 - Dependency position: follows the first carried many-class plus missingness
   dagzoo slice under [TF-RD-010](tf_rd_010_many_class_promotion.md), depends on
-  dagzoo RD-008 steering landing under
-  [bensonlee5/dagzoo#246](https://github.com/bensonlee5/dagzoo/issues/246),
+  dagzoo RD-002 and RD-005 expansion landing under
+  [bensonlee5/dagzoo#249](https://github.com/bensonlee5/dagzoo/issues/249)
+  and [bensonlee5/dagzoo#247](https://github.com/bensonlee5/dagzoo/issues/247),
   and runs before later kernel/runtime tuning under
   [TF-RD-022](tf_rd_022_training_runtime_vram_efficiency.md)
 
@@ -32,43 +33,51 @@ This is the canonical long-form evidence note for
   staged-control harder-front winners that now serve as historical dagzoo
   context rather than the active sandwich carried slice
 - TF-RD-010 now owns the first explicit carried sandwich dagzoo many-class plus
-  missingness slice that steering will attempt to improve
-- Dagzoo issue
+  missingness slice that TF-RD-021 will attempt to improve
+- Completed dagzoo issue
   [bensonlee5/dagzoo#246](https://github.com/bensonlee5/dagzoo/issues/246)
-  plus its child chain now define the upstream steering implementation,
-  deterministic policy metadata, and coverage-movement diagnostics
+  remains historical steering context
+- Dagzoo issues
+  [bensonlee5/dagzoo#249](https://github.com/bensonlee5/dagzoo/issues/249)
+  and [bensonlee5/dagzoo#247](https://github.com/bensonlee5/dagzoo/issues/247)
+  now define the upstream expansion of admissible synthetic surfaces and
+  metadata that TF-RD-021 phase 1 must freeze for evaluation
 - Tab-foundry now tracks the local steering-derived continuation under
-  [#165](https://github.com/bensonlee5/tab-foundry/issues/165), with first
-  sweep contract issue
+  [#165](https://github.com/bensonlee5/tab-foundry/issues/165), with one phase
+  1 candidate-freeze child and phase 2 sweep contract issue
   [#167](https://github.com/bensonlee5/tab-foundry/issues/167)
 
 ## Current Interpretation
 
 - Treat TF-RD-020 as settled historical harder-front evidence rather than the
   place to reopen curriculum-steered corpora
-- Keep the first steering-derived read small and explicit: one control row on
-  the carried sandwich dagzoo slice plus `3-4` steering-derived corpus rows
-  from named steering policies or presets
+- Treat TF-RD-021 as a two-phase lane:
+  - phase 1 freezes the admissible post-RD-002/RD-005 dagzoo candidate surface
+    and metadata contract for matched-regime-budget evaluation
+  - phase 2 runs one bounded carry-forward read: one control row on the
+    carried sandwich dagzoo slice plus a small set of named post-RD-002/RD-005
+    corpus rows
 - Interpret rows by multiclass log loss first, with runtime, clipped-step
   fraction, and stability telemetry as guardrails
-- Keep exactly one steering-derived carry-forward surface only if it clearly
-  beats the incumbent control; otherwise retain the original carried slice
-- Feed the kept steering decision into TF-RD-022 and TF-RD-009 rather than
-  reopening TF-RD-010 or TF-RD-018
+- Keep exactly one carry-forward surface only if it clearly beats the
+  incumbent control; otherwise retain the original carried slice
+- Feed the kept carry-forward decision into TF-RD-022 and TF-RD-009 rather
+  than reopening TF-RD-010 or TF-RD-018
 
 ## Open Evidence Gaps
 
 - The repo does not yet have curated external literature specific to
   meta-feature coverage steering as a synthetic harder-front continuation
-- There is no first steering-derived sweep matrix or result package yet in
-  tab-foundry
-- The repo still needs a practical stop rule for how much steering movement and
-  metric gain counts as a genuinely new carry-forward surface rather than a
-  noisy variant of the incumbent carried control slice
+- There is no phase 1 candidate-freeze package or phase 2 carry-forward sweep
+  result package yet in tab-foundry
+- The repo still needs a practical stop rule for how much post-RD-002/RD-005
+  surface movement and metric gain counts as a genuinely new carry-forward
+  surface rather than a noisy variant of the incumbent carried control slice
 
 ## Exit Signals
 
-- The repo has one explicit keep/defer decision on whether any steering-derived
-  corpus front replaces the incumbent carried sandwich control slice
+- The repo has one explicit keep/defer decision on whether any frozen
+  post-RD-002/RD-005 corpus front replaces the incumbent carried sandwich
+  control slice
 - TF-RD-022 can inherit a documented synthetic carry-forward decision without
   reopening TF-RD-010 or blurring the completed TF-RD-020 ladder

--- a/reference/roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md
+++ b/reference/roadmap_evidence/tf_rd_022_training_runtime_vram_efficiency.md
@@ -6,7 +6,7 @@ This is the canonical long-form evidence note for
 - Status: `planned`
 - Milestone: `Next`
 - Dependency position: runs after the first carried sandwich dagzoo many-class
-  slice and the steering-derived corpus decision are explicit, and before
+  slice and the full TF-RD-021 carry-forward decision are explicit, and before
   TF-RD-009 scaling fits; it should not reopen sandwich-parent or regime-choice
   work, but it should hand one explicit kernel/runtime policy back to later
   scaling work
@@ -66,8 +66,8 @@ This is the canonical long-form evidence note for
   and measurable before chasing larger architecture or optimizer changes for
   speed
 - the runtime ladder should stay classification-only and should inherit one
-  frozen carried recipe rather than reopening sandwich-parent selection,
-  steering, or law design
+  frozen carried recipe rather than reopening sandwich-parent selection, the
+  upstream dagzoo surface expansion, or law design
 - the bounded runtime knobs remain:
   - `bf16`
   - benchmark-facing activation-trace policy


### PR DESCRIPTION
## Summary
- reorder the post-TF-RD-010 roadmap to make the critical path `TF-RD-021 phase 1 -> TF-RD-021 phase 2 -> TF-RD-022 -> TF-RD-009`
- move TF-RD-017 out of the active critical path and keep TF-RD-014 as the next follow-on lane
- update the supporting roadmap evidence notes and refresh the issue tree for TF-RD-021, TF-RD-022, and TF-RD-009

## GitHub alignment
- updates TF-RD-021 umbrella and phase split in #165, #167, and #228
- updates TF-RD-022 runtime gate wording in #168
- updates TF-RD-009 umbrella and sweep dependencies in #51, #140, and #229
- cross-links downstream dagzoo dependencies in bensonlee5/dagzoo#249 and bensonlee5/dagzoo#247

## Verification
- commit hooks passed during `git commit`
- repo-local `./scripts/dev verify paths ...` could not run in this worktree because `.venv/bin/python` is missing
