### PR TITLE
[codex] Add TF-RD-009 scaling audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- User-facing note: the packaged CLI now exposes
+  `tab-foundry research scaling audit`, which writes fit-audit artifacts with
+  validation-vs-benchmark target comparisons, grouped holdout residuals,
+  bootstrap parameter intervals, diagnostic broken-power-law checks, and an
+  iso-loss `Bcrit(L)` readiness gate before using `Cmin` as compute-optimal
+  evidence.
 - User-facing note: benchmark run registration now persists optional W&B run
   identity plus a versioned remote checkpoint artifact ref in the benchmark run
   registry, and new `tab-foundry dev checkpoint-publish` /

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -937,9 +937,15 @@ Legacy wording note:
   completed width-transfer child
   [#254](https://github.com/bensonlee5/tab-foundry/issues/254), completed
   joint width-depth child
-  [#255](https://github.com/bensonlee5/tab-foundry/issues/255), and active
+  [#255](https://github.com/bensonlee5/tab-foundry/issues/255), completed
   Kaplan-exact Phase-2 fit/report child
-  [#256](https://github.com/bensonlee5/tab-foundry/issues/256)
+  [#256](https://github.com/bensonlee5/tab-foundry/issues/256), follow-on
+  hardware-freeze child
+  [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
+  compute-frontier child
+  [#259](https://github.com/bensonlee5/tab-foundry/issues/259), and
+  curriculum/repetition slice child
+  [#260](https://github.com/bensonlee5/tab-foundry/issues/260)
 - Goal: fit the first classification scaling laws on the simplified sandwich
   family only after the repo has the closed TF-RD-010 benchmark contract, one
   TF-RD-022 runtime policy, one TF-RD-024 bounded architecture read, and a
@@ -1017,6 +1023,11 @@ Legacy wording note:
     and `log_space_r2=-0.0649503`; the derived `L(Cmin)` fit reports
     `alpha_cmin=0.123823`, `log_space_r2=0.915117`, and `rmse=0.014289`, but
     depends on that weak `Bcrit(L)` relation
+  - `tab-foundry research scaling audit` now adds the Phase-2 fit-audit layer:
+    validation-vs-benchmark target comparisons, leave-one-geometry and
+    leave-one-step residual checks, bootstrap intervals, diagnostic
+    broken-power-law univariate checks, and an iso-loss `Bcrit(L)` readiness
+    gate before treating any derived `Cmin` relation as compute-optimal
 - Required work:
   - keep [#253](https://github.com/bensonlee5/tab-foundry/issues/253) as the
     authoritative fixed-budget family epic
@@ -1053,6 +1064,24 @@ Legacy wording note:
     FLOPs, and report the complete validation-backed Phase-2 fit family
     `L(N)`, `L(D)`, `L(C)`, `L(N,D)`, `L(N,S)`, `Bcrit(L)`, and `L(Cmin)`,
     with explicit caveats on the weak two-point `Bcrit(L)` envelope
+  - before using the Phase-2 fit as a compute-optimal law, run the fit-audit
+    command and keep validation loss as the primary law-fitting target while
+    treating benchmark log loss as external transfer validation and
+    repo-facing ranking evidence
+  - redesign the batch-critical branch before deriving `Cmin`: run the
+    TF-RD-009 medium `96x2`, `152x5`, and `176x6` batch sweep over
+    `grad_accum_steps={1,2,4,8}` to `5000` steps with validation checkpoints at
+    `{625,1250,2500,5000}`, then estimate `Bcrit(L)` from equal-validation-loss
+    contours rather than the final-only lower envelope
+  - use [#259](https://github.com/bensonlee5/tab-foundry/issues/259) for the
+    medium compute-frontier sweep: choose `S` from measured
+    `train_flops_per_step(N)` across `{72x1,96x2,112x3,128x4,152x5,176x6}`,
+    bound `S` to `625..10000`, and compare a fitted Chinchilla-style
+    `L(N,D)=E+A/N^alpha+B/D^beta` against the Kaplan-style `L(N,S)` surface
+  - keep [#260](https://github.com/bensonlee5/tab-foundry/issues/260) as a
+    separate repetition/curriculum slice with fixed architecture and explicit
+    `unique_task_budget` / `curriculum_id`; do not merge those rows into the
+    base `N,S,C` law
   - maintain the preferred architecture statefully in
     `src/tab_foundry/bench/hardware_architecture_baselines_v1.json`, keyed by
     hardware profile plus sweep surface rather than by GitHub issue state; the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -454,6 +454,7 @@ a compact validation overlay. Inspect and fit that full state with:
 ```bash
 tab-foundry research scaling inspect --study tf_rd_009_phase2
 tab-foundry research scaling fit --study tf_rd_009_phase2
+tab-foundry research scaling audit --study tf_rd_009_phase2
 ```
 
 The default full fit reports `L(N)`, `L(D)`, `L(C)`, `L(N,D)`, `L(N,S)`,
@@ -464,6 +465,15 @@ requires observed training-shape summaries and same-model monotone NS compute
 accounting, so legacy fallback FLOP estimates do not silently enter the C axis.
 Treat the current `Bcrit(L)` output as weak diagnostic evidence: the completed
 lower envelope has only two points.
+
+Use `research scaling audit` before interpreting the Phase-2 fit as a
+compute-optimal law. It writes `audit/audit_summary.json` and `audit/audit.md`
+under the study artifact root by default, compares validation-loss and
+benchmark-loss targets, runs leave-one-geometry and leave-one-step residual
+checks for joint `N,D` / `N,S` fits, bootstraps parameter intervals, adds
+diagnostic broken-power-law univariate checks, and gates `Cmin` interpretation
+on a redesigned iso-loss `Bcrit(L)` analysis with at least four contour
+estimates across the multi-geometry batch sweep.
 
 ## Scope Boundaries
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.16.14"
+version = "0.16.15"
 description = "Tabular foundation model that generates its own training data via dagzoo, trains on it, and predicts on new tasks"
 readme = "README.md"
 license = "Apache-2.0"

--- a/reference/evidence.md
+++ b/reference/evidence.md
@@ -424,6 +424,10 @@ evidence for TF-RD-018 and later research-oriented epics now lives under
     accounting, and C-axis fits reject missing or non-monotone compute metadata
   - the primary usable fit signal is `L(N,S)`; `Bcrit(L)` is recorded but weak
     because its completed lower envelope has only two points
+  - the stronger `research scaling audit` surface now separates validation-loss
+    fits from benchmark-loss transfer checks, adds grouped holdouts and
+    bootstrap intervals, and keeps `Cmin` quarantined until the redesigned
+    iso-loss `Bcrit(L)` branch has enough contour evidence
   - the canonical long-form note now lives in
     `reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md`
 - Success signal:

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -22,10 +22,14 @@ handoff into the sweep-program design issue
   [#140](https://github.com/bensonlee5/tab-foundry/issues/140), active
   fixed-budget family epic [#253](https://github.com/bensonlee5/tab-foundry/issues/253),
   completed width-transfer child
-  [#254](https://github.com/bensonlee5/tab-foundry/issues/254), then active
+  [#254](https://github.com/bensonlee5/tab-foundry/issues/254), completed
   joint width-depth child [#255](https://github.com/bensonlee5/tab-foundry/issues/255),
-  and active Kaplan-exact Phase-2 fit/report child
-  [#256](https://github.com/bensonlee5/tab-foundry/issues/256)
+  completed Kaplan-exact Phase-2 fit/report child
+  [#256](https://github.com/bensonlee5/tab-foundry/issues/256), follow-on
+  hardware-freeze child [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
+  compute-frontier child [#259](https://github.com/bensonlee5/tab-foundry/issues/259),
+  and curriculum/repetition slice child
+  [#260](https://github.com/bensonlee5/tab-foundry/issues/260)
 
 ## Core Reading Path
 
@@ -384,6 +388,57 @@ Axis audit for the complete matrix:
   supports the reported `L(N,S)` surface; benchmark log loss is noisier across
   `N`, `D`, and `C`, which is why the one-dimensional benchmark-loss fits are
   carried as diagnostics.
+
+### Stronger Fit Audit And Follow-On Law Design
+
+Treat [#256](https://github.com/bensonlee5/tab-foundry/issues/256) as a
+completed Phase-2 diagnostic, not as a settled compute-optimal law. The useful
+signal is validation-backed `L(N,S)`. The weak signals are `L(N)`, `L(D)`,
+`L(C)`, `L(N,D)`, and especially `Bcrit(L)` because the current axes are
+partly entangled and the completed batch envelope has only two points.
+
+The repo now exposes the stronger fit-audit surface:
+
+```bash
+tab-foundry research scaling audit --study tf_rd_009_phase2
+```
+
+The audit writes `audit/audit_summary.json` and `audit/audit.md` under the
+study artifact root by default. It compares validation-loss versus
+benchmark-loss targets, runs leave-one-geometry and leave-one-step residual
+checks on joint laws, bootstraps parameter intervals, adds diagnostic
+broken-power-law univariate checks for knees and non-monotone slices, and gates
+any `Cmin` interpretation on iso-loss `Bcrit(L)` readiness. The audit policy is
+to fit repo telemetry directly: validation loss is the primary law-fitting
+target, benchmark log loss is external transfer validation and repo-facing
+ranking evidence, and Kaplan/Chinchilla exponents are not imported from the
+papers.
+
+Next sweep ordering:
+
+- first: run the audit and seed/noise checks before interpreting benchmark-loss
+  fits; add two extra seeds for `{96x2,128x4,152x5}` at `{2500,5000}` steps so
+  residuals can be separated into target noise versus real scaling deviation
+- second: redesign `Bcrit(L)` as an iso-loss crossing analysis; run `96x2`,
+  `152x5`, and `176x6` over `grad_accum_steps={1,2,4,8}` to `5000` steps with
+  validation checkpoints at `{625,1250,2500,5000}`, then fit
+  McCandlish-style `Bcrit = Emin / Smin` from equal-validation-loss contours
+  rather than a final-only lower envelope
+- third: use [#259](https://github.com/bensonlee5/tab-foundry/issues/259) for
+  the medium compute-frontier sweep; choose steps from measured
+  `train_flops_per_step(N)` across `{72x1,96x2,112x3,128x4,152x5,176x6}`,
+  bound steps to `625..10000`, and compare Chinchilla-style
+  `L(N,D)=E+A/N^alpha+B/D^beta` against the existing Kaplan-style `L(N,S)`
+- last: keep [#260](https://github.com/bensonlee5/tab-foundry/issues/260)
+  separate for repetition/curriculum slices with fixed architecture plus
+  explicit `unique_task_budget` and `curriculum_id`; fit data-constrained
+  effective-data laws instead of merging those rows into the base `N,S,C`
+  curve
+
+TF-RD-009 adoption decision: do not use `Bcrit(L)` to derive `Cmin` until the
+iso-loss analysis has at least four contour estimates across the redesigned
+multi-geometry batch sweep. Broken neural scaling laws are diagnostic tools for
+knees or non-monotone slices, not the default compute-optimal frontier.
 
 ## Joint Width-Depth Derivation For [#255](https://github.com/bensonlee5/tab-foundry/issues/255)
 

--- a/src/tab_foundry/cli/groups/research.py
+++ b/src/tab_foundry/cli/groups/research.py
@@ -100,6 +100,11 @@ _SCALING_GROUP = LazyGroup(
     name="scaling",
     help="Scaling-study workflows",
     lazy_commands={
+        "audit": LazyCommandSpec(
+            module="tab_foundry.cli.research_scaling",
+            attr="AUDIT_COMMAND",
+            help="Audit one scaling study fit and write diagnostic artifacts",
+        ),
         "backfill-validation": LazyCommandSpec(
             module="tab_foundry.cli.research_scaling",
             attr="BACKFILL_VALIDATION_COMMAND",

--- a/src/tab_foundry/cli/research_scaling.py
+++ b/src/tab_foundry/cli/research_scaling.py
@@ -15,6 +15,11 @@ from tab_foundry.cli.click_utils import (
     run_click_command,
     sweep_path_options,
 )
+from tab_foundry.research.scaling.audit import (
+    AUDIT_SCOPE_CHOICES,
+    audit_scaling_study,
+    render_scaling_audit_text,
+)
 from tab_foundry.research.scaling.fit import (
     FIT_SCOPE_CHOICES,
     fit_scaling_study,
@@ -120,6 +125,68 @@ def FIT_COMMAND(
     return 0
 
 
+@click.command(name="audit", help="Audit one scaling study fit and write diagnostic artifacts")
+@_study_options
+@click.option(
+    "--fit-scope",
+    default="all",
+    show_default=True,
+    type=click.Choice(AUDIT_SCOPE_CHOICES),
+    help="Audit all scaling rows or only NS-core laws while batch-critical rows are pending.",
+)
+@click.option(
+    "--bootstrap-samples",
+    default=64,
+    show_default=True,
+    type=POSITIVE_INT,
+    help="Bootstrap resamples for parameter interval diagnostics.",
+)
+@click.option(
+    "--bootstrap-seed",
+    default=0,
+    show_default=True,
+    type=int,
+    help="Random seed for deterministic bootstrap resampling.",
+)
+@path_option(
+    "out-root",
+    required=False,
+    help="Optional override for the scaling-audit artifact root",
+)
+@json_output_option
+@sweep_path_options(include_registry=True, include_sweeps_root=True)
+def AUDIT_COMMAND(
+    study: str | None,
+    study_path: Path | None,
+    studies_root: Path | None,
+    fit_scope: str,
+    bootstrap_samples: int,
+    bootstrap_seed: int,
+    out_root: Path | None,
+    json_mode: bool,
+    catalog_path: Path,
+    index_path: Path,
+    sweeps_root: Path,
+    registry_path: Path,
+) -> int:
+    _require_study_selection(study=study, study_path=study_path)
+    payload = audit_scaling_study(
+        study_id=study,
+        study_path=study_path,
+        studies_root=studies_root,
+        registry_path=registry_path.expanduser().resolve(),
+        index_path=index_path.expanduser().resolve(),
+        catalog_path=catalog_path.expanduser().resolve(),
+        sweeps_root=sweeps_root.expanduser().resolve(),
+        out_root=None if out_root is None else out_root.expanduser().resolve(),
+        fit_scope=fit_scope,
+        bootstrap_samples=bootstrap_samples,
+        bootstrap_seed=bootstrap_seed,
+    )
+    emit_payload(payload, json_mode=json_mode, render_text=render_scaling_audit_text)
+    return 0
+
+
 @click.command(
     name="backfill-validation",
     help="Backfill validation loss sidecars from completed scaling-study checkpoints",
@@ -202,6 +269,7 @@ def main(argv: list[str] | None = None) -> int:
     group = click.Group(
         name="research-scaling",
         commands={
+            "audit": AUDIT_COMMAND,
             "backfill-validation": BACKFILL_VALIDATION_COMMAND,
             "fit": FIT_COMMAND,
             "inspect": INSPECT_COMMAND,

--- a/src/tab_foundry/research/scaling/__init__.py
+++ b/src/tab_foundry/research/scaling/__init__.py
@@ -1,5 +1,6 @@
 """Scaling-study helpers."""
 
+from .audit import SCALING_AUDIT_SCHEMA, audit_scaling_study
 from .fit import collect_completed_scaling_points, fit_scaling_study, inspect_scaling_study
 from .study import (
     SCALING_STUDY_SCHEMA,
@@ -11,9 +12,11 @@ from .study import (
 )
 
 __all__ = [
+    "SCALING_AUDIT_SCHEMA",
     "SCALING_STUDY_SCHEMA",
     "ScalingStudyConfig",
     "ScalingStudySweepRef",
+    "audit_scaling_study",
     "collect_completed_scaling_points",
     "default_scaling_studies_root",
     "default_scaling_study_path",

--- a/src/tab_foundry/research/scaling/audit.py
+++ b/src/tab_foundry/research/scaling/audit.py
@@ -1,0 +1,1083 @@
+"""Scaling-study fit audit diagnostics."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping, Sequence
+
+import numpy as np
+
+from tab_foundry.bench.artifacts import write_json
+from tab_foundry.repo_paths import normalize_repo_relative_path, repo_root
+from tab_foundry.research.scaling.fit import (
+    FIT_SCOPE_ALL,
+    FIT_SCOPE_NS_ONLY,
+    FIT_SCOPE_CHOICES,
+    ScalingStudyRunPoint,
+    _batch_envelope,
+    _batch_points,
+    _fit_stats,
+    _missing_validation_points,
+    _normalize_fit_scope,
+    _ns_points,
+    _target_values,
+    _validate_c_axis_points,
+    _validation_backed_points,
+    _validation_coverage_payload,
+    collect_completed_scaling_points,
+    fit_bcrit,
+    fit_loss_vs_nd,
+    fit_loss_vs_ns,
+    fit_loss_vs_scale,
+    select_l_d_points,
+    select_l_n_points,
+)
+from tab_foundry.research.scaling.study import ScalingStudyConfig, load_scaling_study_config
+
+
+SCALING_AUDIT_SCHEMA = "tab-foundry-scaling-audit-v1"
+AUDIT_SCOPE_CHOICES = FIT_SCOPE_CHOICES
+AuditScope = Literal["all", "ns-only"]
+_MIN_POSITIVE = 1.0e-12
+_MIN_BOOTSTRAP_SAMPLES = 1
+_DEFAULT_BOOTSTRAP_SAMPLES = 64
+_MIN_UNIVARIATE_FIT_POINTS = 2
+_MIN_JOINT_FIT_POINTS = 4
+_MIN_BROKEN_POWER_POINTS = 5
+_MIN_INTERPOLATED_BATCHES = 2
+_PARAMETER_BOUND_TOLERANCE = 1.0e-10
+_INTERPOLATION_TOLERANCE = 1.0e-12
+_LARGE_ALPHA_WARNING = 25.0
+_VERY_LARGE_ALPHA_WARNING = 100.0
+_MIN_CMIN_ISO_LOSS_ESTIMATES = 4
+_MIN_CMIN_GEOMETRIES = 3
+
+
+def _target_points(
+    points: Sequence[ScalingStudyRunPoint],
+    *,
+    target_key: str,
+) -> tuple[ScalingStudyRunPoint, ...]:
+    if target_key == "validation_loss":
+        return _validation_backed_points(points)
+    return tuple(points)
+
+
+def _fit_parameter_flags(
+    fit_payload: Mapping[str, Any],
+    *,
+    context: str,
+) -> list[dict[str, Any]]:
+    parameters = fit_payload.get("parameters")
+    if not isinstance(parameters, Mapping):
+        return []
+    flags: list[dict[str, Any]] = []
+    for raw_name, raw_value in parameters.items():
+        name = str(raw_name)
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(value):
+            flags.append(
+                {
+                    "context": context,
+                    "parameter": name,
+                    "reason": "non_finite_parameter",
+                    "value": raw_value,
+                }
+            )
+            continue
+        if value <= _PARAMETER_BOUND_TOLERANCE:
+            flags.append(
+                {
+                    "context": context,
+                    "parameter": name,
+                    "reason": "near_lower_bound",
+                    "value": value,
+                }
+            )
+        if name.startswith("alpha") and value >= _VERY_LARGE_ALPHA_WARNING:
+            flags.append(
+                {
+                    "context": context,
+                    "parameter": name,
+                    "reason": "very_large_alpha",
+                    "value": value,
+                }
+            )
+        elif name.startswith("alpha") and value >= _LARGE_ALPHA_WARNING:
+            flags.append(
+                {
+                    "context": context,
+                    "parameter": name,
+                    "reason": "large_alpha",
+                    "value": value,
+                }
+            )
+    return flags
+
+
+def _fit_univariate(
+    *,
+    name: str,
+    points: Sequence[ScalingStudyRunPoint],
+    target_key: str,
+    x_value: Callable[[ScalingStudyRunPoint], float],
+    scale_name: str,
+    alpha_name: str,
+) -> dict[str, Any]:
+    selected_points = _target_points(points, target_key=target_key)
+    if len(selected_points) < _MIN_UNIVARIATE_FIT_POINTS:
+        return {
+            "status": "skipped",
+            "reason": "insufficient_points",
+            "n_points": len(selected_points),
+        }
+    fit_payload = fit_loss_vs_scale(
+        name=name,
+        x_values=[x_value(point) for point in selected_points],
+        y_values=_target_values(selected_points, target_key=target_key, context=name),
+        scale_name=scale_name,
+        alpha_name=alpha_name,
+    )
+    return {
+        "status": "fit",
+        **fit_payload,
+        "target_key": target_key,
+        "points": [point.as_dict() for point in selected_points],
+        "fit_quality_flags": _fit_parameter_flags(
+            fit_payload,
+            context=f"{name}:{target_key}",
+        ),
+    }
+
+
+def _fit_joint(
+    *,
+    name: str,
+    points: Sequence[ScalingStudyRunPoint],
+    target_key: str,
+    family: Literal["nd", "ns"],
+) -> dict[str, Any]:
+    selected_points = _target_points(points, target_key=target_key)
+    if len(selected_points) < _MIN_JOINT_FIT_POINTS:
+        return {
+            "status": "skipped",
+            "reason": "insufficient_points",
+            "n_points": len(selected_points),
+        }
+    fit_payload = (
+        fit_loss_vs_nd(points=selected_points, target_key=target_key)
+        if family == "nd"
+        else fit_loss_vs_ns(points=selected_points, target_key=target_key)
+    )
+    return {
+        "status": "fit",
+        **fit_payload,
+        "target_key": target_key,
+        "points": [point.as_dict() for point in selected_points],
+        "fit_quality_flags": _fit_parameter_flags(
+            fit_payload,
+            context=f"{name}:{target_key}",
+        ),
+    }
+
+
+def _target_comparisons(points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+    ns_points = _ns_points(points)
+    l_n_points = select_l_n_points(points)
+    l_d_points = select_l_d_points(points)
+    comparisons: dict[str, Any] = {
+        "primary_target": "validation_loss",
+        "external_transfer_target": "benchmark_log_loss",
+        "fits": {},
+    }
+    c_axis_error: str | None = None
+    try:
+        _validate_c_axis_points(points, context="fit audit L(C)")
+        c_axis_points: tuple[ScalingStudyRunPoint, ...] = tuple(points)
+    except RuntimeError as exc:
+        c_axis_error = str(exc)
+        c_axis_points = ()
+
+    specs: list[tuple[str, Callable[[str], dict[str, Any]]]] = [
+        (
+            "L(N)",
+            lambda target_key: _fit_univariate(
+                name="L(N)",
+                points=l_n_points,
+                target_key=target_key,
+                x_value=lambda point: point.n,
+                scale_name="Nc",
+                alpha_name="alpha_n",
+            ),
+        ),
+        (
+            "L(D)",
+            lambda target_key: _fit_univariate(
+                name="L(D)",
+                points=l_d_points,
+                target_key=target_key,
+                x_value=lambda point: point.d,
+                scale_name="Dc",
+                alpha_name="alpha_d",
+            ),
+        ),
+        (
+            "L(N,D)",
+            lambda target_key: _fit_joint(
+                name="L(N,D)",
+                points=ns_points,
+                target_key=target_key,
+                family="nd",
+            ),
+        ),
+        (
+            "L(N,S)",
+            lambda target_key: _fit_joint(
+                name="L(N,S)",
+                points=ns_points,
+                target_key=target_key,
+                family="ns",
+            ),
+        ),
+    ]
+    if c_axis_error is None:
+        specs.insert(
+            2,
+            (
+                "L(C)",
+                lambda target_key: _fit_univariate(
+                    name="L(C)",
+                    points=c_axis_points,
+                    target_key=target_key,
+                    x_value=lambda point: point.c,
+                    scale_name="Cc",
+                    alpha_name="alpha_c",
+                ),
+            ),
+        )
+    else:
+        comparisons["fits"]["L(C)"] = {
+            "benchmark_log_loss": {"status": "skipped", "reason": c_axis_error},
+            "validation_loss": {"status": "skipped", "reason": c_axis_error},
+        }
+
+    for fit_name, fit_fn in specs:
+        comparisons["fits"].setdefault(fit_name, {})
+        for target_key in ("benchmark_log_loss", "validation_loss"):
+            try:
+                comparisons["fits"][fit_name][target_key] = fit_fn(target_key)
+            except RuntimeError as exc:
+                comparisons["fits"][fit_name][target_key] = {
+                    "status": "failed",
+                    "reason": str(exc),
+                }
+    return comparisons
+
+
+def _parameters(fit_payload: Mapping[str, Any], *, context: str) -> dict[str, float]:
+    raw_parameters = fit_payload.get("parameters")
+    if not isinstance(raw_parameters, Mapping):
+        raise RuntimeError(f"{context} missing fit parameters")
+    resolved: dict[str, float] = {}
+    for raw_name, raw_value in raw_parameters.items():
+        value = float(raw_value)
+        if not math.isfinite(value):
+            raise RuntimeError(f"{context} parameter {raw_name!r} must be finite")
+        resolved[str(raw_name)] = value
+    return resolved
+
+
+def _predict_joint(
+    fit_payload: Mapping[str, Any],
+    points: Sequence[ScalingStudyRunPoint],
+    *,
+    family: Literal["nd", "ns"],
+) -> list[float]:
+    parameters = _parameters(fit_payload, context=str(fit_payload.get("name") or "joint fit"))
+    irreducible_loss = parameters["irreducible_loss"]
+    nc = parameters["Nc"]
+    alpha_n = parameters["alpha_n"]
+    if family == "nd":
+        dc = parameters["Dc"]
+        alpha_d = parameters["alpha_d"]
+        return [
+            float(
+                irreducible_loss
+                + (
+                    (nc / max(point.n, _MIN_POSITIVE)) ** (alpha_n / alpha_d)
+                    + (dc / max(point.d, _MIN_POSITIVE))
+                )
+                ** alpha_d
+            )
+            for point in points
+        ]
+    sc = parameters["Sc"]
+    alpha_s = parameters["alpha_s"]
+    return [
+        float(
+            irreducible_loss
+            + (
+                (nc / max(point.n, _MIN_POSITIVE)) ** (alpha_n / alpha_s)
+                + (sc / max(point.s, _MIN_POSITIVE))
+            )
+            ** alpha_s
+        )
+        for point in points
+    ]
+
+
+def _holdout_summary(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {"status": "skipped", "reason": "no_successful_holdouts", "n_holdout_points": 0}
+    y_true = np.asarray([float(row["observed"]) for row in rows], dtype=float)
+    y_pred = np.asarray([float(row["predicted"]) for row in rows], dtype=float)
+    return {
+        "status": "computed",
+        "n_holdout_points": len(rows),
+        "stats": _fit_stats(y_true=y_true, y_pred=y_pred, param_count=0),
+        "rows": list(rows),
+    }
+
+
+def _holdout_joint_fit(
+    *,
+    name: str,
+    points: Sequence[ScalingStudyRunPoint],
+    target_key: str,
+    family: Literal["nd", "ns"],
+    group_key: Callable[[ScalingStudyRunPoint], str],
+    group_axis: str,
+    min_train_points: int = 6,
+) -> dict[str, Any]:
+    selected_points = _target_points(points, target_key=target_key)
+    groups: dict[str, list[ScalingStudyRunPoint]] = {}
+    for point in selected_points:
+        groups.setdefault(group_key(point), []).append(point)
+    rows: list[dict[str, Any]] = []
+    skipped_groups: list[dict[str, Any]] = []
+    fit_fn = fit_loss_vs_nd if family == "nd" else fit_loss_vs_ns
+    for heldout_value, test_points in sorted(groups.items()):
+        train_points = tuple(point for point in selected_points if group_key(point) != heldout_value)
+        if len(train_points) < min_train_points:
+            skipped_groups.append(
+                {
+                    "heldout": heldout_value,
+                    "reason": "insufficient_train_points",
+                    "train_points": len(train_points),
+                }
+            )
+            continue
+        try:
+            fit_payload = fit_fn(points=train_points, target_key=target_key)
+            predictions = _predict_joint(fit_payload, test_points, family=family)
+            observed = _target_values(test_points, target_key=target_key, context=name)
+        except RuntimeError as exc:
+            skipped_groups.append(
+                {
+                    "heldout": heldout_value,
+                    "reason": str(exc),
+                    "train_points": len(train_points),
+                }
+            )
+            continue
+        for point, observed_value, predicted_value in zip(
+            test_points,
+            observed,
+            predictions,
+            strict=False,
+        ):
+            rows.append(
+                {
+                    "group_axis": group_axis,
+                    "heldout": heldout_value,
+                    "target_key": target_key,
+                    "fit": name,
+                    "run_id": point.run_id,
+                    "row_label": point.row_label,
+                    "steps": point.steps,
+                    "observed": float(observed_value),
+                    "predicted": float(predicted_value),
+                    "residual": float(observed_value - predicted_value),
+                }
+            )
+    payload = _holdout_summary(rows)
+    payload["skipped_groups"] = skipped_groups
+    return payload
+
+
+def _holdout_residuals(points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+    ns_points = _ns_points(points)
+    payload: dict[str, Any] = {}
+    for fit_name, family in (("L(N,D)", "nd"), ("L(N,S)", "ns")):
+        payload[fit_name] = {}
+        for target_key in ("validation_loss", "benchmark_log_loss"):
+            payload[fit_name][target_key] = {
+                "leave_one_geometry": _holdout_joint_fit(
+                    name=fit_name,
+                    points=ns_points,
+                    target_key=target_key,
+                    family=family,  # type: ignore[arg-type]
+                    group_key=lambda point: point.row_label,
+                    group_axis="row_label",
+                ),
+                "leave_one_step": _holdout_joint_fit(
+                    name=fit_name,
+                    points=ns_points,
+                    target_key=target_key,
+                    family=family,  # type: ignore[arg-type]
+                    group_key=lambda point: str(point.steps),
+                    group_axis="steps",
+                ),
+            }
+    return payload
+
+
+def _bootstrap_parameter_summary(samples: Mapping[str, Sequence[float]]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for parameter_name, values in sorted(samples.items()):
+        finite_values = np.asarray([float(value) for value in values if math.isfinite(float(value))])
+        if finite_values.size == 0:
+            summary[parameter_name] = None
+            continue
+        lower, median, upper = np.percentile(finite_values, [2.5, 50.0, 97.5])
+        summary[parameter_name] = {
+            "lower": float(lower),
+            "median": float(median),
+            "upper": float(upper),
+            "n": int(finite_values.size),
+        }
+    return summary
+
+
+def _bootstrap_fit(
+    *,
+    name: str,
+    points: Sequence[ScalingStudyRunPoint],
+    target_key: str,
+    samples: int,
+    rng: np.random.Generator,
+    fit_fn: Callable[[Sequence[ScalingStudyRunPoint]], dict[str, Any]],
+    parameter_names: Sequence[str],
+    min_points: int,
+) -> dict[str, Any]:
+    selected_points = _target_points(points, target_key=target_key)
+    if len(selected_points) < min_points:
+        return {
+            "status": "skipped",
+            "reason": "insufficient_points",
+            "n_points": len(selected_points),
+        }
+    parameter_samples: dict[str, list[float]] = {name: [] for name in parameter_names}
+    failures: list[str] = []
+    for _ in range(max(_MIN_BOOTSTRAP_SAMPLES, int(samples))):
+        indexes = rng.integers(0, len(selected_points), size=len(selected_points))
+        sampled_points = tuple(selected_points[int(index)] for index in indexes)
+        try:
+            fit_payload = fit_fn(sampled_points)
+            parameters = _parameters(fit_payload, context=name)
+        except RuntimeError as exc:
+            failures.append(str(exc))
+            continue
+        for parameter_name in parameter_names:
+            value = parameters.get(parameter_name)
+            if value is not None and math.isfinite(value):
+                parameter_samples[parameter_name].append(float(value))
+    accepted = max((len(values) for values in parameter_samples.values()), default=0)
+    if accepted == 0:
+        return {
+            "status": "failed",
+            "reason": "no_successful_bootstrap_samples",
+            "n_points": len(selected_points),
+            "failures": failures[:10],
+        }
+    return {
+        "status": "computed",
+        "n_points": len(selected_points),
+        "attempted_samples": max(_MIN_BOOTSTRAP_SAMPLES, int(samples)),
+        "accepted_samples": accepted,
+        "failed_samples": len(failures),
+        "parameter_percentiles_95": _bootstrap_parameter_summary(parameter_samples),
+        "failure_examples": failures[:10],
+    }
+
+
+def _bootstrap_univariate_fit_fn(
+    *,
+    name: str,
+    target_key: str,
+    x_value: Callable[[ScalingStudyRunPoint], float],
+    scale_name: str,
+    alpha_name: str,
+) -> Callable[[Sequence[ScalingStudyRunPoint]], dict[str, Any]]:
+    def _fit(sample_points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+        return fit_loss_vs_scale(
+            name=name,
+            x_values=[x_value(point) for point in sample_points],
+            y_values=_target_values(sample_points, target_key=target_key, context=name),
+            scale_name=scale_name,
+            alpha_name=alpha_name,
+        )
+
+    return _fit
+
+
+def _bootstrap_joint_fit_fn(
+    *,
+    target_key: str,
+    family: Literal["nd", "ns"],
+) -> Callable[[Sequence[ScalingStudyRunPoint]], dict[str, Any]]:
+    def _fit(sample_points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+        if family == "nd":
+            return fit_loss_vs_nd(points=sample_points, target_key=target_key)
+        return fit_loss_vs_ns(points=sample_points, target_key=target_key)
+
+    return _fit
+
+
+def _bootstrap_confidence_intervals(
+    points: Sequence[ScalingStudyRunPoint],
+    *,
+    samples: int,
+    seed: int,
+) -> dict[str, Any]:
+    rng = np.random.default_rng(int(seed))
+    ns_points = _ns_points(points)
+    l_n_points = select_l_n_points(points)
+    l_d_points = select_l_d_points(points)
+    c_axis_points: tuple[ScalingStudyRunPoint, ...]
+    try:
+        _validate_c_axis_points(points, context="fit audit bootstrap L(C)")
+        c_axis_points = tuple(points)
+        c_axis_skip: str | None = None
+    except RuntimeError as exc:
+        c_axis_points = ()
+        c_axis_skip = str(exc)
+
+    payload: dict[str, Any] = {
+        "samples": int(samples),
+        "seed": int(seed),
+        "fits": {},
+    }
+    for target_key in ("benchmark_log_loss", "validation_loss"):
+        payload["fits"].setdefault("L(N)", {})[target_key] = _bootstrap_fit(
+            name=f"L(N):{target_key}",
+            points=l_n_points,
+            target_key=target_key,
+            samples=samples,
+            rng=rng,
+            min_points=_MIN_UNIVARIATE_FIT_POINTS,
+            parameter_names=("irreducible_loss", "Nc", "alpha_n"),
+            fit_fn=_bootstrap_univariate_fit_fn(
+                name="L(N)",
+                target_key=target_key,
+                x_value=lambda point: point.n,
+                scale_name="Nc",
+                alpha_name="alpha_n",
+            ),
+        )
+        payload["fits"].setdefault("L(D)", {})[target_key] = _bootstrap_fit(
+            name=f"L(D):{target_key}",
+            points=l_d_points,
+            target_key=target_key,
+            samples=samples,
+            rng=rng,
+            min_points=_MIN_UNIVARIATE_FIT_POINTS,
+            parameter_names=("irreducible_loss", "Dc", "alpha_d"),
+            fit_fn=_bootstrap_univariate_fit_fn(
+                name="L(D)",
+                target_key=target_key,
+                x_value=lambda point: point.d,
+                scale_name="Dc",
+                alpha_name="alpha_d",
+            ),
+        )
+        if c_axis_skip is None:
+            payload["fits"].setdefault("L(C)", {})[target_key] = _bootstrap_fit(
+                name=f"L(C):{target_key}",
+                points=c_axis_points,
+                target_key=target_key,
+                samples=samples,
+                rng=rng,
+                min_points=_MIN_UNIVARIATE_FIT_POINTS,
+                parameter_names=("irreducible_loss", "Cc", "alpha_c"),
+                fit_fn=_bootstrap_univariate_fit_fn(
+                    name="L(C)",
+                    target_key=target_key,
+                    x_value=lambda point: point.c,
+                    scale_name="Cc",
+                    alpha_name="alpha_c",
+                ),
+            )
+        else:
+            payload["fits"].setdefault("L(C)", {})[target_key] = {
+                "status": "skipped",
+                "reason": c_axis_skip,
+            }
+        payload["fits"].setdefault("L(N,D)", {})[target_key] = _bootstrap_fit(
+            name=f"L(N,D):{target_key}",
+            points=ns_points,
+            target_key=target_key,
+            samples=samples,
+            rng=rng,
+            min_points=_MIN_JOINT_FIT_POINTS,
+            parameter_names=("irreducible_loss", "Nc", "Dc", "alpha_n", "alpha_d"),
+            fit_fn=_bootstrap_joint_fit_fn(target_key=target_key, family="nd"),
+        )
+        payload["fits"].setdefault("L(N,S)", {})[target_key] = _bootstrap_fit(
+            name=f"L(N,S):{target_key}",
+            points=ns_points,
+            target_key=target_key,
+            samples=samples,
+            rng=rng,
+            min_points=_MIN_JOINT_FIT_POINTS,
+            parameter_names=("irreducible_loss", "Nc", "Sc", "alpha_n", "alpha_s"),
+            fit_fn=_bootstrap_joint_fit_fn(target_key=target_key, family="ns"),
+        )
+    batch_points = _batch_points(points)
+    envelope_points = _batch_envelope(batch_points)
+    if len(envelope_points) < _MIN_CMIN_ISO_LOSS_ESTIMATES:
+        payload["fits"]["Bcrit(L)"] = {
+            "validation_loss": {
+                "status": "skipped",
+                "reason": "insufficient_batch_envelope_points",
+                "envelope_points": len(envelope_points),
+                "required_envelope_points": _MIN_CMIN_ISO_LOSS_ESTIMATES,
+            }
+        }
+    else:
+        payload["fits"]["Bcrit(L)"] = {
+            "validation_loss": _bootstrap_fit(
+                name="Bcrit(L):validation_loss",
+                points=batch_points,
+                target_key="validation_loss",
+                samples=samples,
+                rng=rng,
+                min_points=_MIN_CMIN_ISO_LOSS_ESTIMATES,
+                parameter_names=("B_star", "alpha_b"),
+                fit_fn=fit_bcrit,
+            )
+        }
+    return payload
+
+
+def _linear_log_fit(log_x: np.ndarray, log_y: np.ndarray) -> tuple[np.ndarray, float, np.ndarray]:
+    design = np.column_stack([np.ones(log_x.size), log_x])
+    coefficients, *_ = np.linalg.lstsq(design, log_y, rcond=None)
+    predictions = design @ coefficients
+    rss = float(np.sum((log_y - predictions) ** 2))
+    return coefficients, rss, predictions
+
+
+def _direction_change_count(values: Sequence[float]) -> int:
+    signs: list[int] = []
+    for left, right in zip(values, values[1:], strict=False):
+        delta = float(right) - float(left)
+        if abs(delta) <= _INTERPOLATION_TOLERANCE:
+            continue
+        signs.append(1 if delta > 0.0 else -1)
+    return sum(1 for left, right in zip(signs, signs[1:], strict=False) if left != right)
+
+
+def _broken_power_diagnostic(
+    *,
+    name: str,
+    points: Sequence[ScalingStudyRunPoint],
+    target_key: str,
+    x_value: Callable[[ScalingStudyRunPoint], float],
+) -> dict[str, Any]:
+    selected_points = _target_points(points, target_key=target_key)
+    if len(selected_points) < _MIN_BROKEN_POWER_POINTS:
+        return {
+            "status": "skipped",
+            "reason": "insufficient_points",
+            "n_points": len(selected_points),
+        }
+    ordered = sorted(selected_points, key=lambda point: x_value(point))
+    x_values = np.asarray([float(x_value(point)) for point in ordered], dtype=float)
+    y_values = np.asarray(
+        _target_values(ordered, target_key=target_key, context=f"{name} broken-power diagnostic"),
+        dtype=float,
+    )
+    unique_x = np.unique(x_values)
+    if unique_x.size < _MIN_BROKEN_POWER_POINTS:
+        return {
+            "status": "skipped",
+            "reason": "insufficient_unique_x_values",
+            "n_points": len(selected_points),
+            "unique_x_values": int(unique_x.size),
+        }
+    floor = max(_MIN_POSITIVE, 0.9 * float(np.min(y_values)))
+    shifted = np.maximum(y_values - floor, _MIN_POSITIVE)
+    log_x = np.log(x_values)
+    log_y = np.log(shifted)
+    single_coefficients, single_rss, single_predictions = _linear_log_fit(log_x, log_y)
+    n_points = int(log_x.size)
+    single_aic = float(n_points * math.log(max(single_rss, _MIN_POSITIVE) / n_points) + 4.0)
+    best: dict[str, Any] | None = None
+    for break_index in range(2, n_points - 1):
+        if x_values[break_index - 1] == x_values[break_index]:
+            continue
+        left_coefficients, left_rss, left_predictions = _linear_log_fit(
+            log_x[:break_index],
+            log_y[:break_index],
+        )
+        right_coefficients, right_rss, right_predictions = _linear_log_fit(
+            log_x[break_index:],
+            log_y[break_index:],
+        )
+        rss = left_rss + right_rss
+        aic = float(n_points * math.log(max(rss, _MIN_POSITIVE) / n_points) + 8.0)
+        predictions = np.concatenate([left_predictions, right_predictions])
+        candidate = {
+            "break_index": int(break_index),
+            "break_x": float(x_values[break_index]),
+            "rss": float(rss),
+            "aic": aic,
+            "left_alpha": float(-left_coefficients[1]),
+            "right_alpha": float(-right_coefficients[1]),
+            "log_space_residuals": (log_y - predictions).tolist(),
+        }
+        if best is None or aic < float(best["aic"]):
+            best = candidate
+    if best is None:
+        return {
+            "status": "skipped",
+            "reason": "no_valid_breakpoint",
+            "n_points": len(selected_points),
+        }
+    return {
+        "status": "computed",
+        "target_key": target_key,
+        "n_points": len(selected_points),
+        "floor": floor,
+        "single_power_law": {
+            "rss": single_rss,
+            "aic": single_aic,
+            "alpha": float(-single_coefficients[1]),
+            "log_space_residuals": (log_y - single_predictions).tolist(),
+        },
+        "best_broken_power_law": {
+            **best,
+            "delta_aic_vs_single": float(best["aic"] - single_aic),
+        },
+        "loss_direction_changes": _direction_change_count(y_values.tolist()),
+        "diagnostic_only": True,
+    }
+
+
+def _broken_power_law_diagnostics(points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {}
+    specs: list[tuple[str, Sequence[ScalingStudyRunPoint], Callable[[ScalingStudyRunPoint], float]]] = [
+        ("L(N)", select_l_n_points(points), lambda point: point.n),
+        ("L(D)", select_l_d_points(points), lambda point: point.d),
+        ("L(C)", tuple(points), lambda point: point.c),
+    ]
+    for fit_name, selected_points, x_value in specs:
+        diagnostics[fit_name] = {}
+        for target_key in ("benchmark_log_loss", "validation_loss"):
+            try:
+                diagnostics[fit_name][target_key] = _broken_power_diagnostic(
+                    name=fit_name,
+                    points=selected_points,
+                    target_key=target_key,
+                    x_value=x_value,
+                )
+            except RuntimeError as exc:
+                diagnostics[fit_name][target_key] = {"status": "failed", "reason": str(exc)}
+    return diagnostics
+
+
+def _interpolate_point_at_loss(
+    points: Sequence[ScalingStudyRunPoint],
+    *,
+    target_loss: float,
+) -> dict[str, float] | None:
+    ordered = sorted(
+        _validation_backed_points(points),
+        key=lambda point: _target_values([point], target_key="validation_loss", context="iso-loss")[
+            0
+        ],
+    )
+    if not ordered:
+        return None
+    losses = [float(point.validation_loss) for point in ordered if point.validation_loss is not None]
+    if (
+        target_loss < min(losses) - _INTERPOLATION_TOLERANCE
+        or target_loss > max(losses) + _INTERPOLATION_TOLERANCE
+    ):
+        return None
+    for point in ordered:
+        if (
+            point.validation_loss is not None
+            and abs(float(point.validation_loss) - target_loss) <= _INTERPOLATION_TOLERANCE
+        ):
+            return {"steps": point.s, "compute": point.c, "batch": point.b_eff}
+    for left, right in zip(ordered, ordered[1:], strict=False):
+        if left.validation_loss is None or right.validation_loss is None:
+            continue
+        left_loss = float(left.validation_loss)
+        right_loss = float(right.validation_loss)
+        if not (left_loss <= target_loss <= right_loss):
+            continue
+        denominator = max(right_loss - left_loss, _MIN_POSITIVE)
+        weight = (target_loss - left_loss) / denominator
+        return {
+            "steps": float(left.s + weight * (right.s - left.s)),
+            "compute": float(left.c + weight * (right.c - left.c)),
+            "batch": float(left.b_eff + weight * (right.b_eff - left.b_eff)),
+        }
+    return None
+
+
+def _iso_loss_bcrit_readiness(batch_points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+    validation_points = _validation_backed_points(batch_points)
+    by_geometry: dict[str, list[ScalingStudyRunPoint]] = {}
+    for point in validation_points:
+        by_geometry.setdefault(point.row_label, []).append(point)
+    estimates: list[dict[str, Any]] = []
+    for row_label, geometry_points in sorted(by_geometry.items()):
+        by_batch: dict[float, list[ScalingStudyRunPoint]] = {}
+        for point in geometry_points:
+            by_batch.setdefault(float(point.b_eff), []).append(point)
+        candidate_losses = sorted(
+            {
+                round(float(point.validation_loss), 12)
+                for point in geometry_points
+                if point.validation_loss is not None
+            }
+        )
+        for target_loss in candidate_losses:
+            interpolated = [
+                interpolation
+                for batch_group in by_batch.values()
+                if (
+                    interpolation := _interpolate_point_at_loss(
+                        batch_group,
+                        target_loss=float(target_loss),
+                    )
+                )
+                is not None
+            ]
+            if len(interpolated) < _MIN_INTERPOLATED_BATCHES:
+                continue
+            emin = min(float(item["compute"]) for item in interpolated)
+            smin = min(float(item["steps"]) for item in interpolated)
+            estimates.append(
+                {
+                    "row_label": row_label,
+                    "target_validation_loss": float(target_loss),
+                    "candidate_batches": len(interpolated),
+                    "emin": emin,
+                    "smin": smin,
+                    "bcrit_estimate": float(emin / max(smin, _MIN_POSITIVE)),
+                }
+            )
+    distinct_geometries = sorted({estimate["row_label"] for estimate in estimates})
+    ready = (
+        len(estimates) >= _MIN_CMIN_ISO_LOSS_ESTIMATES
+        and len(distinct_geometries) >= _MIN_CMIN_GEOMETRIES
+    )
+    return {
+        "method": "diagnostic_iso_loss_interpolation",
+        "ready_for_cmin": ready,
+        "iso_loss_estimates": estimates,
+        "iso_loss_estimate_count": len(estimates),
+        "distinct_geometry_count": len(distinct_geometries),
+        "distinct_geometries": distinct_geometries,
+        "required_iso_loss_estimates": _MIN_CMIN_ISO_LOSS_ESTIMATES,
+        "required_geometry_count": _MIN_CMIN_GEOMETRIES,
+        "recommendation": (
+            "Bcrit(L) may be used for Cmin once the iso-loss contour and geometry gates pass."
+            if ready
+            else "Do not use Bcrit(L) to derive Cmin; run the redesigned multi-geometry batch sweep first."
+        ),
+    }
+
+
+def _fit_policy_diagnostics(points: Sequence[ScalingStudyRunPoint]) -> dict[str, Any]:
+    batch_points = _batch_points(points)
+    envelope = _batch_envelope(batch_points)
+    return {
+        "primary_target": "validation_loss",
+        "benchmark_target_role": "external_transfer_validation_and_repo_ranking",
+        "do_not_import_paper_exponents": True,
+        "reject_or_quarantine_flags": [
+            "near_lower_bound",
+            "large_alpha",
+            "very_large_alpha",
+            "non_finite_parameter",
+        ],
+        "bcrit_envelope_points": len(envelope),
+        "bcrit_iso_loss_readiness": _iso_loss_bcrit_readiness(batch_points),
+        "missing_validation_points": [
+            point.as_dict() for point in _missing_validation_points(points)
+        ],
+    }
+
+
+def _audit_markdown(
+    *,
+    config: ScalingStudyConfig,
+    artifact_root: Path,
+    payload: Mapping[str, Any],
+) -> str:
+    counts = payload.get("counts", {})
+    policy = payload.get("fit_policy", {})
+    readiness = {}
+    if isinstance(policy, Mapping):
+        readiness = policy.get("bcrit_iso_loss_readiness", {})
+    lines = [
+        f"# {config.study_id} Scaling Fit Audit",
+        "",
+        f"- Artifact root: `{normalize_repo_relative_path(artifact_root)}`",
+        f"- Completed points: `{counts.get('total_completed_points', 0)}`",
+        f"- Validation-backed points: `{counts.get('validation_backed_points', 0)}`",
+        "- Primary target: `validation_loss`",
+        "- Benchmark target role: `external_transfer_validation_and_repo_ranking`",
+        "",
+        "## Bcrit Readiness",
+        (
+            f"- ready_for_cmin: `{readiness.get('ready_for_cmin')}` "
+            f"iso_loss_estimates=`{readiness.get('iso_loss_estimate_count')}` "
+            f"geometries=`{readiness.get('distinct_geometry_count')}`"
+        ),
+        f"- recommendation: {readiness.get('recommendation', 'unknown')}",
+        "",
+        "## Holdout Diagnostics",
+    ]
+    holdouts = payload.get("holdout_residuals", {})
+    if isinstance(holdouts, Mapping):
+        for fit_name in sorted(holdouts):
+            fit_payload = holdouts.get(fit_name)
+            if not isinstance(fit_payload, Mapping):
+                continue
+            lines.append(f"- `{fit_name}`")
+            for target_key in sorted(fit_payload):
+                target_payload = fit_payload.get(target_key)
+                if not isinstance(target_payload, Mapping):
+                    continue
+                for group_axis, axis_payload in sorted(target_payload.items()):
+                    if not isinstance(axis_payload, Mapping):
+                        continue
+                    stats = axis_payload.get("stats") if isinstance(axis_payload, Mapping) else None
+                    rmse = stats.get("rmse") if isinstance(stats, Mapping) else None
+                    lines.append(
+                        f"  - `{target_key}` `{group_axis}`: "
+                        f"status=`{axis_payload.get('status')}` rmse=`{rmse}`"
+                    )
+    return "\n".join(lines) + "\n"
+
+
+def audit_scaling_study(
+    *,
+    study_id: str | None = None,
+    study_path: Path | None = None,
+    studies_root: Path | None = None,
+    registry_path: Path,
+    index_path: Path,
+    catalog_path: Path,
+    sweeps_root: Path,
+    out_root: Path | None = None,
+    fit_scope: str = FIT_SCOPE_ALL,
+    bootstrap_samples: int = _DEFAULT_BOOTSTRAP_SAMPLES,
+    bootstrap_seed: int = 0,
+) -> dict[str, Any]:
+    """Audit a configured scaling study without executing new sweeps or W&B writes."""
+
+    normalized_scope = _normalize_fit_scope(fit_scope)
+    config = load_scaling_study_config(
+        study_id=study_id,
+        study_path=study_path,
+        studies_root=studies_root,
+    )
+    all_points = collect_completed_scaling_points(
+        config=config,
+        registry_path=registry_path,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+    )
+    points = _ns_points(all_points) if normalized_scope == FIT_SCOPE_NS_ONLY else all_points
+    artifact_root = (
+        out_root.expanduser().resolve()
+        if out_root is not None
+        else config.output_root_path(root=repo_root()) / "audit"
+    )
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    ns_points = _ns_points(points)
+    batch_points = _batch_points(points)
+    payload: dict[str, Any] = {
+        "schema": SCALING_AUDIT_SCHEMA,
+        "study": config.as_dict(),
+        "fit_scope": normalized_scope,
+        "counts": {
+            "total_completed_points": len(points),
+            "all_completed_points": len(all_points),
+            "ns_core_completed_points": len(ns_points),
+            "batch_critical_completed_points": len(batch_points),
+            "validation_backed_points": len(_validation_backed_points(points)),
+            "missing_validation_points": len(_missing_validation_points(points)),
+            "ns_core_validation_backed_points": len(_validation_backed_points(ns_points)),
+            "batch_critical_validation_backed_points": len(
+                _validation_backed_points(batch_points)
+            ),
+        },
+        "validation_coverage": _validation_coverage_payload(points),
+        "target_comparisons": _target_comparisons(points),
+        "holdout_residuals": _holdout_residuals(points),
+        "bootstrap_confidence_intervals": _bootstrap_confidence_intervals(
+            points,
+            samples=bootstrap_samples,
+            seed=bootstrap_seed,
+        ),
+        "broken_power_law_diagnostics": _broken_power_law_diagnostics(points),
+        "fit_policy": _fit_policy_diagnostics(points),
+        "artifact_paths": {
+            "artifact_root": str(artifact_root),
+            "json_path": str(artifact_root / "audit_summary.json"),
+            "markdown_path": str(artifact_root / "audit.md"),
+        },
+    }
+    write_json(artifact_root / "audit_summary.json", payload)
+    (artifact_root / "audit.md").write_text(
+        _audit_markdown(config=config, artifact_root=artifact_root, payload=payload),
+        encoding="utf-8",
+    )
+    return payload
+
+
+def render_scaling_audit_text(payload: Mapping[str, Any]) -> str:
+    """Render a short human-readable summary for `research scaling audit`."""
+
+    study = payload.get("study", {})
+    counts = payload.get("counts", {})
+    policy = payload.get("fit_policy", {})
+    readiness = policy.get("bcrit_iso_loss_readiness") if isinstance(policy, Mapping) else {}
+    if not isinstance(readiness, Mapping):
+        readiness = {}
+    lines = [
+        f"Study: {study.get('study_id', 'unknown')}",
+        f"Completed points: {counts.get('total_completed_points', 0)}",
+        f"Validation-backed points: {counts.get('validation_backed_points', 0)}",
+        "Primary target: validation_loss",
+        (
+            "Bcrit Cmin ready: "
+            f"{readiness.get('ready_for_cmin')} "
+            f"(iso-loss estimates={readiness.get('iso_loss_estimate_count')}, "
+            f"geometries={readiness.get('distinct_geometry_count')})"
+        ),
+        f"Audit JSON: {payload.get('artifact_paths', {}).get('json_path', 'unknown')}",
+    ]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "AUDIT_SCOPE_CHOICES",
+    "SCALING_AUDIT_SCHEMA",
+    "audit_scaling_study",
+    "render_scaling_audit_text",
+]

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -1073,7 +1073,7 @@ def test_cli_groups_register_expected_commands() -> None:
     assert _command_names(adequacy_group) == ["finalize", "pilot"]
     scaling_group = research_group.GROUP.get_command(research_ctx, "scaling")
     assert isinstance(scaling_group, click.Group)
-    assert _command_names(scaling_group) == ["backfill-validation", "fit", "inspect"]
+    assert _command_names(scaling_group) == ["audit", "backfill-validation", "fit", "inspect"]
     sweep_group = research_group.GROUP.get_command(research_ctx, "sweep")
     assert isinstance(sweep_group, click.Group)
     assert _command_names(sweep_group) == [

--- a/tests/research/test_scaling_fit.py
+++ b/tests/research/test_scaling_fit.py
@@ -11,8 +11,10 @@ import pytest
 
 import tab_foundry.cli.app as cli_module
 import tab_foundry.cli.research_scaling as research_scaling_cli_module
+import tab_foundry.research.scaling.audit as scaling_audit_module
 import tab_foundry.research.scaling.fit as scaling_fit_module
 import tab_foundry.research.scaling.validation_backfill as validation_backfill_module
+from tab_foundry.research.scaling.audit import audit_scaling_study
 from tab_foundry.research.scaling.fit import (
     ScalingStudyRunPoint,
     collect_completed_scaling_points,
@@ -791,6 +793,35 @@ def test_fit_scaling_study_ns_only_omits_batch_fits(
         assert not stale_plot.exists()
 
 
+def test_audit_scaling_study_emits_fit_diagnostics(tmp_path: Path) -> None:
+    study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
+
+    payload = audit_scaling_study(
+        study_path=study_path,
+        registry_path=registry_path,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+        out_root=tmp_path / "audit",
+        bootstrap_samples=2,
+        bootstrap_seed=7,
+    )
+
+    artifact_root = Path(payload["artifact_paths"]["artifact_root"])
+    assert payload["schema"] == scaling_audit_module.SCALING_AUDIT_SCHEMA
+    assert (artifact_root / "audit_summary.json").exists()
+    assert (artifact_root / "audit.md").exists()
+    assert payload["target_comparisons"]["primary_target"] == "validation_loss"
+    assert payload["target_comparisons"]["fits"]["L(N,S)"]["validation_loss"]["status"] == "fit"
+    assert "leave_one_geometry" in payload["holdout_residuals"]["L(N,S)"]["validation_loss"]
+    assert "bootstrap_confidence_intervals" in payload
+    assert payload["fit_policy"]["bcrit_iso_loss_readiness"]["ready_for_cmin"] is False
+    assert (
+        payload["fit_policy"]["bcrit_iso_loss_readiness"]["required_iso_loss_estimates"]
+        == 4
+    )
+
+
 def test_fit_scaling_study_all_scope_requires_batch_critical_points(tmp_path: Path) -> None:
     study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
     _mark_batch_queue_pending(sweeps_root)
@@ -1154,6 +1185,7 @@ def test_research_scaling_cli_dispatches_to_fit_and_inspect(
 ) -> None:
     inspect_called: dict[str, Any] = {}
     fit_called: dict[str, Any] = {}
+    audit_called: dict[str, Any] = {}
     backfill_called: dict[str, Any] = {}
     monkeypatch.setattr(
         research_scaling_cli_module,
@@ -1168,6 +1200,25 @@ def test_research_scaling_cli_dispatches_to_fit_and_inspect(
         lambda **kwargs: (
             fit_called.update(kwargs)
             or {"study": {"study_id": "synthetic"}, "counts": {}, "fit_summary": {}}
+        ),
+    )
+    monkeypatch.setattr(
+        research_scaling_cli_module,
+        "audit_scaling_study",
+        lambda **kwargs: (
+            audit_called.update(kwargs)
+            or {
+                "study": {"study_id": "synthetic"},
+                "counts": {},
+                "fit_policy": {
+                    "bcrit_iso_loss_readiness": {
+                        "ready_for_cmin": False,
+                        "iso_loss_estimate_count": 0,
+                        "distinct_geometry_count": 0,
+                    }
+                },
+                "artifact_paths": {"json_path": "audit_summary.json"},
+            }
         ),
     )
     monkeypatch.setattr(
@@ -1203,6 +1254,23 @@ def test_research_scaling_cli_dispatches_to_fit_and_inspect(
             "--json",
         ],
     )
+    audit_result = CliRunner().invoke(
+        cli_module.cli,
+        [
+            "research",
+            "scaling",
+            "audit",
+            "--study",
+            "synthetic_phase2",
+            "--fit-scope",
+            "ns-only",
+            "--bootstrap-samples",
+            "3",
+            "--bootstrap-seed",
+            "11",
+            "--json",
+        ],
+    )
     backfill_result = CliRunner().invoke(
         cli_module.cli,
         [
@@ -1220,10 +1288,15 @@ def test_research_scaling_cli_dispatches_to_fit_and_inspect(
 
     assert inspect_result.exit_code == 0
     assert fit_result.exit_code == 0
+    assert audit_result.exit_code == 0
     assert backfill_result.exit_code == 0
     assert inspect_called["study_id"] == "synthetic_phase2"
     assert fit_called["study_id"] == "synthetic_phase2"
     assert fit_called["fit_scope"] == "ns-only"
+    assert audit_called["study_id"] == "synthetic_phase2"
+    assert audit_called["fit_scope"] == "ns-only"
+    assert audit_called["bootstrap_samples"] == 3
+    assert audit_called["bootstrap_seed"] == 11
     assert backfill_called["study_id"] == "synthetic_phase2"
     assert backfill_called["preseed_gcs_root"] == str(Path("/tmp/source"))
     assert backfill_called["dry_run"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -1735,7 +1735,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.16.14"
+version = "0.16.15"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

Adds a post-#256 TF-RD-009 scaling audit command and report path for interpreting the completed Phase-2 scaling evidence before using it for compute-optimal planning.

## What changed

- Added `tab-foundry research scaling audit` with validation-vs-benchmark target comparisons, leave-one-geometry / leave-one-step holdouts, bootstrap parameter intervals, diagnostic broken-power-law checks, and an iso-loss `Bcrit(L)` readiness gate.
- Updated TF-RD-009 roadmap/evidence/workflow docs to keep validation loss as the primary law-fitting target, benchmark log loss as transfer/ranking evidence, and #259 as the owner of the real Chinchilla-like compute frontier.
- Bumped the package version to `0.16.15` and updated the changelog.

## Audit result

Ran:

```bash
tab-foundry research scaling audit --study tf_rd_009_phase2 --bootstrap-samples 64 --bootstrap-seed 0 --json
```

The audit confirms the existing interpretation: validation `L(N,S)` remains the strongest Kaplan-style signal, benchmark-loss joint fits still show degeneracy, leave-one-step validation holdouts are weak, and `Bcrit(L)` / derived `Cmin` remains quarantined with `ready_for_cmin=false`.

## Validation

- Commit hook passed: version bump guard, Ruff, mypy, and path verification.
- Previously ran full path verification including full pytest: `1504 passed, 12 skipped`.
- Targeted audit CLI tests passed after the final tolerance cleanup.

## Tracking

- Does not close #256.
- Keeps #259 as the follow-on owner for Chinchilla-like compute-frontier work.
- Keeps #260 separate for repetition/curriculum slices.
