### PR TITLE
Add checkpoint artifact recovery and live sandwich export support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ site/site/
 # Runtime outputs / generated data
 /data/
 /outputs/
+/.artifacts/
 /wandb/
 benchmarks/results/
 *.parquet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- User-facing note: benchmark run registration now persists optional W&B run
+  identity plus a versioned remote checkpoint artifact ref in the benchmark run
+  registry, and new `tab-foundry dev checkpoint-publish` /
+  `tab-foundry dev checkpoint-resolve` commands now backfill and recover those
+  best-checkpoint artifacts through W&B when local registry paths are missing.
+- User-facing note: export bundles now preserve the full live sandwich contract
+  needed by the TF-RD-009 `d_icl=96` candidate, including
+  `feature_type_conditioning`, likelihood settings, and sandwich summary / pre-
+  attention fields, and compiled `_orig_mod.*` checkpoint keys now normalize on
+  the canonical export path instead of requiring downstream compatibility shims.
+
 ## [0.16.12] - 2026-04-09
 
 ### Changed

--- a/docs/development/module-dependency-map.md
+++ b/docs/development/module-dependency-map.md
@@ -16,6 +16,7 @@ section factual and keep design intent in the policy section below it.
   `tab_foundry.control_baseline_registry`, `tab_foundry.data`,
   `tab_foundry.device`, `tab_foundry.external_benchmarks`,
   `tab_foundry.benchmark_registry`,
+  `tab_foundry.checkpoint_state`,
   `tab_foundry.input_normalization`, `tab_foundry.model`,
   `tab_foundry.preprocessing`, `tab_foundry.registry`,
   `tab_foundry.repo_paths`, `tab_foundry.task_batching`,
@@ -41,7 +42,8 @@ section factual and keep design intent in the policy section below it.
   `tab_foundry.preprocessing`, `tab_foundry.repo_paths`,
   `tab_foundry.task_batching`, `tab_foundry.timestamps`, and
   `tab_foundry.types`.
-- `tab_foundry.export` depends on `tab_foundry.feature_types`,
+- `tab_foundry.export` depends on `tab_foundry.checkpoint_state`,
+  `tab_foundry.feature_types`,
   `tab_foundry.hashing`, `tab_foundry.model`, `tab_foundry.preprocessing`,
   `tab_foundry.repo_paths`, and `tab_foundry.types`.
 - `tab_foundry.model` depends on `tab_foundry.feature_types`,
@@ -76,6 +78,7 @@ Observed cycle status:
 - `tab_foundry.config`, `tab_foundry.repo_paths`,
   `tab_foundry.device`, `tab_foundry.registry`,
   `tab_foundry.benchmark_registry`,
+  `tab_foundry.checkpoint_state`,
   `tab_foundry.control_baseline_registry`,
   `tab_foundry.external_benchmarks`, `tab_foundry.hashing`,
   `tab_foundry.types`, `tab_foundry.input_normalization`,

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -57,6 +57,8 @@ tab-foundry dev forward-check experiment=cls_smoke
 tab-foundry dev diff-config --left experiment=cls_smoke --right experiment=cls_smoke --right model.stage=many_class
 tab-foundry dev run-inspect --run-dir outputs/cls_smoke
 tab-foundry dev export-check --checkpoint outputs/cls_smoke/checkpoints/best.pt
+tab-foundry dev checkpoint-publish --run-id sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1
+tab-foundry dev checkpoint-resolve --run-id sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1 --allow-remote
 tab-foundry data manifest-inspect --manifest data/manifests/default.parquet --experiment cls_smoke --override data.manifest_path=data/manifests/default.parquet
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.16.12"
+version = "0.16.13"
 description = "Tabular foundation model that generates its own training data via dagzoo, trains on it, and predicts on new tasks"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -13982,6 +13982,9 @@
         "unique_task_budget": 143976
       },
       "registered_at_utc": "2026-04-09T08:22:33Z",
+      "remote_artifacts": {
+        "best_checkpoint_wandb_artifact": "bensonlee55-none/tab-foundry/benchmark-checkpoint-sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1:v0"
+      },
       "run_id": "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
       "runtime_summary": {
         "non_train_overhead_seconds": 18.900836650282145,
@@ -14039,6 +14042,12 @@
         "post_warmup_train_loss_var": 0.07017782111975905,
         "train_elapsed_seconds": 8529.771452456713,
         "wall_elapsed_seconds": 8548.462426710874
+      },
+      "wandb": {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "run_id": "bbmhj6c4",
+        "run_name": "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1"
       }
     },
     "sd_tf_rd_009_width_transfer_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1": {

--- a/src/tab_foundry/bench/checkpoint.py
+++ b/src/tab_foundry/bench/checkpoint.py
@@ -15,6 +15,7 @@ from tab_foundry.bench.openml_benchmark.metrics import (
     BenchmarkClassificationFold,
     BenchmarkClassificationFoldResult,
 )
+from tab_foundry.checkpoint_state import normalize_checkpoint_model_state_dict
 from tab_foundry.input_normalization import (
     InputNormalizationMode,
     normalize_train_test_arrays,
@@ -40,32 +41,6 @@ from tab_foundry.task_batching import collate_task_batch, move_batch
 from tab_foundry.types import TaskBatch
 
 
-def _normalize_checkpoint_model_state_dict(
-    model_state: Mapping[str, Any],
-    *,
-    checkpoint_path: Path | None = None,
-) -> dict[str, Any]:
-    """Normalize compile-wrapped state-dict keys for benchmark loading."""
-
-    normalized: dict[str, Any] = {}
-    normalized_sources: dict[str, str] = {}
-    for raw_key, value in model_state.items():
-        source_key = str(raw_key)
-        normalized_key = source_key
-        while normalized_key.startswith("_orig_mod."):
-            normalized_key = normalized_key.removeprefix("_orig_mod.")
-        existing_source = normalized_sources.get(normalized_key)
-        if existing_source is not None and existing_source != source_key:
-            location = "" if checkpoint_path is None else f" in checkpoint {checkpoint_path}"
-            raise RuntimeError(
-                "compiled checkpoint state_dict normalization produced duplicate key "
-                f"{normalized_key!r} from {existing_source!r} and {source_key!r}{location}"
-            )
-        normalized[normalized_key] = value
-        normalized_sources[normalized_key] = source_key
-    return normalized
-
-
 def _checkpoint_model_state_dict(
     payload: Mapping[str, Any],
     *,
@@ -74,7 +49,7 @@ def _checkpoint_model_state_dict(
     model_state = payload.get("model")
     if not isinstance(model_state, Mapping):
         return None
-    return _normalize_checkpoint_model_state_dict(model_state, checkpoint_path=checkpoint_path)
+    return normalize_checkpoint_model_state_dict(model_state, checkpoint_path=checkpoint_path)
 
 
 def _checkpoint_model_spec(

--- a/src/tab_foundry/bench/checkpoint_artifacts.py
+++ b/src/tab_foundry/bench/checkpoint_artifacts.py
@@ -1,0 +1,299 @@
+"""Benchmark checkpoint publication and resolution helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Literal, Mapping, cast
+
+from tab_foundry.bench.openml_benchmark import resolve_tab_foundry_best_checkpoint
+from tab_foundry.benchmark_registry import (
+    default_benchmark_run_registry_path,
+    load_benchmark_run_registry,
+    resolve_registry_path_value,
+)
+from tab_foundry.bench.artifacts import write_json
+from tab_foundry.repo_paths import repo_root
+from tab_foundry.training.instability import telemetry_path
+from tab_foundry.training.wandb import (
+    download_checkpoint_artifact,
+    publish_checkpoint_artifact,
+)
+
+
+CheckpointSource = Literal["local_registry", "wandb_artifact"]
+
+_WANDB_REQUIRED_FIELDS = ("project", "run_id", "run_name")
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointResolution:
+    """Resolved checkpoint source for one benchmark run."""
+
+    run_id: str
+    source: CheckpointSource
+    checkpoint_path: Path
+    artifact_ref: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedBenchmarkCheckpoint:
+    """Result of publishing one benchmark run checkpoint to W&B."""
+
+    run_id: str
+    checkpoint_path: Path
+    artifact_ref: str
+    wandb: dict[str, str]
+
+
+def default_checkpoint_cache_root() -> Path:
+    """Return the repo-local checkpoint artifact cache root."""
+
+    return repo_root() / ".artifacts" / "checkpoints"
+
+
+def artifact_name_for_run_id(run_id: str) -> str:
+    """Return the stable W&B artifact name for one benchmark run."""
+
+    normalized_run_id = str(run_id).strip()
+    if not normalized_run_id:
+        raise RuntimeError("run_id must be a non-empty string")
+    return f"benchmark-checkpoint-{normalized_run_id}"
+
+
+def normalized_wandb_registry_payload(value: Any) -> dict[str, str] | None:
+    """Normalize persisted W&B identity metadata from a registry entry or telemetry payload."""
+
+    if not isinstance(value, Mapping):
+        return None
+    normalized: dict[str, str] = {}
+    for field in ("entity", "project", "run_id", "run_name"):
+        raw_value = value.get(field)
+        if raw_value is None:
+            continue
+        if not isinstance(raw_value, str):
+            raise RuntimeError(f"wandb metadata field {field!r} must be a string when present")
+        stripped = raw_value.strip()
+        if stripped:
+            normalized[field] = stripped
+    missing = [field for field in _WANDB_REQUIRED_FIELDS if field not in normalized]
+    if missing:
+        return None
+    return normalized
+
+
+def wandb_registry_payload_from_telemetry(telemetry_payload: Mapping[str, Any] | None) -> dict[str, str] | None:
+    """Extract registry-safe W&B identity fields from one telemetry payload."""
+
+    if not isinstance(telemetry_payload, Mapping):
+        return None
+    return normalized_wandb_registry_payload(telemetry_payload.get("wandb"))
+
+
+def remote_artifacts_payload(*, artifact_ref: str) -> dict[str, str]:
+    """Build the persisted remote-artifact payload for one checkpoint artifact."""
+
+    normalized_ref = str(artifact_ref).strip()
+    if not normalized_ref:
+        raise RuntimeError("artifact_ref must be a non-empty string")
+    return {
+        "best_checkpoint_wandb_artifact": normalized_ref,
+    }
+
+
+def load_training_telemetry_payload(run_dir: Path) -> dict[str, Any] | None:
+    """Load one run's telemetry payload when present."""
+
+    resolved_path = telemetry_path(run_dir)
+    if not resolved_path.exists():
+        return None
+    payload = cast(dict[str, Any], json.loads(resolved_path.read_text(encoding="utf-8")))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"telemetry.json must be a JSON object: {resolved_path}")
+    return payload
+
+
+def resolve_registry_best_checkpoint_path(
+    entry: Mapping[str, Any],
+    *,
+    registry_root: Path,
+    run_dir_override: Path | None = None,
+) -> Path:
+    """Resolve the best checkpoint path for one registry entry."""
+
+    if run_dir_override is not None:
+        return resolve_tab_foundry_best_checkpoint(run_dir_override.expanduser().resolve())
+    raw_artifacts = entry.get("artifacts")
+    if not isinstance(raw_artifacts, Mapping):
+        raise RuntimeError("benchmark run entry is missing artifacts metadata")
+    raw_checkpoint_path = raw_artifacts.get("best_checkpoint_path")
+    if not isinstance(raw_checkpoint_path, str) or not raw_checkpoint_path.strip():
+        raise RuntimeError("benchmark run entry artifacts.best_checkpoint_path must be a non-empty string")
+    return resolve_registry_path_value(raw_checkpoint_path, root=registry_root)
+
+
+def resolve_registry_run_dir(
+    entry: Mapping[str, Any],
+    *,
+    registry_root: Path,
+    run_dir_override: Path | None = None,
+) -> Path:
+    """Resolve the canonical run directory for one registry entry."""
+
+    if run_dir_override is not None:
+        return run_dir_override.expanduser().resolve()
+    raw_artifacts = entry.get("artifacts")
+    if not isinstance(raw_artifacts, Mapping):
+        raise RuntimeError("benchmark run entry is missing artifacts metadata")
+    raw_run_dir = raw_artifacts.get("run_dir")
+    if not isinstance(raw_run_dir, str) or not raw_run_dir.strip():
+        raise RuntimeError("benchmark run entry artifacts.run_dir must be a non-empty string")
+    return resolve_registry_path_value(raw_run_dir, root=registry_root)
+
+
+def publish_benchmark_checkpoint_artifact(
+    *,
+    run_id: str,
+    entry: Mapping[str, Any],
+    registry_root: Path,
+    run_dir_override: Path | None = None,
+) -> PublishedBenchmarkCheckpoint:
+    """Publish one benchmark run checkpoint to W&B."""
+
+    normalized_run_id = str(run_id).strip()
+    if not normalized_run_id:
+        raise RuntimeError("run_id must be a non-empty string")
+    checkpoint_path = resolve_registry_best_checkpoint_path(
+        entry,
+        registry_root=registry_root,
+        run_dir_override=run_dir_override,
+    )
+    if not checkpoint_path.exists():
+        raise RuntimeError(f"benchmark checkpoint does not exist: {checkpoint_path}")
+    wandb_payload = normalized_wandb_registry_payload(entry.get("wandb"))
+    if wandb_payload is None:
+        telemetry_payload = load_training_telemetry_payload(
+            resolve_registry_run_dir(
+                entry,
+                registry_root=registry_root,
+                run_dir_override=run_dir_override,
+            )
+        )
+        wandb_payload = wandb_registry_payload_from_telemetry(telemetry_payload)
+    if wandb_payload is None:
+        raise RuntimeError(
+            "benchmark run is missing W&B identity metadata and cannot publish a checkpoint artifact"
+        )
+
+    sweep_payload = entry.get("sweep")
+    metadata: dict[str, Any] = {"benchmark_run_id": normalized_run_id}
+    if isinstance(sweep_payload, Mapping):
+        for key in ("sweep_id", "delta_id", "parent_sweep_id", "queue_order", "run_kind"):
+            if key in sweep_payload:
+                metadata[key] = sweep_payload[key]
+    artifact = publish_checkpoint_artifact(
+        checkpoint_path=checkpoint_path,
+        artifact_name=artifact_name_for_run_id(normalized_run_id),
+        entity=wandb_payload.get("entity"),
+        project=wandb_payload["project"],
+        run_id=wandb_payload["run_id"],
+        run_name=wandb_payload.get("run_name"),
+        metadata=metadata,
+        aliases=["best"],
+    )
+    return PublishedBenchmarkCheckpoint(
+        run_id=normalized_run_id,
+        checkpoint_path=artifact.local_path,
+        artifact_ref=artifact.artifact_ref,
+        wandb=wandb_payload,
+    )
+
+
+def resolve_benchmark_checkpoint(
+    *,
+    run_id: str,
+    registry_path: Path | None = None,
+    allow_remote: bool,
+    cache_root: Path | None = None,
+) -> CheckpointResolution:
+    """Resolve one benchmark checkpoint from the registry or W&B artifact cache."""
+
+    resolved_registry_path = (registry_path or default_benchmark_run_registry_path()).expanduser().resolve()
+    registry_payload = load_benchmark_run_registry(resolved_registry_path)
+    runs = cast(dict[str, Any], registry_payload["runs"])
+    try:
+        entry = cast(dict[str, Any], runs[str(run_id)])
+    except KeyError as exc:
+        raise RuntimeError(f"unknown benchmark registry run_id: {run_id!r}") from exc
+    local_path = resolve_registry_best_checkpoint_path(
+        entry,
+        registry_root=repo_root(),
+    )
+    if local_path.exists():
+        return CheckpointResolution(
+            run_id=str(run_id),
+            source="local_registry",
+            checkpoint_path=local_path,
+        )
+    if not allow_remote:
+        raise RuntimeError(
+            "benchmark checkpoint is not available locally; rerun with --allow-remote to use W&B "
+            f"artifact recovery for run_id={run_id}"
+        )
+    remote_payload = entry.get("remote_artifacts")
+    if not isinstance(remote_payload, Mapping):
+        raise RuntimeError(
+            "benchmark run entry does not include remote checkpoint metadata: "
+            f"run_id={run_id!r}"
+        )
+    artifact_ref = remote_payload.get("best_checkpoint_wandb_artifact")
+    if not isinstance(artifact_ref, str) or not artifact_ref.strip():
+        raise RuntimeError(
+            "benchmark run entry remote_artifacts.best_checkpoint_wandb_artifact must be a non-empty "
+            f"string: run_id={run_id!r}"
+        )
+    resolved_cache_root = (
+        default_checkpoint_cache_root()
+        if cache_root is None
+        else cache_root.expanduser().resolve()
+    )
+    downloaded = download_checkpoint_artifact(
+        artifact_ref=artifact_ref,
+        out_dir=resolved_cache_root / str(run_id),
+    )
+    return CheckpointResolution(
+        run_id=str(run_id),
+        source="wandb_artifact",
+        checkpoint_path=downloaded.local_path,
+        artifact_ref=downloaded.artifact_ref,
+    )
+
+
+def backfill_benchmark_checkpoint_artifact(
+    *,
+    run_id: str,
+    registry_path: Path | None = None,
+    run_dir_override: Path | None = None,
+) -> PublishedBenchmarkCheckpoint:
+    """Publish one historical checkpoint artifact and persist its registry metadata."""
+
+    resolved_registry_path = (registry_path or default_benchmark_run_registry_path()).expanduser().resolve()
+    registry_payload = load_benchmark_run_registry(resolved_registry_path)
+    runs = cast(dict[str, Any], registry_payload["runs"])
+    try:
+        entry = cast(dict[str, Any], runs[str(run_id)])
+    except KeyError as exc:
+        raise RuntimeError(f"unknown benchmark registry run_id: {run_id!r}") from exc
+    published = publish_benchmark_checkpoint_artifact(
+        run_id=str(run_id),
+        entry=entry,
+        registry_root=repo_root(),
+        run_dir_override=run_dir_override,
+    )
+    updated_entry = {str(key): value for key, value in entry.items()}
+    updated_entry["wandb"] = dict(published.wandb)
+    updated_entry["remote_artifacts"] = remote_artifacts_payload(artifact_ref=published.artifact_ref)
+    runs[str(run_id)] = updated_entry
+    write_json(resolved_registry_path, registry_payload)
+    return published

--- a/src/tab_foundry/bench/registry/record_helpers.py
+++ b/src/tab_foundry/bench/registry/record_helpers.py
@@ -210,6 +210,30 @@ def _load_training_telemetry(run_dir: Path) -> dict[str, Any] | None:
     return cast(dict[str, Any], payload)
 
 
+def _wandb_identity_from_telemetry(
+    telemetry_payload: Mapping[str, Any] | None,
+) -> dict[str, str] | None:
+    if not isinstance(telemetry_payload, Mapping):
+        return None
+    raw_wandb = telemetry_payload.get("wandb")
+    if not isinstance(raw_wandb, Mapping):
+        return None
+    normalized: dict[str, str] = {}
+    for key in ("entity", "project", "run_id", "run_name"):
+        raw_value = raw_wandb.get(key)
+        if raw_value is None:
+            continue
+        if not isinstance(raw_value, str):
+            raise RuntimeError(f"telemetry wandb.{key} must be a string when present")
+        stripped = raw_value.strip()
+        if stripped:
+            normalized[key] = stripped
+    required = ("project", "run_id", "run_name")
+    if any(field not in normalized for field in required):
+        return None
+    return normalized
+
+
 def _normalized_optional_mapping(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         return None

--- a/src/tab_foundry/bench/registry/schema.py
+++ b/src/tab_foundry/bench/registry/schema.py
@@ -98,6 +98,17 @@ class _BenchmarkArtifactsPayload(_RegistryPayloadModel):
     training_surface_record_path: StrictStr | None = None
 
 
+class _WandbIdentityPayload(_RegistryPayloadModel):
+    entity: StrictStr | None = None
+    project: StrictStr
+    run_id: StrictStr
+    run_name: StrictStr
+
+
+class _RemoteArtifactsPayload(_RegistryPayloadModel):
+    best_checkpoint_wandb_artifact: StrictStr
+
+
 class _TabFoundryMetricsPayload(_RegistryPayloadModel):
     best_step: FiniteFloat | None = None
     best_training_time: FiniteFloat | None = None
@@ -204,6 +215,7 @@ class _BenchmarkRunRecordPayload(_RegistryPayloadModel):
     model: _BenchmarkRunModelPayload
     benchmark_bundle: _BenchmarkBundlePayload
     artifacts: _BenchmarkArtifactsPayload
+    wandb: _WandbIdentityPayload | None = None
     tab_foundry_metrics: _TabFoundryMetricsPayload
     training_diagnostics: _TrainingDiagnosticsPayload
     runtime_summary: _RuntimeSummaryPayload | None = None
@@ -226,6 +238,8 @@ class _BenchmarkRunEntryPayload(_RegistryPayloadModel):
     seed_set: list[StrictInt] = Field(min_length=1)
     benchmark_bundle: _BenchmarkBundlePayload
     artifacts: _BenchmarkArtifactsPayload
+    wandb: _WandbIdentityPayload | None = None
+    remote_artifacts: _RemoteArtifactsPayload | None = None
     tab_foundry_metrics: _TabFoundryMetricsPayload
     training_diagnostics: _TrainingDiagnosticsPayload
     runtime_summary: _RuntimeSummaryPayload | None = None

--- a/src/tab_foundry/bench/run_registration.py
+++ b/src/tab_foundry/bench/run_registration.py
@@ -10,6 +10,10 @@ import torch
 import tab_foundry.benchmark_registry as read_benchmark_registry
 from tab_foundry.bench.artifacts import load_history, write_json
 from tab_foundry.bench.openml_benchmark import resolve_tab_foundry_run_artifact_paths
+from tab_foundry.bench.checkpoint_artifacts import (
+    publish_benchmark_checkpoint_artifact,
+    remote_artifacts_payload,
+)
 from tab_foundry.bench.registry.record_helpers import (
     _count_parameters_from_cfg,
     _load_training_telemetry,
@@ -19,6 +23,7 @@ from tab_foundry.bench.registry.record_helpers import (
     _training_diagnostics_from_history,
     _training_surface_record,
     _runtime_summary_from_telemetry,
+    _wandb_identity_from_telemetry,
 )
 from tab_foundry.bench.registry.schema import (
     _BenchmarkRunEntryPayload,
@@ -375,6 +380,7 @@ def derive_benchmark_run_record(
             if training_surface_path is None
             else _normalize_registry_path(training_surface_path),
         },
+        "wandb": _wandb_identity_from_telemetry(telemetry_payload),
         "tab_foundry_metrics": tab_foundry_metrics_from_summary(tab_foundry),
         "training_diagnostics": _training_diagnostics_from_history(history, raw_cfg=raw_cfg),
         "runtime_summary": _runtime_summary_from_telemetry(telemetry_payload),
@@ -482,6 +488,7 @@ def derive_benchmark_run_entry(
         "seed_set": list(record["seed_set"]),
         "benchmark_bundle": record["benchmark_bundle"],
         "artifacts": record["artifacts"],
+        "wandb": record.get("wandb"),
         "tab_foundry_metrics": record["tab_foundry_metrics"],
         "training_diagnostics": record["training_diagnostics"],
         "runtime_summary": record.get("runtime_summary"),
@@ -574,6 +581,22 @@ def register_benchmark_run(
         run_kind=run_kind,
         registry_path=registry_path,
     )
+    telemetry_payload = _load_training_telemetry(run_dir.expanduser().resolve())
+    raw_wandb = None if telemetry_payload is None else telemetry_payload.get("wandb")
+    if isinstance(raw_wandb, Mapping):
+        raw_mode = raw_wandb.get("mode")
+        normalized_mode = None if raw_mode is None else str(raw_mode).strip().lower()
+        if normalized_mode != "offline":
+            published = publish_benchmark_checkpoint_artifact(
+                run_id=run_id,
+                entry=entry,
+                registry_root=repo_root(),
+                run_dir_override=run_dir.expanduser().resolve(),
+            )
+            entry["wandb"] = dict(published.wandb)
+            entry["remote_artifacts"] = remote_artifacts_payload(
+                artifact_ref=published.artifact_ref
+            )
     resolved_registry_path = upsert_benchmark_run_entry(entry, registry_path=registry_path)
     return {
         "registry_path": str(resolved_registry_path),

--- a/src/tab_foundry/checkpoint_state.py
+++ b/src/tab_foundry/checkpoint_state.py
@@ -1,0 +1,32 @@
+"""Shared checkpoint state-dict normalization helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def normalize_checkpoint_model_state_dict(
+    model_state: Mapping[str, Any],
+    *,
+    checkpoint_path: Path | None = None,
+) -> dict[str, Any]:
+    """Strip compile-wrapper prefixes from checkpoint state-dict keys."""
+
+    normalized: dict[str, Any] = {}
+    normalized_sources: dict[str, str] = {}
+    for raw_key, value in model_state.items():
+        source_key = str(raw_key)
+        normalized_key = source_key
+        while normalized_key.startswith("_orig_mod."):
+            normalized_key = normalized_key.removeprefix("_orig_mod.")
+        existing_source = normalized_sources.get(normalized_key)
+        if existing_source is not None and existing_source != source_key:
+            location = "" if checkpoint_path is None else f" in checkpoint {checkpoint_path}"
+            raise RuntimeError(
+                "compiled checkpoint state_dict normalization produced duplicate key "
+                f"{normalized_key!r} from {existing_source!r} and {source_key!r}{location}"
+            )
+        normalized[normalized_key] = value
+        normalized_sources[normalized_key] = source_key
+    return normalized

--- a/src/tab_foundry/cli/dev.py
+++ b/src/tab_foundry/cli/dev.py
@@ -11,6 +11,11 @@ import click
 import torch
 
 import tab_foundry.cli.groups.data as data_group
+from tab_foundry.bench.checkpoint_artifacts import (
+    backfill_benchmark_checkpoint_artifact,
+    resolve_benchmark_checkpoint,
+)
+from tab_foundry.benchmark_registry import default_benchmark_run_registry_path
 from tab_foundry.cli.click_utils import (
     DEVICE_CHOICES,
     GROUP_KWARGS,
@@ -416,6 +421,35 @@ def render_run_inspect_text(payload: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def render_checkpoint_resolve_text(payload: Mapping[str, Any]) -> str:
+    lines = [
+        "Checkpoint resolved.",
+        f"run_id={payload['run_id']}",
+        f"source={payload['source']}",
+        f"checkpoint_path={payload['checkpoint_path']}",
+    ]
+    artifact_ref = payload.get("artifact_ref")
+    if artifact_ref is not None:
+        lines.append(f"artifact_ref={artifact_ref}")
+    return "\n".join(lines)
+
+
+def render_checkpoint_publish_text(payload: Mapping[str, Any]) -> str:
+    lines = [
+        "Checkpoint artifact published.",
+        f"run_id={payload['run_id']}",
+        f"checkpoint_path={payload['checkpoint_path']}",
+        f"artifact_ref={payload['artifact_ref']}",
+        f"wandb.project={payload['wandb']['project']}",
+        f"wandb.run_id={payload['wandb']['run_id']}",
+        f"wandb.run_name={payload['wandb']['run_name']}",
+    ]
+    entity = payload["wandb"].get("entity")
+    if entity is not None:
+        lines.append(f"wandb.entity={entity}")
+    return "\n".join(lines)
+
+
 def _run_resolve_config(*, json_mode: bool, overrides: Sequence[str]) -> int:
     payload = resolve_config_payload(overrides)
     emit_payload(payload, json_mode=json_mode, render_text=render_resolve_config_text)
@@ -466,6 +500,58 @@ def _run_health_check(*, run_dir: Path, json_mode: bool) -> int:
 def _run_run_inspect(*, run_dir: Path, json_mode: bool) -> int:
     payload = run_inspect(run_dir)
     emit_payload(payload, json_mode=json_mode, render_text=render_run_inspect_text)
+    return 0
+
+
+def _run_checkpoint_resolve(
+    *,
+    run_id: str,
+    allow_remote: bool,
+    cache_root: Path | None,
+    registry_path: Path,
+    json_mode: bool,
+) -> int:
+    payload = resolve_benchmark_checkpoint(
+        run_id=run_id,
+        registry_path=registry_path,
+        allow_remote=allow_remote,
+        cache_root=cache_root,
+    )
+    emit_payload(
+        {
+            "run_id": payload.run_id,
+            "source": payload.source,
+            "checkpoint_path": str(payload.checkpoint_path),
+            "artifact_ref": payload.artifact_ref,
+        },
+        json_mode=json_mode,
+        render_text=render_checkpoint_resolve_text,
+    )
+    return 0
+
+
+def _run_checkpoint_publish(
+    *,
+    run_id: str,
+    run_dir: Path | None,
+    registry_path: Path,
+    json_mode: bool,
+) -> int:
+    payload = backfill_benchmark_checkpoint_artifact(
+        run_id=run_id,
+        registry_path=registry_path,
+        run_dir_override=run_dir,
+    )
+    emit_payload(
+        {
+            "run_id": payload.run_id,
+            "checkpoint_path": str(payload.checkpoint_path),
+            "artifact_ref": payload.artifact_ref,
+            "wandb": dict(payload.wandb),
+        },
+        json_mode=json_mode,
+        render_text=render_checkpoint_publish_text,
+    )
     return 0
 
 
@@ -570,6 +656,79 @@ def RUN_INSPECT_COMMAND(run_dir: Path, json_mode: bool) -> int:
     return _run_run_inspect(run_dir=run_dir, json_mode=json_mode)
 
 
+@click.command(
+    name="checkpoint-resolve",
+    help="Resolve one benchmark checkpoint locally or recover it from W&B artifacts",
+)
+@click.option("--run-id", required=True, type=str, help="Benchmark registry run id to resolve")
+@click.option(
+    "--registry-path",
+    default=default_benchmark_run_registry_path(),
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Path to benchmark_run_registry_v1.json",
+)
+@click.option(
+    "--allow-remote",
+    is_flag=True,
+    help="Allow W&B artifact recovery when the local checkpoint path is missing",
+)
+@click.option(
+    "--cache-root",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Optional checkpoint cache root; omit to use .artifacts/checkpoints under the repo root",
+)
+@json_output_option
+def CHECKPOINT_RESOLVE_COMMAND(
+    run_id: str,
+    registry_path: Path,
+    allow_remote: bool,
+    cache_root: Path | None,
+    json_mode: bool,
+) -> int:
+    return _run_checkpoint_resolve(
+        run_id=run_id,
+        allow_remote=allow_remote,
+        cache_root=cache_root,
+        registry_path=registry_path,
+        json_mode=json_mode,
+    )
+
+
+@click.command(
+    name="checkpoint-publish",
+    help="Publish one historical benchmark checkpoint to W&B and persist its registry metadata",
+)
+@click.option("--run-id", required=True, type=str, help="Benchmark registry run id to publish")
+@click.option(
+    "--registry-path",
+    default=default_benchmark_run_registry_path(),
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Path to benchmark_run_registry_v1.json",
+)
+@click.option(
+    "--run-dir",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Optional override run directory for telemetry and checkpoint discovery during backfill",
+)
+@json_output_option
+def CHECKPOINT_PUBLISH_COMMAND(
+    run_id: str,
+    registry_path: Path,
+    run_dir: Path | None,
+    json_mode: bool,
+) -> int:
+    return _run_checkpoint_publish(
+        run_id=run_id,
+        run_dir=run_dir,
+        registry_path=registry_path,
+        json_mode=json_mode,
+    )
+
+
 @click.group(name="dev", help="Developer-focused inspection tools", **GROUP_KWARGS)
 def GROUP() -> None:
     """Developer tooling group."""
@@ -581,4 +740,6 @@ GROUP.add_command(DIFF_CONFIG_COMMAND)
 GROUP.add_command(EXPORT_CHECK_COMMAND)
 GROUP.add_command(HEALTH_CHECK_COMMAND)
 GROUP.add_command(RUN_INSPECT_COMMAND)
+GROUP.add_command(CHECKPOINT_RESOLVE_COMMAND)
+GROUP.add_command(CHECKPOINT_PUBLISH_COMMAND)
 GROUP.add_command(data_group.DEV_GROUP)

--- a/src/tab_foundry/export/_contracts/models.py
+++ b/src/tab_foundry/export/_contracts/models.py
@@ -100,6 +100,14 @@ class _ManifestModelPayloadV3(_ContractsPayloadModel):
     sandwich_ff_expansion: StrictInt | None = None
     sandwich_activation: StrictStr | None = None
     sandwich_block_norm: StrictStr | None = None
+    sandwich_summary_tokens_per_axis: StrictInt | None = None
+    sandwich_self_attention_per_cross: StrictInt | None = None
+    sandwich_pre_row_attention_layers: StrictInt | None = None
+    sandwich_pre_column_attention_layers: StrictInt | None = None
+    sandwich_pre_column_inducing_tokens: StrictInt | None = None
+    feature_type_conditioning: StrictStr | None = None
+    floating_likelihood: StrictStr | None = None
+    integer_likelihood: StrictStr | None = None
     stage_label: StrictStr | None = None
     module_overrides: dict[StrictStr, Any] | None = None
     staged_dropout: FiniteFloat | None = None
@@ -326,6 +334,14 @@ class ExportModelSpec:
     sandwich_ff_expansion: int
     sandwich_activation: str
     sandwich_block_norm: str
+    sandwich_summary_tokens_per_axis: int
+    sandwich_self_attention_per_cross: int
+    sandwich_pre_row_attention_layers: int
+    sandwich_pre_column_attention_layers: int
+    sandwich_pre_column_inducing_tokens: int
+    feature_type_conditioning: str
+    floating_likelihood: str
+    integer_likelihood: str
 
     @classmethod
     def from_build_spec(
@@ -369,6 +385,14 @@ class ExportModelSpec:
             sandwich_ff_expansion=int(spec.sandwich_ff_expansion),
             sandwich_activation=str(spec.sandwich_activation),
             sandwich_block_norm=str(spec.sandwich_block_norm),
+            sandwich_summary_tokens_per_axis=int(spec.sandwich_summary_tokens_per_axis),
+            sandwich_self_attention_per_cross=int(spec.sandwich_self_attention_per_cross),
+            sandwich_pre_row_attention_layers=int(spec.sandwich_pre_row_attention_layers),
+            sandwich_pre_column_attention_layers=int(spec.sandwich_pre_column_attention_layers),
+            sandwich_pre_column_inducing_tokens=int(spec.sandwich_pre_column_inducing_tokens),
+            feature_type_conditioning=str(spec.feature_type_conditioning),
+            floating_likelihood=str(spec.floating_likelihood),
+            integer_likelihood=str(spec.integer_likelihood),
         )
 
     def to_build_spec(self, task: str) -> Any:
@@ -409,6 +433,14 @@ class ExportModelSpec:
                 "sandwich_ff_expansion": self.sandwich_ff_expansion,
                 "sandwich_activation": self.sandwich_activation,
                 "sandwich_block_norm": self.sandwich_block_norm,
+                "sandwich_summary_tokens_per_axis": self.sandwich_summary_tokens_per_axis,
+                "sandwich_self_attention_per_cross": self.sandwich_self_attention_per_cross,
+                "sandwich_pre_row_attention_layers": self.sandwich_pre_row_attention_layers,
+                "sandwich_pre_column_attention_layers": self.sandwich_pre_column_attention_layers,
+                "sandwich_pre_column_inducing_tokens": self.sandwich_pre_column_inducing_tokens,
+                "feature_type_conditioning": self.feature_type_conditioning,
+                "floating_likelihood": self.floating_likelihood,
+                "integer_likelihood": self.integer_likelihood,
             },
         )
 
@@ -432,6 +464,14 @@ class ExportModelSpec:
                 "sandwich_ff_expansion",
                 "sandwich_activation",
                 "sandwich_block_norm",
+                "sandwich_summary_tokens_per_axis",
+                "sandwich_self_attention_per_cross",
+                "sandwich_pre_row_attention_layers",
+                "sandwich_pre_column_attention_layers",
+                "sandwich_pre_column_inducing_tokens",
+                "feature_type_conditioning",
+                "floating_likelihood",
+                "integer_likelihood",
             ):
                 payload.pop(field_name, None)
             return payload
@@ -446,6 +486,14 @@ class ExportModelSpec:
                 "sandwich_ff_expansion",
                 "sandwich_activation",
                 "sandwich_block_norm",
+                "sandwich_summary_tokens_per_axis",
+                "sandwich_self_attention_per_cross",
+                "sandwich_pre_row_attention_layers",
+                "sandwich_pre_column_attention_layers",
+                "sandwich_pre_column_inducing_tokens",
+                "feature_type_conditioning",
+                "floating_likelihood",
+                "integer_likelihood",
             ):
                 payload.pop(field_name, None)
             return payload

--- a/src/tab_foundry/export/exporter.py
+++ b/src/tab_foundry/export/exporter.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping
 from safetensors.torch import save_file
 import torch
 
+from tab_foundry.checkpoint_state import normalize_checkpoint_model_state_dict
 from tab_foundry.model.spec import ModelBuildSpec, checkpoint_model_build_spec_from_mappings
 from tab_foundry.preprocessing import (
     MISSING_VALUE_STRATEGY_TRAIN_MEAN,
@@ -161,10 +162,11 @@ def _preprocessor_state_v3(cfg: Mapping[str, Any]) -> ExportPreprocessorState:
 
 
 def _normalize_state_dict(state_dict: Any) -> dict[str, torch.Tensor]:
-    if not isinstance(state_dict, dict):
+    if not isinstance(state_dict, Mapping):
         raise RuntimeError("checkpoint['model'] must be a state_dict object")
     out: dict[str, torch.Tensor] = {}
-    for key, value in state_dict.items():
+    normalized = normalize_checkpoint_model_state_dict(state_dict)
+    for key, value in normalized.items():
         if not isinstance(key, str):
             raise RuntimeError("state_dict keys must be strings")
         if not isinstance(value, torch.Tensor):

--- a/src/tab_foundry/training/wandb.py
+++ b/src/tab_foundry/training/wandb.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import json
 import math
 from netrc import NetrcParseError, netrc
@@ -11,6 +12,15 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from omegaconf import DictConfig, OmegaConf
+
+
+@dataclass(frozen=True, slots=True)
+class WandbArtifactReference:
+    """One uploaded or downloaded W&B artifact reference."""
+
+    artifact_name: str
+    artifact_ref: str
+    local_path: Path
 
 
 def _normalize_wandb_value(value: object) -> Any | None:
@@ -281,6 +291,142 @@ def finish_wandb_run(run: Any | None) -> None:
     finish = getattr(run, "finish", None)
     if callable(finish):
         finish()
+
+
+def _require_wandb_sdk() -> Any:
+    _ = resolve_wandb_api_key()
+    try:
+        import wandb
+    except Exception as exc:  # pragma: no cover - import failure depends on environment
+        raise RuntimeError("wandb is required for checkpoint artifact publication") from exc
+    return wandb
+
+
+def _normalize_artifact_metadata(payload: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+    normalized = _normalized_wandb_payload(payload)
+    return normalized or None
+
+
+def publish_checkpoint_artifact(
+    *,
+    checkpoint_path: Path,
+    artifact_name: str,
+    entity: str | None,
+    project: str,
+    run_id: str,
+    run_name: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    aliases: list[str] | None = None,
+) -> WandbArtifactReference:
+    """Upload one checkpoint as a versioned W&B artifact and return its exact ref."""
+
+    resolved_checkpoint = checkpoint_path.expanduser().resolve()
+    if not resolved_checkpoint.exists():
+        raise RuntimeError(f"checkpoint path does not exist: {resolved_checkpoint}")
+    normalized_project = str(project).strip()
+    normalized_run_id = str(run_id).strip()
+    normalized_artifact_name = str(artifact_name).strip()
+    if not normalized_project:
+        raise RuntimeError("project must be a non-empty string for W&B checkpoint publication")
+    if not normalized_run_id:
+        raise RuntimeError("run_id must be a non-empty string for W&B checkpoint publication")
+    if not normalized_artifact_name:
+        raise RuntimeError("artifact_name must be a non-empty string for W&B checkpoint publication")
+    normalized_entity = None if entity is None else str(entity).strip() or None
+    normalized_run_name = None if run_name is None else str(run_name).strip() or None
+    normalized_aliases = [str(value).strip() for value in (aliases or ["best"]) if str(value).strip()]
+    if not normalized_aliases:
+        normalized_aliases = ["best"]
+
+    wandb = _require_wandb_sdk()
+    init_kwargs: dict[str, Any] = {
+        "project": normalized_project,
+        "id": normalized_run_id,
+        "resume": "allow",
+        "job_type": "benchmark-checkpoint-publish",
+        "mode": "online",
+    }
+    if normalized_entity is not None:
+        init_kwargs["entity"] = normalized_entity
+    if normalized_run_name is not None:
+        init_kwargs["name"] = normalized_run_name
+
+    run = wandb.init(**init_kwargs)
+    if run is None:  # pragma: no cover - defensive branch
+        raise RuntimeError("wandb.init returned no run while publishing checkpoint artifact")
+    try:
+        artifact = wandb.Artifact(
+            name=normalized_artifact_name,
+            type="model",
+            metadata=_normalize_artifact_metadata(metadata),
+        )
+        artifact.add_file(str(resolved_checkpoint), name="best.pt")
+        logged_artifact = run.log_artifact(artifact, aliases=normalized_aliases)
+        logged_artifact = logged_artifact.wait()
+        resolved_ref = str(getattr(logged_artifact, "name", "")).strip()
+        if resolved_ref:
+            path_parts = [part for part in resolved_ref.split("/") if part]
+            if len(path_parts) == 1:
+                base = f"{normalized_project}/{resolved_ref}"
+                resolved_ref = base if normalized_entity is None else f"{normalized_entity}/{base}"
+            elif len(path_parts) == 2 and normalized_entity is not None:
+                resolved_ref = f"{normalized_entity}/{resolved_ref}"
+        else:
+            base = f"{normalized_project}/{normalized_artifact_name}:{normalized_aliases[0]}"
+            resolved_ref = base if normalized_entity is None else f"{normalized_entity}/{base}"
+        return WandbArtifactReference(
+            artifact_name=normalized_artifact_name,
+            artifact_ref=resolved_ref,
+            local_path=resolved_checkpoint,
+        )
+    finally:
+        finish_wandb_run(run)
+
+
+def download_checkpoint_artifact(
+    *,
+    artifact_ref: str,
+    out_dir: Path,
+) -> WandbArtifactReference:
+    """Download one checkpoint artifact and return the resolved local best.pt path."""
+
+    normalized_ref = str(artifact_ref).strip()
+    if not normalized_ref:
+        raise RuntimeError("artifact_ref must be a non-empty string")
+    resolved_out_dir = out_dir.expanduser().resolve()
+    resolved_out_dir.mkdir(parents=True, exist_ok=True)
+    cached_checkpoint = resolved_out_dir / "best.pt"
+    if cached_checkpoint.exists():
+        return WandbArtifactReference(
+            artifact_name=normalized_ref.split("/")[-1].split(":")[0],
+            artifact_ref=normalized_ref,
+            local_path=cached_checkpoint,
+        )
+
+    wandb = _require_wandb_sdk()
+    try:
+        api = wandb.Api()
+        artifact = api.artifact(normalized_ref)
+        downloaded_root = Path(artifact.download(root=str(resolved_out_dir))).expanduser().resolve()
+    except Exception as exc:  # pragma: no cover - network/API behavior
+        raise RuntimeError(f"failed to download W&B artifact {normalized_ref!r}") from exc
+
+    candidate = downloaded_root / "best.pt"
+    if not candidate.exists():
+        matches = sorted(downloaded_root.rglob("best.pt"))
+        if len(matches) != 1:
+            raise RuntimeError(
+                "downloaded W&B artifact does not contain exactly one best.pt: "
+                f"artifact_ref={normalized_ref} download_root={downloaded_root}"
+            )
+        candidate = matches[0]
+    return WandbArtifactReference(
+        artifact_name=normalized_ref.split("/")[-1].split(":")[0],
+        artifact_ref=normalized_ref,
+        local_path=candidate.resolve(),
+    )
 
 
 def _telemetry_wandb_payload(telemetry_path: Path) -> dict[str, Any] | None:

--- a/tests/benchmark/test_checkpoint_artifacts.py
+++ b/tests/benchmark/test_checkpoint_artifacts.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import tab_foundry.bench.checkpoint_artifacts as checkpoint_artifacts_module
+import tab_foundry.bench.run_registration as run_registration_module
+from tab_foundry.benchmark_registry import default_benchmark_run_registry_path, load_benchmark_run_registry
+import tab_foundry.training.wandb as wandb_module
+from tests.support.benchmark_run_registry_cases import _prepare_run
+
+
+def test_publish_checkpoint_artifact_returns_waited_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    checkpoint_path = tmp_path / "best.pt"
+    checkpoint_path.write_bytes(b"checkpoint")
+    captured: dict[str, object] = {}
+
+    class FakeArtifact:
+        def __init__(self, name: str, type: str, metadata=None, **_: object) -> None:
+            captured["artifact_name"] = name
+            captured["artifact_type"] = type
+            captured["artifact_metadata"] = metadata
+            self.files: list[tuple[str, str | None]] = []
+
+        def add_file(self, path: str, name: str | None = None) -> None:
+            self.files.append((path, name))
+            captured["files"] = list(self.files)
+
+    class FakeLoggedArtifact:
+        name = "benchmark-checkpoint-run_001:v7"
+
+        def wait(self, timeout: int | None = None):
+            captured["wait_timeout"] = timeout
+            return self
+
+    class FakeRun:
+        def log_artifact(self, artifact: FakeArtifact, aliases=None):
+            captured["aliases"] = list(aliases or [])
+            captured["logged_artifact"] = artifact
+            return FakeLoggedArtifact()
+
+        def finish(self) -> None:
+            captured["finished"] = True
+
+    class FakeWandb:
+        Artifact = FakeArtifact
+
+        @staticmethod
+        def init(**kwargs):
+            captured["init_kwargs"] = kwargs
+            return FakeRun()
+
+    monkeypatch.setattr(wandb_module, "_require_wandb_sdk", lambda: FakeWandb)
+
+    published = wandb_module.publish_checkpoint_artifact(
+        checkpoint_path=checkpoint_path,
+        artifact_name="benchmark-checkpoint-run_001",
+        entity="bensonlee55-none",
+        project="tab-foundry",
+        run_id="bbmhj6c4",
+        run_name="run_001",
+        metadata={"benchmark_run_id": "run_001", "queue_order": 2},
+        aliases=["best"],
+    )
+
+    assert published.artifact_ref == "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_001:v7"
+    assert published.local_path == checkpoint_path.resolve()
+    assert captured["init_kwargs"] == {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "id": "bbmhj6c4",
+        "resume": "allow",
+        "job_type": "benchmark-checkpoint-publish",
+        "mode": "online",
+        "name": "run_001",
+    }
+    assert captured["aliases"] == ["best"]
+    assert captured["files"] == [(str(checkpoint_path.resolve()), "best.pt")]
+    assert captured["finished"] is True
+
+
+def test_download_checkpoint_artifact_downloads_best_pt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeApiArtifact:
+        def download(self, root: str, **_: object) -> str:
+            resolved_root = Path(root).resolve()
+            resolved_root.mkdir(parents=True, exist_ok=True)
+            (resolved_root / "best.pt").write_bytes(b"checkpoint")
+            captured["download_root"] = resolved_root
+            return str(resolved_root)
+
+    class FakeApi:
+        def artifact(self, name: str):
+            captured["artifact_ref"] = name
+            return FakeApiArtifact()
+
+    class FakeWandb:
+        @staticmethod
+        def Api():
+            return FakeApi()
+
+    monkeypatch.setattr(wandb_module, "_require_wandb_sdk", lambda: FakeWandb)
+
+    downloaded = wandb_module.download_checkpoint_artifact(
+        artifact_ref="bensonlee55-none/tab-foundry/benchmark-checkpoint-run_001:v7",
+        out_dir=tmp_path / "cache",
+    )
+
+    assert downloaded.local_path == (tmp_path / "cache" / "best.pt").resolve()
+    assert captured["artifact_ref"] == "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_001:v7"
+    assert downloaded.local_path.read_bytes() == b"checkpoint"
+
+
+def test_register_benchmark_run_attaches_remote_artifact_when_online_wandb_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    registry_path = repo_root / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
+    run_dir, summary_path = _prepare_run(
+        repo_root,
+        run_name="wandb_online",
+        telemetry_extra_payload={
+            "wandb": {
+                "entity": "bensonlee55-none",
+                "project": "tab-foundry",
+                "run_id": "bbmhj6c4",
+                "run_name": "wandb_online",
+                "mode": "online",
+            }
+        },
+    )
+    monkeypatch.setattr(run_registration_module, "repo_root", lambda: repo_root)
+    monkeypatch.setattr(
+        run_registration_module,
+        "publish_benchmark_checkpoint_artifact",
+        lambda **_: checkpoint_artifacts_module.PublishedBenchmarkCheckpoint(
+            run_id="run_001",
+            checkpoint_path=run_dir / "checkpoints" / "best.pt",
+            artifact_ref="bensonlee55-none/tab-foundry/benchmark-checkpoint-run_001:v7",
+            wandb={
+                "entity": "bensonlee55-none",
+                "project": "tab-foundry",
+                "run_id": "bbmhj6c4",
+                "run_name": "wandb_online",
+            },
+        ),
+    )
+
+    result = run_registration_module.register_benchmark_run(
+        run_id="run_001",
+        track="binary_ladder",
+        experiment="cls_benchmark_staged",
+        config_profile="cls_benchmark_staged",
+        budget_class="short-run",
+        run_dir=run_dir,
+        comparison_summary_path=summary_path,
+        decision="keep",
+        conclusion="online wandb run",
+        registry_path=registry_path,
+    )
+
+    assert result["run"]["wandb"] == {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "run_id": "bbmhj6c4",
+        "run_name": "wandb_online",
+    }
+    assert result["run"]["remote_artifacts"] == {
+        "best_checkpoint_wandb_artifact": "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_001:v7"
+    }
+
+
+def test_backfill_benchmark_checkpoint_artifact_updates_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    registry_path = repo_root / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
+    run_dir, summary_path = _prepare_run(repo_root, run_name="historical")
+    monkeypatch.setattr(run_registration_module, "repo_root", lambda: repo_root)
+    _ = run_registration_module.register_benchmark_run(
+        run_id="run_002",
+        track="binary_ladder",
+        experiment="cls_benchmark_staged",
+        config_profile="cls_benchmark_staged",
+        budget_class="short-run",
+        run_dir=run_dir,
+        comparison_summary_path=summary_path,
+        decision="keep",
+        conclusion="historical backfill",
+        registry_path=registry_path,
+    )
+    telemetry_path = run_dir / "telemetry.json"
+    telemetry_payload = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    telemetry_payload["wandb"] = {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "run_id": "bbmhj6c4",
+        "run_name": "historical",
+        "mode": "online",
+    }
+    telemetry_path.write_text(json.dumps(telemetry_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    monkeypatch.setattr(checkpoint_artifacts_module, "repo_root", lambda: repo_root)
+    monkeypatch.setattr(
+        checkpoint_artifacts_module,
+        "publish_checkpoint_artifact",
+        lambda **_: wandb_module.WandbArtifactReference(
+            artifact_name="benchmark-checkpoint-run_002",
+            artifact_ref="bensonlee55-none/tab-foundry/benchmark-checkpoint-run_002:v4",
+            local_path=(run_dir / "checkpoints" / "best.pt").resolve(),
+        ),
+    )
+
+    published = checkpoint_artifacts_module.backfill_benchmark_checkpoint_artifact(
+        run_id="run_002",
+        registry_path=registry_path,
+    )
+
+    assert published.artifact_ref == "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_002:v4"
+    registry_payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert registry_payload["runs"]["run_002"]["wandb"] == {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "run_id": "bbmhj6c4",
+        "run_name": "historical",
+    }
+    assert registry_payload["runs"]["run_002"]["remote_artifacts"] == {
+        "best_checkpoint_wandb_artifact": "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_002:v4"
+    }
+
+
+def test_resolve_benchmark_checkpoint_downloads_remote_artifact_when_local_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    registry_path = repo_root / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
+    run_dir, summary_path = _prepare_run(repo_root, run_name="remote_only")
+    monkeypatch.setattr(run_registration_module, "repo_root", lambda: repo_root)
+    _ = run_registration_module.register_benchmark_run(
+        run_id="run_003",
+        track="binary_ladder",
+        experiment="cls_benchmark_staged",
+        config_profile="cls_benchmark_staged",
+        budget_class="short-run",
+        run_dir=run_dir,
+        comparison_summary_path=summary_path,
+        decision="keep",
+        conclusion="remote recovery",
+        registry_path=registry_path,
+    )
+    registry_payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry_payload["runs"]["run_003"]["remote_artifacts"] = {
+        "best_checkpoint_wandb_artifact": "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_003:v2"
+    }
+    registry_path.write_text(json.dumps(registry_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (run_dir / "checkpoints" / "best.pt").unlink()
+    monkeypatch.setattr(checkpoint_artifacts_module, "repo_root", lambda: repo_root)
+
+    def _fake_download_checkpoint_artifact(*, artifact_ref: str, out_dir: Path):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        checkpoint_path = out_dir / "best.pt"
+        checkpoint_path.write_bytes(b"checkpoint")
+        return wandb_module.WandbArtifactReference(
+            artifact_name="benchmark-checkpoint-run_003",
+            artifact_ref=artifact_ref,
+            local_path=checkpoint_path,
+        )
+
+    monkeypatch.setattr(
+        checkpoint_artifacts_module,
+        "download_checkpoint_artifact",
+        _fake_download_checkpoint_artifact,
+    )
+
+    resolved = checkpoint_artifacts_module.resolve_benchmark_checkpoint(
+        run_id="run_003",
+        registry_path=registry_path,
+        allow_remote=True,
+        cache_root=tmp_path / "cache",
+    )
+
+    assert resolved.source == "wandb_artifact"
+    assert resolved.artifact_ref == "bensonlee55-none/tab-foundry/benchmark-checkpoint-run_003:v2"
+    assert resolved.checkpoint_path == (tmp_path / "cache" / "run_003" / "best.pt").resolve()
+    assert resolved.checkpoint_path.read_bytes() == b"checkpoint"
+
+
+def test_checked_in_live_candidate_has_remote_checkpoint_artifact_metadata() -> None:
+    registry = load_benchmark_run_registry(default_benchmark_run_registry_path())
+    entry = registry["runs"][
+        "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1"
+    ]
+
+    assert entry["wandb"] == {
+        "entity": "bensonlee55-none",
+        "project": "tab-foundry",
+        "run_id": "bbmhj6c4",
+        "run_name": "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+    }
+    assert (
+        entry["remote_artifacts"]["best_checkpoint_wandb_artifact"]
+        == "bensonlee55-none/tab-foundry/benchmark-checkpoint-sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1:v0"
+    )

--- a/tests/export/test_contract_fixtures.py
+++ b/tests/export/test_contract_fixtures.py
@@ -277,6 +277,14 @@ def test_manifest_validation_accepts_tabfoundry_sandwich_fields() -> None:
     model_payload["sandwich_layers"] = 2
     model_payload["sandwich_heads"] = 4
     model_payload["sandwich_ff_expansion"] = 2
+    model_payload["sandwich_summary_tokens_per_axis"] = 3
+    model_payload["sandwich_self_attention_per_cross"] = 4
+    model_payload["sandwich_pre_row_attention_layers"] = 1
+    model_payload["sandwich_pre_column_attention_layers"] = 1
+    model_payload["sandwich_pre_column_inducing_tokens"] = 16
+    model_payload["feature_type_conditioning"] = "film"
+    model_payload["floating_likelihood"] = "single_gaussian"
+    model_payload["integer_likelihood"] = "hybrid_mixture"
     model_payload.pop("stage", None)
     model_payload.pop("stage_label", None)
     model_payload.pop("module_overrides", None)
@@ -299,6 +307,14 @@ def test_manifest_validation_accepts_tabfoundry_sandwich_fields() -> None:
     assert manifest.model.sandwich_layers == 2
     assert manifest.model.sandwich_heads == 4
     assert manifest.model.sandwich_ff_expansion == 2
+    assert manifest.model.sandwich_summary_tokens_per_axis == 3
+    assert manifest.model.sandwich_self_attention_per_cross == 4
+    assert manifest.model.sandwich_pre_row_attention_layers == 1
+    assert manifest.model.sandwich_pre_column_attention_layers == 1
+    assert manifest.model.sandwich_pre_column_inducing_tokens == 16
+    assert manifest.model.feature_type_conditioning == "film"
+    assert manifest.model.floating_likelihood == "single_gaussian"
+    assert manifest.model.integer_likelihood == "hybrid_mixture"
     assert manifest.inference is not None
     assert manifest.inference.model_arch == "tabfoundry_sandwich"
     assert manifest.inference.model_stage is None

--- a/tests/export/test_export_reference.py
+++ b/tests/export/test_export_reference.py
@@ -3,5 +3,6 @@ from __future__ import annotations
 # ruff: noqa: F401
 
 from tests.support.exporter_cases import (
+    test_export_checkpoint_normalizes_compiled_state_dict_keys,
     test_reference_loader_round_trip_classification_logits,
 )

--- a/tests/support/exporter_cases.py
+++ b/tests/support/exporter_cases.py
@@ -9,6 +9,7 @@ import typing
 import numpy as np
 from omegaconf import OmegaConf
 import pytest
+from safetensors.torch import load_file
 import torch
 
 import tab_foundry.export.exporter as exporter_module
@@ -839,6 +840,52 @@ def test_reference_loader_round_trip_classification_logits(tmp_path: Path) -> No
 
     assert getattr(loaded.model, "many_class_train_mode") == "path_nll"
     assert loaded.validated.inference_config.many_class_inference_mode == "full_probs"
+    assert src_out.logits is not None
+    assert dst_out.logits is not None
+    assert torch.allclose(src_out.logits, dst_out.logits)
+
+
+def test_export_checkpoint_normalizes_compiled_state_dict_keys(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "ckpt_compiled_prefix.pt"
+    cfg = _make_config("classification", input_normalization="none")
+    model_cfg = cfg["model"]
+    assert isinstance(model_cfg, dict)
+    torch.manual_seed(11)
+    source_model = _build_model("classification", model_cfg)
+    compiled_state = {
+        f"_orig_mod.{key}": value
+        for key, value in source_model.state_dict().items()
+    }
+    torch.save(
+        {
+            "model": compiled_state,
+            "global_step": 7,
+            "config": cfg,
+        },
+        checkpoint,
+    )
+
+    out_dir = tmp_path / "export_compiled_prefix"
+    _ = _export_v3_checkpoint(checkpoint, out_dir)
+
+    weights = load_file(str(out_dir / "weights.safetensors"))
+    assert weights
+    assert not any(key.startswith("_orig_mod.") for key in weights)
+
+    loaded = load_export_bundle(out_dir)
+    torch.manual_seed(21)
+    batch = TaskBatch(
+        x_train=torch.randn(8, 5),
+        y_train=torch.randint(0, 3, (8,)),
+        x_test=torch.randn(3, 5),
+        y_test=torch.randint(0, 3, (3,)),
+        metadata={},
+        num_classes=3,
+    )
+    with torch.no_grad():
+        src_out = source_model(batch)
+        dst_out = loaded.model(batch)
+
     assert src_out.logits is not None
     assert dst_out.logits is not None
     assert torch.allclose(src_out.logits, dst_out.logits)

--- a/uv.lock
+++ b/uv.lock
@@ -1735,7 +1735,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.16.12"
+version = "0.16.13"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary
- preserve the full live sandwich surface in exported bundle manifests and normalize compiled checkpoint state before export
- add benchmark checkpoint publish/resolve flows with W&B artifact metadata persisted in the registry
- expose new `tab-foundry dev checkpoint-publish` and `tab-foundry dev checkpoint-resolve` developer commands
- document the artifact schema change and bump the package version to `0.16.13`

## Validation
- `.venv/bin/pytest tests/benchmark/test_checkpoint_artifacts.py tests/benchmark/test_benchmark_run_registry_register.py tests/benchmark/test_benchmark_run_registry_fixture.py tests/export/test_export_reference.py tests/export/test_contract_fixtures.py`
- `.venv/bin/tab-foundry dev checkpoint-publish --run-id sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1 --run-dir /Users/bensonlee/dev/tab-foundry/outputs/staged_ladder/research/tf_rd_009_width_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl96_v1/sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1/train --json`
- `.venv/bin/tab-foundry dev checkpoint-resolve --run-id sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1 --allow-remote --json`
- `.venv/bin/tab-foundry dev export-check --checkpoint outputs/staged_ladder/research/tf_rd_009_width_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl96_v1/sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1/train/checkpoints/best.pt --out-dir <tmpdir> --json`