### PR TITLE
[codex] Fix TF-RD-009 large validation artifact selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compute accounting. The compact TF-RD-009 registry state now corrects the
   reused 2,500-step NS rows plus the reused batch-critical 96x2 row that had
   inherited fallback `3x2x4x2` FLOP accounting.
+- User-facing note: the benchmark run registry and canonical
+  `tf_rd_009_large_validation_152x5_v1` sweep artifacts now record the
+  completed TF-RD-009 #257 large-rung validation. The reused `152x5` transfer
+  finished at `final_log_loss_at_matched_regime_budget=0.9337034781`, so the
+  result is a defer and the first TF-RD-009 hardware baseline remains
+  unfrozen.
 
 ## [0.16.12] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compute accounting. The compact TF-RD-009 registry state now corrects the
   reused 2,500-step NS rows plus the reused batch-critical 96x2 row that had
   inherited fallback `3x2x4x2` FLOP accounting.
-- User-facing note: the benchmark run registry and canonical
-  `tf_rd_009_large_validation_152x5_v1` sweep artifacts now record the
-  completed TF-RD-009 #257 large-rung validation. The reused `152x5` transfer
-  finished at `final_log_loss_at_matched_regime_budget=0.9337034781`, so the
-  result is a defer and the first TF-RD-009 hardware baseline remains
-  unfrozen.
+- User-facing note: telemetry-backed benchmark checkpoint selection now drops
+  `step_*.pt` entries whose files are missing from the retained reusable
+  artifact tree and appends terminal `latest.pt` when it is newer than the
+  highest retained numbered snapshot, so `benchmark_checkpoint_selection=all`
+  faithfully evaluates truncated reusable artifacts.
+- User-facing note: the benchmark run registry, canonical
+  `tf_rd_009_large_validation_152x5_v1` sweep artifacts, and hardware
+  architecture baseline registry now record the corrected TF-RD-009 #257
+  large-rung validation rerun. The reused `152x5` transfer consumed
+  `latest.pt` at step 2500, finished at
+  `final_log_loss_at_matched_regime_budget=0.7436636568` versus anchor
+  `0.8974410961`, and froze
+  `tf_rd_009_rtx8000_44gb_classification_medium_v1`.
 
 ## [0.16.12] - 2026-04-09
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -940,7 +940,7 @@ Legacy wording note:
   [#255](https://github.com/bensonlee5/tab-foundry/issues/255), completed
   Kaplan-exact Phase-2 fit/report child
   [#256](https://github.com/bensonlee5/tab-foundry/issues/256), follow-on
-  hardware-freeze child
+  large-rung validation / hardware-freeze child
   [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
   compute-frontier child
   [#259](https://github.com/bensonlee5/tab-foundry/issues/259), and
@@ -992,6 +992,15 @@ Legacy wording note:
     queue-construction planning axis
   - `152x5` is the current fixed-budget winner at `final_log_loss=0.5740` and
     `final_roc_auc=0.7351`
+  - `tf_rd_009_large_validation_152x5_v1` is now the staged #257 one-row
+    large-rung validation sweep that reuses the completed `152x5` train
+    artifact on `openml_classification_large_v1`; benchmark outcome is pending
+    execution on the retained RTX 8000 / CUDA runner
+  - the #257 gate is explicit: keep/defer on whether `152x5` beats the
+    TF-RD-010 large clean-control anchor `0.8974410961` at
+    `final_log_loss_at_matched_regime_budget`; only a pass should freeze the
+    first hardware baseline entry, and the large row itself does not join the
+    medium constraint-model evidence
   - `176x6` completed cleanly at `final_log_loss=0.5816` and
     `final_roc_auc=0.7238`; keep it as upper-family and near-ceiling evidence,
     but do not add extra near-ceiling rows on this branch because
@@ -1001,8 +1010,9 @@ Legacy wording note:
     `152x5` and `17.84 GiB` at `176x6`, materially below the pre-run
     width-evidence memory bridge; the hardware-freeze work in
     [#257](https://github.com/bensonlee5/tab-foundry/issues/257) now needs to
-    fit constraints from the completed mixed-depth evidence rather than treat
-    the old memory bridge as authoritative
+    fit constraints from the completed mixed-depth evidence only after the
+    staged `tf_rd_009_large_validation_152x5_v1` large-rung gate is executed,
+    rather than treat the old memory bridge as authoritative
   - TF-RD-021 remains sidecar corpus context under
     [#165](https://github.com/bensonlee5/tab-foundry/issues/165) rather than a
     blocker for this lane
@@ -1087,13 +1097,14 @@ Legacy wording note:
     hardware profile plus sweep surface rather than by GitHub issue state; the
     first TF-RD-009 entry should be the retained `rtx8000_44gb` medium
     classification surface selected from the healthy benchmark-backed evidence
-    only after the completed dense diagonal and the follow-on freeze work are
-    enough to freeze a real constraint model and preferred row
+    only after the completed dense diagonal and the #257 large-rung validation
+    gate are enough to freeze a real constraint model and preferred row
   - use [#256](https://github.com/bensonlee5/tab-foundry/issues/256) as the
     completed Kaplan-exact fit-and-report issue for the current Phase-2
     evidence payload, then
-    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) to freeze the
-    hardware baseline from the completed joint width-depth family
+    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) to run the
+    one-row `152x5` large-rung validation and freeze the hardware baseline only
+    on a passing transfer
   - keep [#259](https://github.com/bensonlee5/tab-foundry/issues/259) and
     [#260](https://github.com/bensonlee5/tab-foundry/issues/260) separate from
     the first fixed-budget law family

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -992,15 +992,22 @@ Legacy wording note:
     queue-construction planning axis
   - `152x5` is the current fixed-budget winner at `final_log_loss=0.5740` and
     `final_roc_auc=0.7351`
-  - `tf_rd_009_large_validation_152x5_v1` is now the staged #257 one-row
-    large-rung validation sweep that reuses the completed `152x5` train
-    artifact on `openml_classification_large_v1`; benchmark outcome is pending
-    execution on the retained RTX 8000 / CUDA runner
+  - `tf_rd_009_large_validation_152x5_v1` is now complete under
+    [#257](https://github.com/bensonlee5/tab-foundry/issues/257): the
+    benchmark-only `152x5` large-rung transfer reused the completed medium
+    train artifact on `openml_classification_large_v1` and finished at
+    `final_log_loss=0.9337034781`, which is worse than the carried TF-RD-010
+    large clean-control anchor `0.8974410961`
   - the #257 gate is explicit: keep/defer on whether `152x5` beats the
     TF-RD-010 large clean-control anchor `0.8974410961` at
     `final_log_loss_at_matched_regime_budget`; only a pass should freeze the
     first hardware baseline entry, and the large row itself does not join the
     medium constraint-model evidence
+  - the completed large-rung result is a defer: `delta_final_log_loss=+0.0363`
+    and `delta_final_roc_auc=-0.0240` versus the carried anchor, so
+    `src/tab_foundry/bench/hardware_architecture_baselines_v1.json` stays
+    unfrozen on this branch and any bracketed large-rung diagnosis remains
+    follow-on work rather than part of [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
   - `176x6` completed cleanly at `final_log_loss=0.5816` and
     `final_roc_auc=0.7238`; keep it as upper-family and near-ceiling evidence,
     but do not add extra near-ceiling rows on this branch because
@@ -1008,11 +1015,11 @@ Legacy wording note:
     width-depth relationship
   - observed training VRAM reserved for the top rows was `16.59 GiB` at
     `152x5` and `17.84 GiB` at `176x6`, materially below the pre-run
-    width-evidence memory bridge; the hardware-freeze work in
-    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) now needs to
-    fit constraints from the completed mixed-depth evidence only after the
-    staged `tf_rd_009_large_validation_152x5_v1` large-rung gate is executed,
-    rather than treat the old memory bridge as authoritative
+    width-evidence memory bridge; the large-rung gate in
+    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) is now
+    complete and failed, so the hardware-freeze work stops here without adding
+    a baseline entry and the old memory bridge remains planning-only rather
+    than freeze-time evidence
   - TF-RD-021 remains sidecar corpus context under
     [#165](https://github.com/bensonlee5/tab-foundry/issues/165) rather than a
     blocker for this lane
@@ -1101,10 +1108,10 @@ Legacy wording note:
     gate are enough to freeze a real constraint model and preferred row
   - use [#256](https://github.com/bensonlee5/tab-foundry/issues/256) as the
     completed Kaplan-exact fit-and-report issue for the current Phase-2
-    evidence payload, then
-    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) to run the
-    one-row `152x5` large-rung validation and freeze the hardware baseline only
-    on a passing transfer
+    evidence payload; [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+    is now complete and records a failed one-row `152x5` large-rung transfer,
+    so the hardware baseline remains unfrozen pending any separate follow-on
+    diagnosis
   - keep [#259](https://github.com/bensonlee5/tab-foundry/issues/259) and
     [#260](https://github.com/bensonlee5/tab-foundry/issues/260) separate from
     the first fixed-budget law family

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -992,34 +992,45 @@ Legacy wording note:
     queue-construction planning axis
   - `152x5` is the current fixed-budget winner at `final_log_loss=0.5740` and
     `final_roc_auc=0.7351`
+  - the first registry-backed [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+    rerun exposed an artifact-resolution bug: telemetry listed checkpoints
+    through step 2500, but the reusable artifact retained numbered
+    `step_*.pt` files only through step 600 plus `latest.pt`, so the old
+    `benchmark_checkpoint_selection=all` path stopped on the last preserved
+    numbered snapshot
   - `tf_rd_009_large_validation_152x5_v1` is now complete under
-    [#257](https://github.com/bensonlee5/tab-foundry/issues/257): the
-    benchmark-only `152x5` large-rung transfer reused the completed medium
-    train artifact on `openml_classification_large_v1` and finished at
-    `final_log_loss=0.9337034781`, which is worse than the carried TF-RD-010
-    large clean-control anchor `0.8974410961`
+    [#257](https://github.com/bensonlee5/tab-foundry/issues/257): corrected
+    rerun `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`
+    filtered telemetry-only missing late numbered checkpoints, appended the
+    retained terminal `latest.pt` checkpoint at `global_step=2500`, completed
+    `25/25` checkpoint comparisons, and finished at
+    `final_log_loss=0.7436636568`, `final_brier_score=0.4288940`, and
+    `final_roc_auc=0.7650940` on `openml_classification_large_v1`
   - the #257 gate is explicit: keep/defer on whether `152x5` beats the
     TF-RD-010 large clean-control anchor `0.8974410961` at
     `final_log_loss_at_matched_regime_budget`; only a pass should freeze the
     first hardware baseline entry, and the large row itself does not join the
     medium constraint-model evidence
-  - the completed large-rung result is a defer: `delta_final_log_loss=+0.0363`
-    and `delta_final_roc_auc=-0.0240` versus the carried anchor, so
-    `src/tab_foundry/bench/hardware_architecture_baselines_v1.json` stays
-    unfrozen on this branch and any bracketed large-rung diagnosis remains
-    follow-on work rather than part of [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+  - the corrected large-rung result is a keep: `delta_final_log_loss=-0.1538`
+    and `delta_final_roc_auc=+0.1327` versus the carried anchor, so
+    `src/tab_foundry/bench/hardware_architecture_baselines_v1.json` now
+    freezes `tf_rd_009_rtx8000_44gb_classification_medium_v1` from medium
+    evidence rows only with preferred `152x5`, formal anchor `60x2`, and
+    baseline `96x2`; the large row remains a gate rather than a fitted
+    constraint-model point
   - `176x6` completed cleanly at `final_log_loss=0.5816` and
     `final_roc_auc=0.7238`; keep it as upper-family and near-ceiling evidence,
     but do not add extra near-ceiling rows on this branch because
     capacity-targeted probes would no longer preserve the original TF-RD-009
     width-depth relationship
   - observed training VRAM reserved for the top rows was `16.59 GiB` at
-    `152x5` and `17.84 GiB` at `176x6`, materially below the pre-run
-    width-evidence memory bridge; the large-rung gate in
-    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) is now
-    complete and failed, so the hardware-freeze work stops here without adding
-    a baseline entry and the old memory bridge remains planning-only rather
-    than freeze-time evidence
+    `152x5` and `17.84 GiB` at `176x6`, materially below the old pre-run
+    width-evidence memory bridge; after the corrected [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+    pass, the frozen baseline now records the medium-evidence constraint model
+    `P_local(d, L) ≈ 18638.80 + 77.94 * d^2 + 47.93 * L * d^2`,
+    `reserved_vram_gb ≈ 8.69 + 9.271e-07 * params`, and
+    `train_wall_seconds ≈ 8298.45 + 2.275e-04 * params` instead of treating
+    the old bridge as freeze-time evidence
   - TF-RD-021 remains sidecar corpus context under
     [#165](https://github.com/bensonlee5/tab-foundry/issues/165) rather than a
     blocker for this lane
@@ -1064,13 +1075,14 @@ Legacy wording note:
     use Kaplan to justify a smooth effective-size axis, keep Chinchilla-style
     parameter-token coupling out of this fixed-budget branch, use μP to justify
     carrying the width winner `96x2`, use the spectral μP paper to require
-    joint width-depth movement once `sandwich_layers` changes, and derive the
-    integer rows through the repo-local planning axis `S(d, L) = L * d^2`, the
-    empirical mixed-depth bridge
-    `P_local(d, L) ≈ 29966.47 + 75.38 * d^2 + 48.43 * L * d^2`, and the
-    current RTX 8000 memory fit `reserved_gb ≈ 6.47 + 2.36e-6 * params`; use
-    that bridge only for integer row construction, then fit the first reported
-    law on measured benchmark-registry `model_size.total_params` from completed
+    joint width-depth movement once `sandwich_layers` changes, and record the
+    repo-local bridge through `S(d, L) = L * d^2`, the frozen mixed-depth
+    parameter fit `P_local(d, L) ≈ 18638.80 + 77.94 * d^2 + 47.93 * L * d^2`,
+    the frozen RTX 8000 reserved-memory fit
+    `reserved_vram_gb ≈ 8.69 + 9.271e-07 * params`, and the frozen train-wall
+    fit `train_wall_seconds ≈ 8298.45 + 2.275e-04 * params`; use those formulas
+    as repo-local hardware-planning aids, then fit the first reported law on
+    measured benchmark-registry `model_size.total_params` from completed
     in-family rows `{72x1, 96x2, 112x3, 128x4, 152x5, 176x6}` only, starting
     with a Kaplan-style power-law family and treating the exponent/intercept as
     repo-specific empirical quantities rather than paper constants
@@ -1102,16 +1114,17 @@ Legacy wording note:
   - maintain the preferred architecture statefully in
     `src/tab_foundry/bench/hardware_architecture_baselines_v1.json`, keyed by
     hardware profile plus sweep surface rather than by GitHub issue state; the
-    first TF-RD-009 entry should be the retained `rtx8000_44gb` medium
-    classification surface selected from the healthy benchmark-backed evidence
-    only after the completed dense diagonal and the #257 large-rung validation
-    gate are enough to freeze a real constraint model and preferred row
+    first TF-RD-009 entry is now the frozen `rtx8000_44gb` medium
+    classification surface selected from the healthy benchmark-backed medium
+    evidence after the completed dense diagonal and the corrected #257
+    large-rung validation gate froze a real constraint model and preferred row
   - use [#256](https://github.com/bensonlee5/tab-foundry/issues/256) as the
     completed Kaplan-exact fit-and-report issue for the current Phase-2
     evidence payload; [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
-    is now complete and records a failed one-row `152x5` large-rung transfer,
-    so the hardware baseline remains unfrozen pending any separate follow-on
-    diagnosis
+    is now complete and records the corrected one-row `152x5` large-rung
+    transfer passing on the terminal `latest.pt` rerun, so the hardware
+    baseline is frozen and any further large-rung diagnosis remains separate
+    follow-on work
   - keep [#259](https://github.com/bensonlee5/tab-foundry/issues/259) and
     [#260](https://github.com/bensonlee5/tab-foundry/issues/260) separate from
     the first fixed-budget law family

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -629,11 +629,12 @@ pending rows as direct inputs to the reported law fit.
 These tables are the planning view for the future
 `hardware_architecture_baselines_v1.json` entry for the retained
 `rtx8000_44gb` classification surface. The width-depth family is now complete,
-but the formulas remain repo-local planning aids until
-[#257](https://github.com/bensonlee5/tab-foundry/issues/257) executes
-`tf_rd_009_large_validation_152x5_v1` on the large rung and, only on pass,
-freezes the hardware baseline from the measured mixed-depth evidence rather
-than from the historical width-only bridge.
+but the formulas remain repo-local planning aids after the completed
+[#257](https://github.com/bensonlee5/tab-foundry/issues/257) large-rung gate:
+`tf_rd_009_large_validation_152x5_v1` finished at
+`final_log_loss_at_matched_regime_budget=0.9337034781`, which did not beat the
+carried TF-RD-010 large clean-control anchor `0.8974410961`, so the hardware
+baseline was not frozen from the mixed-depth evidence.
 
 Current planning formulas:
 
@@ -685,6 +686,18 @@ timings directly.
   (`0.5740`) and final ROC AUC (`0.7351`)
 - `176x6` completed cleanly and remains useful upper-family evidence, but it
   did not beat `152x5` on the carried matched-budget objective
+- `tf_rd_009_large_validation_152x5_v1` is now complete under
+  [#257](https://github.com/bensonlee5/tab-foundry/issues/257): the
+  benchmark-only large-rung reuse of the completed `152x5` train artifact
+  finished at `final_log_loss=0.9337034781`, `final_brier_score=0.5533658082`,
+  and `final_roc_auc=0.6083568022`
+- the carried large clean-control anchor remained better at `0.8974410961`, so
+  the large-rung transfer decision is `defer`; `delta_final_log_loss=+0.0363`
+  and `delta_final_roc_auc=-0.0240` versus the anchor are the operative gate
+  values
+- because the large gate failed, `src/tab_foundry/bench/hardware_architecture_baselines_v1.json`
+  stays unfrozen on this branch and any bracketed large-rung diagnosis should
+  be treated as separate follow-on work rather than part of [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
 - the observed upper-row training VRAM (`16.59 GiB` at `152x5`, `17.84 GiB` at
   `176x6`) undershot the pre-run width-evidence reserved-memory fit
   (`23.85 GB` and `33.29 GB` respectively), so that fit should remain a
@@ -981,18 +994,19 @@ Selection contract:
 
 First TF-RD-009 use:
 
-- create the first entry for the retained `rtx8000_44gb` medium classification
-  surface only after the dense width-depth family is complete enough to support
-  a real hardware-aware decision and the staged
-  `tf_rd_009_large_validation_152x5_v1` large-rung transfer passes
+- [#257](https://github.com/bensonlee5/tab-foundry/issues/257) is now complete:
+  `tf_rd_009_large_validation_152x5_v1` failed the large-rung gate at
+  `final_log_loss_at_matched_regime_budget=0.9337034781` versus the carried
+  control `0.8974410961`, so do not create the first
+  `rtx8000_44gb` medium-classification hardware baseline entry on this branch
 - keep the formal external anchor `60x2` for lane interpretation
 - keep the carried baseline `96x2` as the fallback preferred architecture if
   the widened family does not produce a cleaner healthy winner
-- stage #257 as benchmark-only reuse of
-  `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
-  on `openml_classification_large_v1`, requiring
-  `final_log_loss_at_matched_regime_budget < 0.8974410961` versus the carried
-  TF-RD-010 large clean-control anchor before any freeze
+- the completed large-rung reuse row is
+  `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`,
+  benchmarked on `openml_classification_large_v1`; it recorded
+  `final_log_loss_at_matched_regime_budget=0.9337034781`, so the freeze gate
+  was not met
 - keep the medium constraint model derived only from the medium evidence rows
   `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`; the large
   validation row is a gate, not an additional fitted point

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -626,28 +626,29 @@ pending rows as direct inputs to the reported law fit.
 
 ## Constraint Budget Table
 
-These tables are the planning view for the future
+These tables now summarize the frozen
 `hardware_architecture_baselines_v1.json` entry for the retained
-`rtx8000_44gb` classification surface. The width-depth family is now complete,
-but the formulas remain repo-local planning aids after the completed
-[#257](https://github.com/bensonlee5/tab-foundry/issues/257) large-rung gate:
-`tf_rd_009_large_validation_152x5_v1` finished at
-`final_log_loss_at_matched_regime_budget=0.9337034781`, which did not beat the
-carried TF-RD-010 large clean-control anchor `0.8974410961`, so the hardware
-baseline was not frozen from the mixed-depth evidence.
+`rtx8000_44gb` classification surface. The width-depth family is complete, and
+the hardware baseline froze only after corrected [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+rerun `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`
+filtered telemetry-only missing late numbered checkpoints, consumed terminal
+`latest.pt` at `global_step=2500`, and beat the carried TF-RD-010 large
+clean-control anchor `0.8974410961` at
+`final_log_loss_at_matched_regime_budget=0.7436636568`. The large-rung result
+remains a gate rather than an additional fitted constraint-model point.
 
-Current planning formulas:
+Current frozen formulas:
 
 - planning-axis expression:
   - `S(d, L) = L * d^2`
 - current fitted mixed-depth parameter bridge:
-  - `P_local(d, L) ≈ 29966.47 + 75.38 * d^2 + 48.43 * L * d^2`
+  - `P_local(d, L) ≈ 18638.80 + 77.94 * d^2 + 47.93 * L * d^2`
 - deprecated width-only diagnostic bridge:
   - `P_local(d, L) ≈ 88.20 * L * d^2` on the historical `L=2` family only
-- current RTX 8000 reserved-memory fit from the benchmarked width evidence:
-  - `reserved_gb ≈ 6.47 + 2.36e-6 * params`
-- current RTX 8000 train-wall fit from the benchmarked width evidence:
-  - `train_wall_seconds ≈ 8407.97 + 1.01e-4 * params`
+- current RTX 8000 reserved-memory fit from the frozen medium evidence:
+  - `reserved_vram_gb ≈ 8.69 + 9.271e-07 * params`
+- current RTX 8000 train-wall fit from the frozen medium evidence:
+  - `train_wall_seconds ≈ 8298.45 + 2.275e-04 * params`
 
 The historical width-family rows predate first-class `benchmark_timing` and
 `inference_timing`, so those timing columns remain intentionally pending for
@@ -658,25 +659,25 @@ timings directly.
 
 | Row | `d_icl` | `sandwich_layers` | `S = L * d^2` | Predicted `P_local` | Predicted reserved GB | Observed reserved GB | Observed headroom to 44 GB |
 |-----|---------|-------------------|---------------|---------------------|-----------------------|----------------------|----------------------------|
-| `60x2` | 60 | 2 | 7200 | 0.650M | 8.00 | 8.05 | 35.95 |
-| `72x1` | 72 | 1 | 5184 | 0.672M | 8.06 | 8.75 | 35.25 |
-| `96x2` | 96 | 2 | 18432 | 1.617M | 10.29 | 10.18 | 33.82 |
-| `112x3` | 112 | 3 | 37632 | 2.798M | 13.07 | 11.65 | 32.35 |
-| `128x4` | 128 | 4 | 65536 | 4.439M | 16.95 | 14.55 | 29.45 |
-| `152x5` | 152 | 5 | 115520 | 7.366M | 23.85 | 16.59 | 27.41 |
-| `176x6` | 176 | 6 | 185856 | 11.366M | 33.29 | 17.84 | 26.16 |
+| `60x2` | 60 | 2 | 7200 | 0.644M | 9.29 | 8.05 | 35.95 |
+| `72x1` | 72 | 1 | 5184 | 0.671M | 9.32 | 8.75 | 35.25 |
+| `96x2` | 96 | 2 | 18432 | 1.620M | 10.20 | 10.18 | 33.82 |
+| `112x3` | 112 | 3 | 37632 | 2.800M | 11.29 | 11.65 | 32.35 |
+| `128x4` | 128 | 4 | 65536 | 4.437M | 12.81 | 14.55 | 29.45 |
+| `152x5` | 152 | 5 | 115520 | 7.357M | 15.51 | 16.59 | 27.41 |
+| `176x6` | 176 | 6 | 185856 | 11.342M | 19.21 | 17.84 | 26.16 |
 
 ### Timing Table
 
 | Row | Predicted train wall seconds | Observed train wall seconds | Observed delta vs `96x2` | Observed benchmark wall seconds | Observed inference mean ms |
 |-----|------------------------------|-----------------------------|--------------------------|---------------------------------|----------------------------|
-| `60x2` | 8474 | 8486 | -62 | pending | pending |
-| `72x1` | 8476 | 8105 | -443 | 1230 | 10.64 |
-| `96x2` | 8571 | 8548 | +0 | pending | pending |
-| `112x3` | 8691 | 9136 | +587 | 1336 | 20.39 |
-| `128x4` | 8856 | 9594 | +1046 | 1391 | 23.91 |
-| `152x5` | 9152 | 10154 | +1606 | 1509 | 27.70 |
-| `176x6` | 9556 | 10635 | +2087 | 1610 | 24.23 |
+| `60x2` | 8445 | 8486 | -62 | pending | pending |
+| `72x1` | 8451 | 8105 | -443 | 1230 | 10.64 |
+| `96x2` | 8667 | 8548 | +0 | pending | pending |
+| `112x3` | 8936 | 9136 | +587 | 1335 | 20.39 |
+| `128x4` | 9308 | 9594 | +1046 | 1391 | 23.91 |
+| `152x5` | 9972 | 10154 | +1606 | 1509 | 27.70 |
+| `176x6` | 10879 | 10635 | +2087 | 1610 | 24.23 |
 
 ### Completed Phase-1 Outcome
 
@@ -686,23 +687,27 @@ timings directly.
   (`0.5740`) and final ROC AUC (`0.7351`)
 - `176x6` completed cleanly and remains useful upper-family evidence, but it
   did not beat `152x5` on the carried matched-budget objective
-- `tf_rd_009_large_validation_152x5_v1` is now complete under
-  [#257](https://github.com/bensonlee5/tab-foundry/issues/257): the
-  benchmark-only large-rung reuse of the completed `152x5` train artifact
-  finished at `final_log_loss=0.9337034781`, `final_brier_score=0.5533658082`,
-  and `final_roc_auc=0.6083568022`
-- the carried large clean-control anchor remained better at `0.8974410961`, so
-  the large-rung transfer decision is `defer`; `delta_final_log_loss=+0.0363`
-  and `delta_final_roc_auc=-0.0240` versus the anchor are the operative gate
-  values
-- because the large gate failed, `src/tab_foundry/bench/hardware_architecture_baselines_v1.json`
-  stays unfrozen on this branch and any bracketed large-rung diagnosis should
-  be treated as separate follow-on work rather than part of [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+- the first registry-backed [#257](https://github.com/bensonlee5/tab-foundry/issues/257)
+  rerun stopped at the last retained numbered snapshot because telemetry still
+  referenced late numbered checkpoints that were no longer present in the
+  reusable artifact tree
+- corrected rerun `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`
+  filtered telemetry-only missing late numbered checkpoints, appended terminal
+  `latest.pt` at `global_step=2500`, completed `25/25` checkpoint comparisons,
+  and finished at `final_log_loss=0.7436636568`,
+  `final_brier_score=0.4288940`, and `final_roc_auc=0.7650940`
+- the corrected large clean-control comparison is now a keep:
+  `delta_final_log_loss=-0.1538` and `delta_final_roc_auc=+0.1327` versus the
+  carried anchor `0.8974410961`
+- because the large gate passed on the terminal 2500-step artifact,
+  `src/tab_foundry/bench/hardware_architecture_baselines_v1.json` now freezes
+  `tf_rd_009_rtx8000_44gb_classification_medium_v1` from medium evidence rows
+  only; the large validation row remains a gate rather than a constraint-model
+  point
 - the observed upper-row training VRAM (`16.59 GiB` at `152x5`, `17.84 GiB` at
-  `176x6`) undershot the pre-run width-evidence reserved-memory fit
-  (`23.85 GB` and `33.29 GB` respectively), so that fit should remain a
-  conservative queue-construction heuristic rather than the freeze-time
-  hardware constraint model
+  `176x6`) still undershot the old width-evidence reserved-memory fit, so the
+  frozen baseline now uses the medium-evidence formulas above rather than the
+  old conservative queue-construction heuristic
 - no extra near-ceiling rows were added on this branch because solving
   directly against the old memory fit would require off-diagonal rows that no
   longer preserve the original TF-RD-009 width-depth relationship
@@ -995,18 +1000,19 @@ Selection contract:
 First TF-RD-009 use:
 
 - [#257](https://github.com/bensonlee5/tab-foundry/issues/257) is now complete:
-  `tf_rd_009_large_validation_152x5_v1` failed the large-rung gate at
-  `final_log_loss_at_matched_regime_budget=0.9337034781` versus the carried
-  control `0.8974410961`, so do not create the first
+  corrected rerun `tf_rd_009_large_validation_152x5_v1` consumed the retained
+  terminal `latest.pt` checkpoint at step 2500, passed the large-rung gate at
+  `final_log_loss_at_matched_regime_budget=0.7436636568` versus the carried
+  control `0.8974410961`, and froze the first
   `rtx8000_44gb` medium-classification hardware baseline entry on this branch
 - keep the formal external anchor `60x2` for lane interpretation
 - keep the carried baseline `96x2` as the fallback preferred architecture if
   the widened family does not produce a cleaner healthy winner
-- the completed large-rung reuse row is
-  `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`,
+- the canonical large-rung reuse row is
+  `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`,
   benchmarked on `openml_classification_large_v1`; it recorded
-  `final_log_loss_at_matched_regime_budget=0.9337034781`, so the freeze gate
-  was not met
+  `final_log_loss_at_matched_regime_budget=0.7436636568`, so the freeze gate
+  was met on the retained terminal 2500-step artifact
 - keep the medium constraint model derived only from the medium evidence rows
   `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`; the large
   validation row is a gate, not an additional fitted point

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -26,7 +26,7 @@ handoff into the sweep-program design issue
   joint width-depth child [#255](https://github.com/bensonlee5/tab-foundry/issues/255),
   completed Kaplan-exact Phase-2 fit/report child
   [#256](https://github.com/bensonlee5/tab-foundry/issues/256), follow-on
-  hardware-freeze child [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
+  large-rung validation / hardware-freeze child [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
   compute-frontier child [#259](https://github.com/bensonlee5/tab-foundry/issues/259),
   and curriculum/repetition slice child
   [#260](https://github.com/bensonlee5/tab-foundry/issues/260)
@@ -630,9 +630,10 @@ These tables are the planning view for the future
 `hardware_architecture_baselines_v1.json` entry for the retained
 `rtx8000_44gb` classification surface. The width-depth family is now complete,
 but the formulas remain repo-local planning aids until
-[#257](https://github.com/bensonlee5/tab-foundry/issues/257) freezes the
-hardware baseline from the measured mixed-depth evidence rather than from the
-historical width-only bridge.
+[#257](https://github.com/bensonlee5/tab-foundry/issues/257) executes
+`tf_rd_009_large_validation_152x5_v1` on the large rung and, only on pass,
+freezes the hardware baseline from the measured mixed-depth evidence rather
+than from the historical width-only bridge.
 
 Current planning formulas:
 
@@ -982,10 +983,19 @@ First TF-RD-009 use:
 
 - create the first entry for the retained `rtx8000_44gb` medium classification
   surface only after the dense width-depth family is complete enough to support
-  a real hardware-aware decision
+  a real hardware-aware decision and the staged
+  `tf_rd_009_large_validation_152x5_v1` large-rung transfer passes
 - keep the formal external anchor `60x2` for lane interpretation
 - keep the carried baseline `96x2` as the fallback preferred architecture if
   the widened family does not produce a cleaner healthy winner
+- stage #257 as benchmark-only reuse of
+  `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+  on `openml_classification_large_v1`, requiring
+  `final_log_loss_at_matched_regime_budget < 0.8974410961` versus the carried
+  TF-RD-010 large clean-control anchor before any freeze
+- keep the medium constraint model derived only from the medium evidence rows
+  `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`; the large
+  validation row is a gate, not an additional fitted point
 - include the machine-readable `constraint_model` block so the registry records
   the exact effective-size, parameter, VRAM, train-wall, benchmark-wall, and
   inference-latency formulas together with the evidence rows used to fit them

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -378,7 +378,7 @@ sweeps:
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
     control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
-    external_benchmarks: &id001 []
+    external_benchmarks: []
   tf_rd_009_batch_critical_medium_v1:
     parent_sweep_id: tf_rd_009_ns_medium_v1
     status: draft
@@ -386,4 +386,12 @@ sweeps:
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
     control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
-    external_benchmarks: *id001
+    external_benchmarks: []
+  tf_rd_009_large_validation_152x5_v1:
+    parent_sweep_id: tf_rd_009_width_depth_medium_v1
+    status: draft
+    anchor_run_id: sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1
+    complexity_level: classification_lg
+    benchmark_manifest_path: data/manifests/bench/openml_classification_large_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_large_v1
+    external_benchmarks: []

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
@@ -1,0 +1,93 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml` (derived from `reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml` plus `reference/system_delta_catalog.yaml`) and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_009_large_validation_152x5_v1`
+- Sweep status: `draft`
+- Parent sweep id: `tf_rd_009_width_depth_medium_v1`
+- Complexity level: `classification_lg`
+- Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml`
+- Resolved queue inputs fingerprint: `74ee7b4163d96cae69bb963f2500ca816df630f43212c9cc4005bddf5884f432`
+
+## Locked Surface
+
+- Anchor run id: `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
+- Benchmark manifest: local benchmark-manifest id `openml_classification_large_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_large_v1`
+- External benchmarks: `none`
+- Training experiment: `cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1`
+- Training config profile: `cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1`
+- Surface role: `classification_scaling_law`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final BPC `2.0860`, final BPF `2.0860`, final log loss `0.8974`, final Brier score `0.5465`, best ROC AUC `0.6324`, final ROC AUC `0.6324`, final training time `7449.8s`
+
+## Anchor Comparison
+
+Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI-g`.
+
+| Dimension | Upstream PerceiverIO | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+| feature encoder | Scalar feature linear encoder with internal train/test z-score+clip handling. | Staged feature encoder `unknown` from the benchmark registry surface. | Feature encoder changes alter the per-cell representation and should be interpreted explicitly. |
+| target conditioning | Mean-padded linear target encoder on the direct binary path. | Target conditioner `unknown` from the staged surface. | Target-conditioning changes should be interpreted separately from encoder or context changes. |
+| cell transformer block | Post-norm nanoTabPFN block with feature attention then row attention. | Cell transformer block `unknown` from the staged surface. | Cell-block changes affect the core table computation and should be isolated carefully. |
+| tokenizer | One scalar token per feature. | Tokenizer `unknown` from the staged surface. | Tokenizer changes alter the token sequence presented to the transformer stack. |
+| column encoder | None on the upstream direct path. | Column encoder `unknown` from the staged surface. | Column-encoder changes should be read separately from row pooling or context changes. |
+| row readout | Target-column readout from the final cell tensor. | Row pool `unknown` from the staged surface. | Row-pool changes alter the readout contract and require their own interpretation. |
+| context encoder | None on the upstream direct path. | Context encoder `unknown` from the staged surface. | Context-encoder changes alter how training rows condition test rows. |
+| prediction head | Direct binary logits head. | Prediction head `unknown` from the staged surface. | Head changes alter the task contract and output semantics. |
+| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet` sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`. | Manifest and training-data changes are first-class sweep rows and should not be inherited from parent sweep prose. |
+| preprocessing | Notebook preprocessing inside the benchmark helper. | Benchmark preprocessing surface label `runtime_default`. | Preprocessing changes can alter the effective task definition and must be tracked explicitly. |
+| training recipe | No repo-local prior-dump training-surface contract. | Training surface label `prior_cosine_warmup`. | Optimizer and schedule changes are first-class sweep rows, not background recipe assumptions. |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` | classification_scaling_law | no | ready | none | Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe. | Execute this single benchmark-only row on the retained RTX 8000 / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` only if the completed large result beats the anchor gate, otherwise document the failed transfer and stop. |
+
+## Detailed Rows
+
+### 1. `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe.
+- Rationale: Benchmark-only validate the current TF-RD-009 medium fixed-budget winner `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` against the closed TF-RD-010 large clean-control anchor before freezing any first hardware architecture baseline.
+- Hypothesis: The retained medium winner `152x5` should transfer cleanly enough on the closed large benchmark rung to beat the carried clean-control anchor without reopening training, seeds, or neighboring bracket rows.
+- Upstream delta: TF-RD-009 uses this row to extend the empirically bridged parameter ladder far enough to fit curvature and identify where hardware guardrails begin to dominate, without switching to a width-depth grid.
+- Anchor delta: Reuse the completed medium `152x5` training artifact and benchmark it against locked anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1` on the local large classification manifest; no retraining, no extra seeds, and no bracketed reruns inside issue 257.
+- Expected effect: If the medium-rung joint law is still smooth at higher effective size, `152x5` should improve the matched-budget objective or expose the first clear bend in the runtime and stability guardrails.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 0, 'loader_pin_memory': False, 'loader_persistent_workers': False, 'loader_prefetch_factor': None, 'non_blocking_device_transfer': False, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2500}`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'd_icl': 152, 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_layers': 5, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture'}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`
+- Reuse training surface fingerprint: `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+- Parameter adequacy plan:
+  - Confirm the reused `152x5` training surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253` matches the preserved train artifact before execution so benchmark-only reuse cannot drift.
+  - Benchmark only on the frozen local large bundle with task ids `[363685, 363699, 363707]` and rank by `final_log_loss_at_matched_regime_budget` against the carried large clean-control anchor `0.8974410961`.
+  - Treat Brier, ROC AUC, runtime, and stability as advisory guardrails unless the run is invalid or clearly unstable.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `all`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`; do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
+  - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253` before benchmark execution to block surface drift.
+  - The large-rung success gate is `final_log_loss_at_matched_regime_budget < 0.8974410961` versus carried large clean-control anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`.
+  - Advisory guardrails are Brier, ROC AUC, benchmark/runtime timing, and stability; only invalid or clearly unstable behavior blocks a keep.
+  - If this row passes, freeze medium hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`; do not add the large validation row to the medium constraint model.
+  - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen and keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate follow-on work.
+  - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009 evidence; the current local workstation does not expose the required GPU surface.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
@@ -9,7 +9,7 @@ This file is rendered from `reference/system_delta_sweeps/tf_rd_009_large_valida
 - Parent sweep id: `tf_rd_009_width_depth_medium_v1`
 - Complexity level: `classification_lg`
 - Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml`
-- Resolved queue inputs fingerprint: `74ee7b4163d96cae69bb963f2500ca816df630f43212c9cc4005bddf5884f432`
+- Resolved queue inputs fingerprint: `7ad8db9e7f47b42e52c6abea8b7c2b0102dc9f0371e46841698c200069f3c360`
 
 ## Locked Surface
 
@@ -37,7 +37,7 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
 | row readout | Target-column readout from the final cell tensor. | Row pool `unknown` from the staged surface. | Row-pool changes alter the readout contract and require their own interpretation. |
 | context encoder | None on the upstream direct path. | Context encoder `unknown` from the staged surface. | Context-encoder changes alter how training rows condition test rows. |
 | prediction head | Direct binary logits head. | Prediction head `unknown` from the staged surface. | Head changes alter the task contract and output semantics. |
-| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet` sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`. | Manifest and training-data changes are first-class sweep rows and should not be inherited from parent sweep prose. |
+| training data surface | OpenML notebook tasks only for benchmarking; no repo-local prior-training manifest contract. | Benchmark manifest `data/manifests/bench/openml_classification_large_v1/manifest.parquet` sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`. | Manifest and training-data changes are first-class sweep rows and should not be inherited from parent sweep prose. |
 | preprocessing | Notebook preprocessing inside the benchmark helper. | Benchmark preprocessing surface label `runtime_default`. | Preprocessing changes can alter the effective task definition and must be tracked explicitly. |
 | training recipe | No repo-local prior-dump training-surface contract. | Training surface label `prior_cosine_warmup`. | Optimizer and schedule changes are first-class sweep rows, not background recipe assumptions. |
 
@@ -45,14 +45,14 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` | classification_scaling_law | no | ready | none | Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe. | Execute this single benchmark-only row on the retained RTX 8000 / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` only if the completed large result beats the anchor gate, otherwise document the failed transfer and stop. |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` | classification_scaling_law | no | completed | none | Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe. | Execute this single benchmark-only row on the retained RTX 8000 / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` only if the completed large result beats the anchor gate, otherwise document the failed transfer and stop. |
 
 ## Detailed Rows
 
 ### 1. `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1`
 
 - Dimension family: `model`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe.
@@ -78,8 +78,8 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
   - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `all`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`; do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
   - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253` before benchmark execution to block surface drift.
@@ -88,6 +88,9 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
   - If this row passes, freeze medium hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`; do not add the large validation row to the medium constraint model.
   - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen and keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate follow-on work.
   - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009 evidence; the current local workstation does not expose the required GPU surface.
+  - Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` with final log loss `0.9337`, delta final log loss `+0.0363`, final Brier score `0.5534`, delta final brier score `+0.0068`, final ROC AUC `0.6084`, delta final roc auc `-0.0240`, final BPC (legacy feature-cell diagnostic) `2.2686`, delta final bpc (legacy feature-cell diagnostic) `+0.1826`, final BPF (legacy feature-cell diagnostic) `2.2686`, delta final bpf (legacy feature-cell diagnostic) `+0.1826`, best ROC AUC `0.5967`, delta final training time `-4841.8s`

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
@@ -9,7 +9,7 @@ This file is rendered from `reference/system_delta_sweeps/tf_rd_009_large_valida
 - Parent sweep id: `tf_rd_009_width_depth_medium_v1`
 - Complexity level: `classification_lg`
 - Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml`
-- Resolved queue inputs fingerprint: `7ad8db9e7f47b42e52c6abea8b7c2b0102dc9f0371e46841698c200069f3c360`
+- Resolved queue inputs fingerprint: `0f98b7b63ecd7b00bb14f0aedb780be423e314e764b5fba62951a5ea8f356dd0`
 
 ## Locked Surface
 
@@ -45,7 +45,7 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
 
 | Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` | classification_scaling_law | no | completed | none | Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe. | Execute this single benchmark-only row on the retained RTX 8000 / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` only if the completed large result beats the anchor gate, otherwise document the failed transfer and stop. |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` | classification_scaling_law | no | completed | none | Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe. | Keep this corrected large-rung gate, maintain frozen hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`, and treat any bracketed large-rung diagnosis as separate follow-on work outside issue 257. |
 
 ## Detailed Rows
 
@@ -79,7 +79,7 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `all`
 - Interpretation status: `completed`
-- Decision: `defer`
+- Decision: `keep`
 - Notes:
   - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`; do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
   - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253` before benchmark execution to block surface drift.
@@ -89,8 +89,12 @@ Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI
   - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen and keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate follow-on work.
   - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009 evidence; the current local workstation does not expose the required GPU surface.
   - Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...
-  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - Partial-snapshot rerun `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` is superseded: telemetry listed checkpoints through step 2500, but the reusable artifact retained numbered `step_*.pt` files only through step 600 plus `latest.pt`, so the old artifact-selection path stopped on the last preserved numbered snapshot.
   - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`.
+  - Corrected artifact resolution kept telemetry as the source of step and elapsed-time metadata, dropped telemetry-only missing late numbered checkpoints, and appended the retained terminal `latest.pt` checkpoint at `global_step=2500` while preserving `benchmark_checkpoint_selection: all`.
+  - The corrected rerun completed `25/25` checkpoint comparisons with terminal `latest.pt` at step `2500`, finished at `final_log_loss=0.7436636568`, `final_brier_score=0.4288940`, and `final_roc_auc=0.7650940`, and beat the carried large clean-control anchor by `delta_final_log_loss=-0.1537774`.
+  - Hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` is now frozen from medium evidence rows only with preferred `152x5`, formal anchor `60x2`, and baseline `96x2`; the large validation row remains a gate and is not added to the medium constraint model.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/result_card.md`
-- Registered run: `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1` with final log loss `0.9337`, delta final log loss `+0.0363`, final Brier score `0.5534`, delta final brier score `+0.0068`, final ROC AUC `0.6084`, delta final roc auc `-0.0240`, final BPC (legacy feature-cell diagnostic) `2.2686`, delta final bpc (legacy feature-cell diagnostic) `+0.1826`, final BPF (legacy feature-cell diagnostic) `2.2686`, delta final bpf (legacy feature-cell diagnostic) `+0.1826`, best ROC AUC `0.5967`, delta final training time `-4841.8s`
+- Registered run: `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2` with final log loss `0.7437`, delta final log loss `-0.1538`, final Brier score `0.4289`, delta final brier score `-0.1177`, final ROC AUC `0.7651`, delta final roc auc `+0.1327`, final BPC (legacy feature-cell diagnostic) `4.5075`, delta final bpc (legacy feature-cell diagnostic) `+2.4214`, final BPF (legacy feature-cell diagnostic) `4.5075`, delta final bpf (legacy feature-cell diagnostic) `+2.4214`, best ROC AUC `0.5967`, delta final training time `+2673.7s`

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
@@ -1,0 +1,113 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_009_large_validation_152x5_v1
+rows:
+- order: 1
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1
+  status: ready
+  rationale: Benchmark-only validate the current TF-RD-009 medium fixed-budget winner
+    `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` against the closed TF-RD-010
+    large clean-control anchor before freezing any first hardware architecture
+    baseline.
+  hypothesis: The retained medium winner `152x5` should transfer cleanly enough
+    on the closed large benchmark rung to beat the carried clean-control anchor
+    without reopening training, seeds, or neighboring bracket rows.
+  anchor_delta: Reuse the completed medium `152x5` training artifact and benchmark
+    it against locked anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
+    on the local large classification manifest; no retraining, no extra seeds,
+    and no bracketed reruns inside issue 257.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 152
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 5
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        min_lr: 1.0e-05
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 4
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train
+    training_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
+  parameter_adequacy_plan:
+  - Confirm the reused `152x5` training surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+    matches the preserved train artifact before execution so benchmark-only reuse
+    cannot drift.
+  - Benchmark only on the frozen local large bundle with task ids `[363685, 363699,
+    363707]` and rank by `final_log_loss_at_matched_regime_budget` against the
+    carried large clean-control anchor `0.8974410961`.
+  - Treat Brier, ROC AUC, runtime, and stability as advisory guardrails unless
+    the run is invalid or clearly unstable.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: all
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute this single benchmark-only row on the retained RTX 8000
+    / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
+    only if the completed large result beats the anchor gate, otherwise document
+    the failed transfer and stop.
+  notes:
+  - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`;
+    do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
+  - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+    before benchmark execution to block surface drift.
+  - The large-rung success gate is `final_log_loss_at_matched_regime_budget <
+    0.8974410961` versus carried large clean-control anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`.
+  - Advisory guardrails are Brier, ROC AUC, benchmark/runtime timing, and stability;
+    only invalid or clearly unstable behavior blocks a keep.
+  - If this row passes, freeze medium hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
+    from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and
+    `176x6`; do not add the large validation row to the medium constraint model.
+  - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen
+    and keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate
+    follow-on work.
+  - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009
+    evidence; the current local workstation does not expose the required GPU surface.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
@@ -79,15 +79,14 @@ rows:
     run is invalid or clearly unstable.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: all
-  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1
+  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2
   followup_run_ids: []
-  decision: defer
+  decision: keep
   interpretation_status: completed
   confounders: []
-  next_action: Execute this single benchmark-only row on the retained RTX 8000 / CUDA
-    runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
-    only if the completed large result beats the anchor gate, otherwise document the
-    failed transfer and stop.
+  next_action: Keep this corrected large-rung gate, maintain frozen hardware baseline
+    `tf_rd_009_rtx8000_44gb_classification_medium_v1`, and treat any bracketed
+    large-rung diagnosis as separate follow-on work outside issue 257.
   notes:
   - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
     at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`;
@@ -108,9 +107,31 @@ rows:
     evidence; the current local workstation does not expose the required GPU surface.
   - 'Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
     failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...'
-  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - >-
+    Partial-snapshot rerun
+    `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    is superseded: telemetry listed checkpoints through step 2500, but the reusable
+    artifact retained numbered `step_*.pt` files only through step 600 plus
+    `latest.pt`, so the old artifact-selection path stopped on the last preserved
+    numbered snapshot.
   - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
     this row in the full sweep context.
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`.
+  - >-
+    Corrected artifact resolution kept telemetry as the source of step and
+    elapsed-time metadata, dropped telemetry-only missing late numbered checkpoints,
+    and appended the retained terminal `latest.pt` checkpoint at `global_step=2500`
+    while preserving `benchmark_checkpoint_selection: all`.
+  - >-
+    The corrected rerun completed `25/25` checkpoint comparisons with terminal
+    `latest.pt` at step `2500`, finished at `final_log_loss=0.7436636568`,
+    `final_brier_score=0.4288940`, and `final_roc_auc=0.7650940`, and beat the
+    carried large clean-control anchor by `delta_final_log_loss=-0.1537774`.
+  - >-
+    Hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` is now
+    frozen from medium evidence rows only with preferred `152x5`, formal anchor
+    `60x2`, and baseline `96x2`; the large validation row remains a gate and is
+    not added to the medium constraint model.
   dynamic_model_overrides: null
   screen_metrics: null
   benchmark_metrics:
@@ -121,21 +142,21 @@ rows:
     best_roc_auc: 0.5967365187249479
     best_log_loss: 0.9507625551301947
     best_brier_score: 0.5675577543042242
-    final_bpc: 2.2686359478877143
-    final_bpf: 2.2686359680615937
-    final_roc_auc: 0.6083568021504234
-    final_log_loss: 0.9337034780913935
-    final_brier_score: 0.5533658082117038
-    final_minus_best_bpc: 0.007364872785715182
-    final_minus_best_bpf: 0.007364837939922708
-    final_minus_best_roc_auc: 0.011620283425475497
-    final_minus_best_log_loss: -0.017059077038801163
-    final_minus_best_brier_score: -0.014191946092520391
+    final_bpc: 4.507453720386212
+    final_bpf: 4.5074539404649
+    final_roc_auc: 0.765094033761902
+    final_log_loss: 0.7436636567836484
+    final_brier_score: 0.42889399685905455
+    final_minus_best_bpc: 2.246182645284213
+    final_minus_best_bpf: 2.2461828103432286
+    final_minus_best_roc_auc: 0.16835751503695406
+    final_minus_best_log_loss: -0.20709889834654627
+    final_minus_best_brier_score: -0.13866375744516962
     objective_metric: final_log_loss_at_matched_regime_budget
-    drift: -0.017059077038801163
-    delta_final_bpc: 0.18260516753563527
-    delta_final_bpf: 0.18260518037355844
-    delta_final_log_loss: 0.03626238194883136
-    delta_final_brier_score: 0.006818717503074834
-    delta_final_roc_auc: -0.02399371692269847
+    drift: -0.20709889834654627
+    delta_final_bpc: 2.421422940034133
+    delta_final_bpf: 2.4214231527768644
+    delta_final_log_loss: -0.15377743935891375
+    delta_final_brier_score: -0.1176530938495744
+    delta_final_roc_auc: 0.1327435146887801
   parent_delta_ref: null

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
@@ -3,18 +3,17 @@ sweep_id: tf_rd_009_large_validation_152x5_v1
 rows:
 - order: 1
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1
-  status: ready
+  status: completed
   rationale: Benchmark-only validate the current TF-RD-009 medium fixed-budget winner
     `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` against the closed TF-RD-010
-    large clean-control anchor before freezing any first hardware architecture
-    baseline.
-  hypothesis: The retained medium winner `152x5` should transfer cleanly enough
-    on the closed large benchmark rung to beat the carried clean-control anchor
-    without reopening training, seeds, or neighboring bracket rows.
+    large clean-control anchor before freezing any first hardware architecture baseline.
+  hypothesis: The retained medium winner `152x5` should transfer cleanly enough on
+    the closed large benchmark rung to beat the carried clean-control anchor without
+    reopening training, seeds, or neighboring bracket rows.
   anchor_delta: Reuse the completed medium `152x5` training artifact and benchmark
     it against locked anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
-    on the local large classification manifest; no retraining, no extra seeds,
-    and no bracketed reruns inside issue 257.
+    on the local large classification manifest; no retraining, no extra seeds, and
+    no bracketed reruns inside issue 257.
   model:
     arch: tabfoundry_sandwich
     d_icl: 152
@@ -74,40 +73,69 @@ rows:
     matches the preserved train artifact before execution so benchmark-only reuse
     cannot drift.
   - Benchmark only on the frozen local large bundle with task ids `[363685, 363699,
-    363707]` and rank by `final_log_loss_at_matched_regime_budget` against the
-    carried large clean-control anchor `0.8974410961`.
-  - Treat Brier, ROC AUC, runtime, and stability as advisory guardrails unless
-    the run is invalid or clearly unstable.
+    363707]` and rank by `final_log_loss_at_matched_regime_budget` against the carried
+    large clean-control anchor `0.8974410961`.
+  - Treat Brier, ROC AUC, runtime, and stability as advisory guardrails unless the
+    run is invalid or clearly unstable.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: all
-  run_id: null
+  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Execute this single benchmark-only row on the retained RTX 8000
-    / CUDA runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
-    only if the completed large result beats the anchor gate, otherwise document
-    the failed transfer and stop.
+  next_action: Execute this single benchmark-only row on the retained RTX 8000 / CUDA
+    runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
+    only if the completed large result beats the anchor gate, otherwise document the
+    failed transfer and stop.
   notes:
   - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
     at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`;
     do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
   - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
     before benchmark execution to block surface drift.
-  - The large-rung success gate is `final_log_loss_at_matched_regime_budget <
-    0.8974410961` versus carried large clean-control anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`.
+  - The large-rung success gate is `final_log_loss_at_matched_regime_budget < 0.8974410961`
+    versus carried large clean-control anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`.
   - Advisory guardrails are Brier, ROC AUC, benchmark/runtime timing, and stability;
     only invalid or clearly unstable behavior blocks a keep.
   - If this row passes, freeze medium hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
-    from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and
-    `176x6`; do not add the large validation row to the medium constraint model.
-  - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen
-    and keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate
-    follow-on work.
+    from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`;
+    do not add the large validation row to the medium constraint model.
+  - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen and
+    keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate follow-on
+    work.
   - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009
     evidence; the current local workstation does not expose the required GPU surface.
+  - 'Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...'
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 550.0
+    max_grad_norm: 54.525353839842566
+    best_bpc: 2.261271075101999
+    best_bpf: 2.261271130121671
+    best_roc_auc: 0.5967365187249479
+    best_log_loss: 0.9507625551301947
+    best_brier_score: 0.5675577543042242
+    final_bpc: 2.2686359478877143
+    final_bpf: 2.2686359680615937
+    final_roc_auc: 0.6083568021504234
+    final_log_loss: 0.9337034780913935
+    final_brier_score: 0.5533658082117038
+    final_minus_best_bpc: 0.007364872785715182
+    final_minus_best_bpf: 0.007364837939922708
+    final_minus_best_roc_auc: 0.011620283425475497
+    final_minus_best_log_loss: -0.017059077038801163
+    final_minus_best_brier_score: -0.014191946092520391
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: -0.017059077038801163
+    delta_final_bpc: 0.18260516753563527
+    delta_final_bpf: 0.18260518037355844
+    delta_final_log_loss: 0.03626238194883136
+    delta_final_brier_score: 0.006818717503074834
+    delta_final_roc_auc: -0.02399371692269847
   parent_delta_ref: null

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
@@ -1,0 +1,461 @@
+schema: tab-foundry-system-delta-resolved-queue-v1
+generated_from_sweep_id: tf_rd_009_large_validation_152x5_v1
+catalog_path: reference/system_delta_catalog.yaml
+canonical_sweep_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/sweep.yaml
+canonical_queue_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml
+canonical_matrix_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md
+sweep_id: tf_rd_009_large_validation_152x5_v1
+parent_sweep_id: tf_rd_009_width_depth_medium_v1
+sweep_status: draft
+complexity_level: classification_lg
+anchor_run_id: sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_large_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_large_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1
+surface_role: classification_scaling_law
+comparison_policy: anchor_only
+upstream_reference:
+  name: PerceiverIO
+  model_source: https://openreview.net/forum?id=fILj7WpI-g
+anchor_surface:
+  notes:
+  - TF-RD-009 issue 257 stages a one-row large-rung validation sweep for the current
+    medium fixed-budget winner `152x5` against the closed TF-RD-010 large clean-control
+    anchor on manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    sourced from `nanotabpfn_openml_classification_large` (task ids `[363685, 363699,
+    363707]`).
+  - Row 1 is benchmark-only reuse of completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`;
+    do not retrain or add extra seeds inside `tf_rd_009_large_validation_152x5_v1`.
+  - The keep/defer gate is whether `152x5` beats the carried TF-RD-010 large clean-control
+    anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
+    at `final_log_loss_at_matched_regime_budget < 0.8974410961`; Brier, ROC AUC, runtime,
+    and stability stay advisory unless the run is invalid or clearly unstable.
+  - If the row passes on the retained RTX 8000 / CUDA surface, freeze hardware baseline
+    `tf_rd_009_rtx8000_44gb_classification_medium_v1` from the medium dense-diagonal
+    evidence with preferred run `152x5`, formal anchor `60x2`, and baseline `96x2`;
+    the large result is a gate, not a medium evidence row.
+  - If the row fails, document the failed transfer and stop; any bracketed large-rung
+    diagnosis plus issues 259 and 260 follow-on work remains separate.
+  dimension_table:
+  - dimension: feature encoder
+    upstream: Scalar feature linear encoder with internal train/test z-score+clip
+      handling.
+    anchor: Staged feature encoder `unknown` from the benchmark registry surface.
+    interpretation: Feature encoder changes alter the per-cell representation and
+      should be interpreted explicitly.
+  - dimension: target conditioning
+    upstream: Mean-padded linear target encoder on the direct binary path.
+    anchor: Target conditioner `unknown` from the staged surface.
+    interpretation: Target-conditioning changes should be interpreted separately from
+      encoder or context changes.
+  - dimension: cell transformer block
+    upstream: Post-norm nanoTabPFN block with feature attention then row attention.
+    anchor: Cell transformer block `unknown` from the staged surface.
+    interpretation: Cell-block changes affect the core table computation and should
+      be isolated carefully.
+  - dimension: tokenizer
+    upstream: One scalar token per feature.
+    anchor: Tokenizer `unknown` from the staged surface.
+    interpretation: Tokenizer changes alter the token sequence presented to the transformer
+      stack.
+  - dimension: column encoder
+    upstream: None on the upstream direct path.
+    anchor: Column encoder `unknown` from the staged surface.
+    interpretation: Column-encoder changes should be read separately from row pooling
+      or context changes.
+  - dimension: row readout
+    upstream: Target-column readout from the final cell tensor.
+    anchor: Row pool `unknown` from the staged surface.
+    interpretation: Row-pool changes alter the readout contract and require their
+      own interpretation.
+  - dimension: context encoder
+    upstream: None on the upstream direct path.
+    anchor: Context encoder `unknown` from the staged surface.
+    interpretation: Context-encoder changes alter how training rows condition test
+      rows.
+  - dimension: prediction head
+    upstream: Direct binary logits head.
+    anchor: Prediction head `unknown` from the staged surface.
+    interpretation: Head changes alter the task contract and output semantics.
+  - dimension: training data surface
+    upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training
+      manifest contract.
+    anchor: Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+      sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values
+      permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`.
+    interpretation: Manifest and training-data changes are first-class sweep rows
+      and should not be inherited from parent sweep prose.
+  - dimension: preprocessing
+    upstream: Notebook preprocessing inside the benchmark helper.
+    anchor: Benchmark preprocessing surface label `runtime_default`.
+    interpretation: Preprocessing changes can alter the effective task definition
+      and must be tracked explicitly.
+  - dimension: training recipe
+    upstream: No repo-local prior-dump training-surface contract.
+    anchor: Training surface label `prior_cosine_warmup`.
+    interpretation: Optimizer and schedule changes are first-class sweep rows, not
+      background recipe assumptions.
+anchor_context:
+  run_id: sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control_curated_v5
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup
+rows:
+- order: 1
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1
+  status: ready
+  rationale: Benchmark-only validate the current TF-RD-009 medium fixed-budget winner
+    `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` against the closed TF-RD-010
+    large clean-control anchor before freezing any first hardware architecture baseline.
+  hypothesis: The retained medium winner `152x5` should transfer cleanly enough on
+    the closed large benchmark rung to beat the carried clean-control anchor without
+    reopening training, seeds, or neighboring bracket rows.
+  anchor_delta: Reuse the completed medium `152x5` training artifact and benchmark
+    it against locked anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
+    on the local large classification manifest; no retraining, no extra seeds, and
+    no bracketed reruns inside issue 257.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 152
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 5
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        min_lr: 1.0e-05
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 4
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+  parameter_adequacy_plan:
+  - Confirm the reused `152x5` training surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+    matches the preserved train artifact before execution so benchmark-only reuse
+    cannot drift.
+  - Benchmark only on the frozen local large bundle with task ids `[363685, 363699,
+    363707]` and rank by `final_log_loss_at_matched_regime_budget` against the carried
+    large clean-control anchor `0.8974410961`.
+  - Treat Brier, ROC AUC, runtime, and stability as advisory guardrails unless the
+    run is invalid or clearly unstable.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: all
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute this single benchmark-only row on the retained RTX 8000 / CUDA
+    runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
+    only if the completed large result beats the anchor gate, otherwise document the
+    failed transfer and stop.
+  notes:
+  - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`;
+    do not retrain this row for `tf_rd_009_large_validation_152x5_v1`.
+  - Preflight must confirm training-surface fingerprint `8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253`
+    before benchmark execution to block surface drift.
+  - The large-rung success gate is `final_log_loss_at_matched_regime_budget < 0.8974410961`
+    versus carried large clean-control anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`.
+  - Advisory guardrails are Brier, ROC AUC, benchmark/runtime timing, and stability;
+    only invalid or clearly unstable behavior blocks a keep.
+  - If this row passes, freeze medium hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
+    from evidence rows `60x2`, `72x1`, `96x2`, `112x3`, `128x4`, `152x5`, and `176x6`;
+    do not add the large validation row to the medium constraint model.
+  - If this row fails, leave `hardware_architecture_baselines_v1.json` unfrozen and
+    keep any `96x2` / `176x6` bracketed large-rung diagnosis as separate follow-on
+    work.
+  - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009
+    evidence; the current local workstation does not expose the required GPU surface.
+  dynamic_model_overrides: null
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train
+    training_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: model
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`,
+    `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb`
+    ceiling probe.
+  upstream_delta: TF-RD-009 uses this row to extend the empirically bridged parameter
+    ladder far enough to fit curvature and identify where hardware guardrails begin
+    to dominate, without switching to a width-depth grid.
+  entangled_legacy_stage: none
+  expected_effect: If the medium-rung joint law is still smooth at higher effective
+    size, `152x5` should improve the matched-budget objective or expose the first
+    clear bend in the runtime and stability guardrails.
+  adequacy_knobs:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+    reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute after `128x4` is benchmark-backed so the family remains a dense diagonal
+      rather than a sparse extrapolation.
+    - Compare directly against the carried `96x2` baseline at matched regime budget
+      using `final_log_loss_at_matched_regime_budget` as the primary metric.
+    - Keep any health=`warn` outcome as explicit ceiling evidence rather than silently
+      replacing this row.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 152
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 5
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 5
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v5
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b/corpus_record.json
+      manifest:
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b/manifest.parquet
+        manifest_sha256: 192bd49fd87ba50790a9e4632d93476676ae108c597f38310cb6c9196b2fdf88
+      dagzoo_provenance:
+        acceptance_rate: 0.9986650538337475
+        accepted_datasets: 183283
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 159984
+        filter_policy: accepted_only
+        generator_fingerprint: f781789b135e
+        invocation_count: 144
+        manifest_record_count: 159984
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v5
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 159984
+          per_invocation_num_datasets: 1111
+          synthetic_epoch_regime: one_epoch_159984_records_2500_steps
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v5
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 245
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 159984
+          missingness: null
+          num_datasets_per_invocation: 1111
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v5
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: schedulefree_adamw
+      optimizer_min_lr: 1.0e-05
+      schedule_stages:
+      - name: prior_dump
+        steps: 2500
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: 0
+      loader_pin_memory: false
+      loader_persistent_workers: false
+      loader_prefetch_factor: null
+      non_blocking_device_transfer: false
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      trace_activations: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 2500
+  resolved_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
+canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
+inputs_fingerprint: 74ee7b4163d96cae69bb963f2500ca816df630f43212c9cc4005bddf5884f432

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
@@ -188,15 +188,14 @@ rows:
     run is invalid or clearly unstable.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: all
-  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1
+  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2
   followup_run_ids: []
-  decision: defer
+  decision: keep
   interpretation_status: completed
   confounders: []
-  next_action: Execute this single benchmark-only row on the retained RTX 8000 / CUDA
-    runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
-    only if the completed large result beats the anchor gate, otherwise document the
-    failed transfer and stop.
+  next_action: Keep this corrected large-rung gate, maintain frozen hardware baseline
+    `tf_rd_009_rtx8000_44gb_classification_medium_v1`, and treat any bracketed large-rung
+    diagnosis as separate follow-on work outside issue 257.
   notes:
   - Reuse completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
     at `outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train`;
@@ -217,9 +216,25 @@ rows:
     evidence; the current local workstation does not expose the required GPU surface.
   - 'Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
     failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...'
-  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - 'Partial-snapshot rerun `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    is superseded: telemetry listed checkpoints through step 2500, but the reusable
+    artifact retained numbered `step_*.pt` files only through step 600 plus `latest.pt`,
+    so the old artifact-selection path stopped on the last preserved numbered snapshot.'
   - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
     this row in the full sweep context.
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`.
+  - 'Corrected artifact resolution kept telemetry as the source of step and elapsed-time
+    metadata, dropped telemetry-only missing late numbered checkpoints, and appended
+    the retained terminal `latest.pt` checkpoint at `global_step=2500` while preserving
+    `benchmark_checkpoint_selection: all`.'
+  - The corrected rerun completed `25/25` checkpoint comparisons with terminal `latest.pt`
+    at step `2500`, finished at `final_log_loss=0.7436636568`, `final_brier_score=0.4288940`,
+    and `final_roc_auc=0.7650940`, and beat the carried large clean-control anchor
+    by `delta_final_log_loss=-0.1537774`.
+  - Hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` is now frozen
+    from medium evidence rows only with preferred `152x5`, formal anchor `60x2`, and
+    baseline `96x2`; the large validation row remains a gate and is not added to the
+    medium constraint model.
   dynamic_model_overrides: null
   reuse_train_artifact:
     run_dir: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train
@@ -233,23 +248,23 @@ rows:
     best_roc_auc: 0.5967365187249479
     best_log_loss: 0.9507625551301947
     best_brier_score: 0.5675577543042242
-    final_bpc: 2.2686359478877143
-    final_bpf: 2.2686359680615937
-    final_roc_auc: 0.6083568021504234
-    final_log_loss: 0.9337034780913935
-    final_brier_score: 0.5533658082117038
-    final_minus_best_bpc: 0.007364872785715182
-    final_minus_best_bpf: 0.007364837939922708
-    final_minus_best_roc_auc: 0.011620283425475497
-    final_minus_best_log_loss: -0.017059077038801163
-    final_minus_best_brier_score: -0.014191946092520391
+    final_bpc: 4.507453720386212
+    final_bpf: 4.5074539404649
+    final_roc_auc: 0.765094033761902
+    final_log_loss: 0.7436636567836484
+    final_brier_score: 0.42889399685905455
+    final_minus_best_bpc: 2.246182645284213
+    final_minus_best_bpf: 2.2461828103432286
+    final_minus_best_roc_auc: 0.16835751503695406
+    final_minus_best_log_loss: -0.20709889834654627
+    final_minus_best_brier_score: -0.13866375744516962
     objective_metric: final_log_loss_at_matched_regime_budget
-    drift: -0.017059077038801163
-    delta_final_bpc: 0.18260516753563527
-    delta_final_bpf: 0.18260518037355844
-    delta_final_log_loss: 0.03626238194883136
-    delta_final_brier_score: 0.006818717503074834
-    delta_final_roc_auc: -0.02399371692269847
+    drift: -0.20709889834654627
+    delta_final_bpc: 2.421422940034133
+    delta_final_bpf: 2.4214231527768644
+    delta_final_log_loss: -0.15377743935891375
+    delta_final_brier_score: -0.1176530938495744
+    delta_final_roc_auc: 0.1327435146887801
   parent_delta_ref: null
   dimension_family: model
   family: classification_scaling_law
@@ -487,4 +502,4 @@ rows:
       max_steps: 2500
   resolved_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
 canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
-inputs_fingerprint: 7ad8db9e7f47b42e52c6abea8b7c2b0102dc9f0371e46841698c200069f3c360
+inputs_fingerprint: 0f98b7b63ecd7b00bb14f0aedb780be423e314e764b5fba62951a5ea8f356dd0

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
@@ -23,7 +23,7 @@ anchor_surface:
   notes:
   - TF-RD-009 issue 257 stages a one-row large-rung validation sweep for the current
     medium fixed-budget winner `152x5` against the closed TF-RD-010 large clean-control
-    anchor on manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    anchor on manifest `data/manifests/bench/openml_classification_large_v1/manifest.parquet`
     sourced from `nanotabpfn_openml_classification_large` (task ids `[363685, 363699,
     363707]`).
   - Row 1 is benchmark-only reuse of completed run `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`;
@@ -82,7 +82,7 @@ anchor_surface:
   - dimension: training data surface
     upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training
       manifest contract.
-    anchor: Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    anchor: Benchmark manifest `data/manifests/bench/openml_classification_large_v1/manifest.parquet`
       sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values
       permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`.
     interpretation: Manifest and training-data changes are first-class sweep rows
@@ -115,7 +115,7 @@ anchor_context:
 rows:
 - order: 1
   delta_id: delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1
-  status: ready
+  status: completed
   rationale: Benchmark-only validate the current TF-RD-009 medium fixed-budget winner
     `delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1` against the closed TF-RD-010
     large clean-control anchor before freezing any first hardware architecture baseline.
@@ -188,10 +188,10 @@ rows:
     run is invalid or clearly unstable.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: all
-  run_id: null
+  run_id: sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Execute this single benchmark-only row on the retained RTX 8000 / CUDA
     runner; freeze hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1`
@@ -215,12 +215,41 @@ rows:
     work.
   - Execute on the same CUDA / RTX 8000 class environment as the retained TF-RD-009
     evidence; the current local workstation does not expose the required GPU surface.
+  - 'Execution attempt `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`
+    failed: [row 01] pinned reusable train artifact is missing or incomplete: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sa...'
+  - Canonical rerun registered as `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact:
     run_dir: outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train
     training_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 550.0
+    max_grad_norm: 54.525353839842566
+    best_bpc: 2.261271075101999
+    best_bpf: 2.261271130121671
+    best_roc_auc: 0.5967365187249479
+    best_log_loss: 0.9507625551301947
+    best_brier_score: 0.5675577543042242
+    final_bpc: 2.2686359478877143
+    final_bpf: 2.2686359680615937
+    final_roc_auc: 0.6083568021504234
+    final_log_loss: 0.9337034780913935
+    final_brier_score: 0.5533658082117038
+    final_minus_best_bpc: 0.007364872785715182
+    final_minus_best_bpf: 0.007364837939922708
+    final_minus_best_roc_auc: 0.011620283425475497
+    final_minus_best_log_loss: -0.017059077038801163
+    final_minus_best_brier_score: -0.014191946092520391
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: -0.017059077038801163
+    delta_final_bpc: 0.18260516753563527
+    delta_final_bpf: 0.18260518037355844
+    delta_final_log_loss: 0.03626238194883136
+    delta_final_brier_score: 0.006818717503074834
+    delta_final_roc_auc: -0.02399371692269847
   parent_delta_ref: null
   dimension_family: model
   family: classification_scaling_law
@@ -458,4 +487,4 @@ rows:
       max_steps: 2500
   resolved_surface_fingerprint: 8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253
 canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml
-inputs_fingerprint: 74ee7b4163d96cae69bb963f2500ca816df630f43212c9cc4005bddf5884f432
+inputs_fingerprint: 7ad8db9e7f47b42e52c6abea8b7c2b0102dc9f0371e46841698c200069f3c360

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/sweep.yaml
@@ -1,0 +1,110 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_009_large_validation_152x5_v1
+parent_sweep_id: tf_rd_009_width_depth_medium_v1
+status: draft
+complexity_level: classification_lg
+anchor_run_id: sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_large_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_large_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1
+surface_role: classification_scaling_law
+comparison_policy: anchor_only
+upstream_reference:
+  name: PerceiverIO
+  model_source: https://openreview.net/forum?id=fILj7WpI-g
+anchor_surface:
+  notes:
+  - TF-RD-009 issue 257 stages a one-row large-rung validation sweep for the current
+    medium fixed-budget winner `152x5` against the closed TF-RD-010 large clean-control
+    anchor on manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    sourced from `nanotabpfn_openml_classification_large` (task ids `[363685,
+    363699, 363707]`).
+  - Row 1 is benchmark-only reuse of completed run
+    `sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1`;
+    do not retrain or add extra seeds inside `tf_rd_009_large_validation_152x5_v1`.
+  - The keep/defer gate is whether `152x5` beats the carried TF-RD-010 large clean-control
+    anchor `sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1`
+    at `final_log_loss_at_matched_regime_budget < 0.8974410961`; Brier, ROC AUC,
+    runtime, and stability stay advisory unless the run is invalid or clearly unstable.
+  - If the row passes on the retained RTX 8000 / CUDA surface, freeze hardware
+    baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` from the medium
+    dense-diagonal evidence with preferred run `152x5`, formal anchor `60x2`,
+    and baseline `96x2`; the large result is a gate, not a medium evidence row.
+  - If the row fails, document the failed transfer and stop; any bracketed large-rung
+    diagnosis plus issues 259 and 260 follow-on work remains separate.
+  dimension_table:
+  - dimension: feature encoder
+    upstream: Scalar feature linear encoder with internal train/test z-score+clip
+      handling.
+    anchor: Staged feature encoder `unknown` from the benchmark registry surface.
+    interpretation: Feature encoder changes alter the per-cell representation and
+      should be interpreted explicitly.
+  - dimension: target conditioning
+    upstream: Mean-padded linear target encoder on the direct binary path.
+    anchor: Target conditioner `unknown` from the staged surface.
+    interpretation: Target-conditioning changes should be interpreted separately from
+      encoder or context changes.
+  - dimension: cell transformer block
+    upstream: Post-norm nanoTabPFN block with feature attention then row attention.
+    anchor: Cell transformer block `unknown` from the staged surface.
+    interpretation: Cell-block changes affect the core table computation and should
+      be isolated carefully.
+  - dimension: tokenizer
+    upstream: One scalar token per feature.
+    anchor: Tokenizer `unknown` from the staged surface.
+    interpretation: Tokenizer changes alter the token sequence presented to the transformer
+      stack.
+  - dimension: column encoder
+    upstream: None on the upstream direct path.
+    anchor: Column encoder `unknown` from the staged surface.
+    interpretation: Column-encoder changes should be read separately from row pooling
+      or context changes.
+  - dimension: row readout
+    upstream: Target-column readout from the final cell tensor.
+    anchor: Row pool `unknown` from the staged surface.
+    interpretation: Row-pool changes alter the readout contract and require their
+      own interpretation.
+  - dimension: context encoder
+    upstream: None on the upstream direct path.
+    anchor: Context encoder `unknown` from the staged surface.
+    interpretation: Context-encoder changes alter how training rows condition test
+      rows.
+  - dimension: prediction head
+    upstream: Direct binary logits head.
+    anchor: Prediction head `unknown` from the staged surface.
+    interpretation: Head changes alter the task contract and output semantics.
+  - dimension: training data surface
+    upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training
+      manifest contract.
+    anchor: Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+      sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values
+      permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`.
+    interpretation: Manifest and training-data changes are first-class sweep rows
+      and should not be inherited from parent sweep prose.
+  - dimension: preprocessing
+    upstream: Notebook preprocessing inside the benchmark helper.
+    anchor: Benchmark preprocessing surface label `runtime_default`.
+    interpretation: Preprocessing changes can alter the effective task definition
+      and must be tracked explicitly.
+  - dimension: training recipe
+    upstream: No repo-local prior-dump training-surface contract.
+    anchor: Training surface label `prior_cosine_warmup`.
+    interpretation: Optimizer and schedule changes are first-class sweep rows, not
+      background recipe assumptions.
+anchor_context:
+  run_id: sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control_curated_v5
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup

--- a/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/sweep.yaml
@@ -18,7 +18,7 @@ anchor_surface:
   notes:
   - TF-RD-009 issue 257 stages a one-row large-rung validation sweep for the current
     medium fixed-budget winner `152x5` against the closed TF-RD-010 large clean-control
-    anchor on manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    anchor on manifest `data/manifests/bench/openml_classification_large_v1/manifest.parquet`
     sourced from `nanotabpfn_openml_classification_large` (task ids `[363685,
     363699, 363707]`).
   - Row 1 is benchmark-only reuse of completed run
@@ -78,7 +78,7 @@ anchor_surface:
   - dimension: training data surface
     upstream: OpenML notebook tasks only for benchmarking; no repo-local prior-training
       manifest contract.
-    anchor: Benchmark manifest `/Users/bensonlee/dev/tab-foundry/data/manifests/bench/openml_classification_large_v1/manifest.parquet`
+    anchor: Benchmark manifest `data/manifests/bench/openml_classification_large_v1/manifest.parquet`
       sourced from `nanotabpfn_openml_classification_large` (3 tasks (missing values
       permitted)) with data surface label `tf_rd_010_dagzoo_medium_control_curated_v5`.
     interpretation: Manifest and training-data changes are first-class sweep rows

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -16627,6 +16627,11044 @@
         "run_name": "sd_tf_rd_009_batch_critical_medium_v1_20_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1"
       }
     },
+    "sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1": {
+      "artifacts": {
+        "accounting_artifact_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/benchmark/model_accounting.json",
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_classification_large",
+        "source_path": "/private/tmp/frozen_local_large_3task_bundle.json",
+        "task_count": 3,
+        "task_ids": [
+          363685,
+          363699,
+          363707
+        ],
+        "version": 1
+      },
+      "benchmark_timing": {
+        "attempted_checkpoint_count": 100,
+        "failed_checkpoint_count": 76,
+        "host_fingerprint": "5b6826bab949|linux|x86_64",
+        "max_checkpoint_elapsed_seconds": 3.536062592174858,
+        "mean_checkpoint_elapsed_seconds": 0.14123357694596053,
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "successful_checkpoint_count": 24,
+        "wall_elapsed_seconds": 14.156587392091751
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": -0.03561400034817397,
+          "best_training_time_delta": -4730.034552419791,
+          "final_avg_pinball_loss_delta": null,
+          "final_bpc_delta": 0.18260516753563527,
+          "final_bpf_delta": 0.18260518037355844,
+          "final_brier_score_delta": 0.006818717503074834,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 0.03626238194883136,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.02399371692269847,
+          "final_training_time_delta": -4841.758751854068,
+          "reference_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": -0.03561400034817397,
+          "best_training_time_delta": -4730.034552419791,
+          "final_avg_pinball_loss_delta": null,
+          "final_bpc_delta": 0.18260516753563527,
+          "final_bpf_delta": 0.18260518037355844,
+          "final_brier_score_delta": 0.006818717503074834,
+          "final_crps_delta": null,
+          "final_log_loss_delta": 0.03626238194883136,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": -0.02399371692269847,
+          "final_training_time_delta": -4841.758751854068,
+          "reference_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+        }
+      },
+      "compute_accounting": {
+        "forward_flops_per_token": 7730862.6,
+        "method": "inspected_analytic_v1",
+        "module_forward_flop_totals": [
+          {
+            "forward_flops": 556320.0,
+            "module_op": "cell_readout.ff.0::linear"
+          },
+          {
+            "forward_flops": 14592.0,
+            "module_op": "cell_readout.ff.1::gelu"
+          },
+          {
+            "forward_flops": 555408.0,
+            "module_op": "cell_readout.ff.2::linear"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "cell_readout.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "cell_readout.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "cell_readout.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1112640.0,
+            "module_op": "column_summary_builder.ff.0::linear"
+          },
+          {
+            "forward_flops": 29184.0,
+            "module_op": "column_summary_builder.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1110816.0,
+            "module_op": "column_summary_builder.ff.2::linear"
+          },
+          {
+            "forward_flops": 16416.0,
+            "module_op": "column_summary_builder.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "column_summary_builder.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 16416.0,
+            "module_op": "column_summary_builder.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 58560.0,
+            "module_op": "direct_head.net.0::linear"
+          },
+          {
+            "forward_flops": 1536.0,
+            "module_op": "direct_head.net.1::gelu"
+          },
+          {
+            "forward_flops": 3860.0,
+            "module_op": "direct_head.net.2::linear"
+          },
+          {
+            "forward_flops": 24320.0,
+            "module_op": "feature_encoder.linear::linear"
+          },
+          {
+            "forward_flops": 556320.0,
+            "module_op": "latent_readout.ff.0::linear"
+          },
+          {
+            "forward_flops": 14592.0,
+            "module_op": "latent_readout.ff.1::gelu"
+          },
+          {
+            "forward_flops": 555408.0,
+            "module_op": "latent_readout.ff.2::linear"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "latent_readout.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "latent_readout.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "latent_readout.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 64296.0,
+            "module_op": "perceiver_stages.0.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.1.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.2.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.3.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.4.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 5934080.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.0::linear"
+          },
+          {
+            "forward_flops": 155648.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.1::gelu"
+          },
+          {
+            "forward_flops": 5924352.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.2::linear"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1854400.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.0::linear"
+          },
+          {
+            "forward_flops": 48640.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1851360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.2::linear"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 5934080.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.0::linear"
+          },
+          {
+            "forward_flops": 155648.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.1::gelu"
+          },
+          {
+            "forward_flops": 5924352.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.2::linear"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_row_attention_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1854400.0,
+            "module_op": "pre_row_attention_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 48640.0,
+            "module_op": "pre_row_attention_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1851360.0,
+            "module_op": "pre_row_attention_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_row_attention_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1390800.0,
+            "module_op": "row_summary_builder.ff.0::linear"
+          },
+          {
+            "forward_flops": 36480.0,
+            "module_op": "row_summary_builder.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1388520.0,
+            "module_op": "row_summary_builder.ff.2::linear"
+          },
+          {
+            "forward_flops": 20520.0,
+            "module_op": "row_summary_builder.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "row_summary_builder.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 20520.0,
+            "module_op": "row_summary_builder.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 185440.0,
+            "module_op": "test_row_pool.ff.0::linear"
+          },
+          {
+            "forward_flops": 4864.0,
+            "module_op": "test_row_pool.ff.1::gelu"
+          },
+          {
+            "forward_flops": 185136.0,
+            "module_op": "test_row_pool.ff.2::linear"
+          },
+          {
+            "forward_flops": 2736.0,
+            "module_op": "test_row_pool.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "test_row_pool.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2736.0,
+            "module_op": "test_row_pool.query_norm::layer_norm"
+          }
+        ],
+        "schema": "tab-foundry-model-accounting-v1",
+        "signature_breakdown": [
+          {
+            "contributions": [
+              {
+                "forward_flops": 24320.0,
+                "module": "feature_encoder.linear",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_row_attention_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_row_attention_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1854400.0,
+                "module": "pre_row_attention_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 48640.0,
+                "module": "pre_row_attention_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1851360.0,
+                "module": "pre_row_attention_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 5934080.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 155648.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 5924352.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 5934080.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 155648.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 5924352.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1854400.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 48640.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1851360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 20520.0,
+                "module": "row_summary_builder.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "row_summary_builder.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 20520.0,
+                "module": "row_summary_builder.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1390800.0,
+                "module": "row_summary_builder.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 36480.0,
+                "module": "row_summary_builder.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1388520.0,
+                "module": "row_summary_builder.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 16416.0,
+                "module": "column_summary_builder.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "column_summary_builder.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 16416.0,
+                "module": "column_summary_builder.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1112640.0,
+                "module": "column_summary_builder.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 29184.0,
+                "module": "column_summary_builder.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1110816.0,
+                "module": "column_summary_builder.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 64296.0,
+                "module": "perceiver_stages.0.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.1.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.2.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.3.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.4.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "latent_readout.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "latent_readout.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "latent_readout.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 556320.0,
+                "module": "latent_readout.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 14592.0,
+                "module": "latent_readout.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 555408.0,
+                "module": "latent_readout.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "cell_readout.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "cell_readout.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "cell_readout.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 556320.0,
+                "module": "cell_readout.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 14592.0,
+                "module": "cell_readout.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 555408.0,
+                "module": "cell_readout.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 2736.0,
+                "module": "test_row_pool.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "test_row_pool.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2736.0,
+                "module": "test_row_pool.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 185440.0,
+                "module": "test_row_pool.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 4864.0,
+                "module": "test_row_pool.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 185136.0,
+                "module": "test_row_pool.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58560.0,
+                "module": "direct_head.net.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 1536.0,
+                "module": "direct_head.net.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 3860.0,
+                "module": "direct_head.net.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              }
+            ],
+            "forward_flops_per_task": 154617252.0,
+            "forward_flops_per_token": 7730862.6,
+            "n_features": 4,
+            "n_test": 2,
+            "n_train": 3,
+            "num_classes": 2,
+            "signature": "3x2x4x2",
+            "task_count": 1,
+            "tokens_per_task": 20
+          }
+        ],
+        "tokens_per_step": 367086.5408,
+        "tokens_seen": 917716352,
+        "total_train_flops": 2.1284217069255704e+16,
+        "train_flops_per_step": 8513686827702.281,
+        "train_flops_per_token": 23192587.799999997,
+        "training_multiplier": 3.0,
+        "training_shape_summary": null
+      },
+      "conclusion": "Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.",
+      "config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "decision": "defer",
+      "experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "hardware_summary": {
+        "device_type": "cuda",
+        "gpu_class": "rtx8000",
+        "hardware_profile_id": "rtx8000_44gb",
+        "raw_device_name": "Quadro RTX 8000",
+        "total_device_vram_bytes": 47560916992,
+        "vram_class_gb": 44
+      },
+      "inference_timing": {
+        "device_type": "cuda",
+        "fixture_id": "classification_medium_reference_v1",
+        "gpu_class": "nvidia-rtx-a6000",
+        "hardware_profile_id": "nvidia-rtx-a6000_44gb",
+        "max_ms": 14.746893662959337,
+        "mean_ms": 14.334501000121236,
+        "measured_iterations": 10,
+        "n_features": 10,
+        "n_test": 40,
+        "n_train": 160,
+        "num_classes": 10,
+        "p50_ms": 14.242831384763122,
+        "p95_ms": 14.701440697535872,
+        "raw_device_name": "NVIDIA RTX A6000",
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "total_measured_seconds": 0.14334501000121236,
+        "vram_class_gb": 44,
+        "warmup_iterations": 3
+      },
+      "lineage": {
+        "anchor_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1",
+        "control_baseline_id": "cls_benchmark_linear_multiclass_large_v1",
+        "parent_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+      },
+      "manifest_path": "outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_sandwich",
+        "architecture": {
+          "feature_type_encoding": "film",
+          "ff_expansion": 2,
+          "floating_likelihood": "single_gaussian",
+          "heads": 1,
+          "initial_input_token_count": "R_times_C_plus_K_times_(R_plus_C)",
+          "initial_input_tokens": "full_cell_plus_row_col_summary_stream",
+          "integer_likelihood": "hybrid_mixture",
+          "label_injection": "fused_into_row_summaries_and_feature_cells",
+          "latent_core": "stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages",
+          "latents": 24,
+          "layer_semantics": "stage0_hybrid_then_summary_repeated_stages",
+          "layers": 5,
+          "position_encoding": "shared_fourier_row_col",
+          "pre_column_attention_layers": 1,
+          "pre_column_inducing_tokens": 16,
+          "pre_perceiver_cell_mixer": "row_feature_self_attention_then_column_row_isab",
+          "pre_row_attention_layers": 1,
+          "readout": "latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool",
+          "repeated_input_token_count": "K_times_(R_plus_C)",
+          "repeated_input_tokens": "row_col_summary_stream",
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "self_attention_per_cross": 4,
+          "summary_builder": "summary_query_attention",
+          "summary_tokens_per_axis": 3
+        },
+        "build_spec": {
+          "arch": "tabfoundry_sandwich",
+          "d_col": 128,
+          "d_icl": 152,
+          "feature_group_size": 1,
+          "feature_type_conditioning": "film",
+          "floating_likelihood": "single_gaussian",
+          "head_hidden_dim": 96,
+          "input_normalization": "train_zscore_clip",
+          "integer_likelihood": "hybrid_mixture",
+          "many_class_base": 10,
+          "many_class_train_mode": "path_nll",
+          "max_mixed_radix_digits": 64,
+          "norm_type": "layernorm",
+          "pre_encoder_clip": null,
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "sandwich_ff_expansion": 2,
+          "sandwich_heads": 1,
+          "sandwich_latents": 24,
+          "sandwich_layers": 5,
+          "sandwich_pre_column_attention_layers": 1,
+          "sandwich_pre_column_inducing_tokens": 16,
+          "sandwich_pre_row_attention_layers": 1,
+          "sandwich_self_attention_per_cross": 4,
+          "sandwich_summary_tokens_per_axis": 3,
+          "task": "classification"
+        },
+        "d_icl": 152,
+        "feature_group_size": 1,
+        "head_hidden_dim": 96,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 10,
+        "stage": null,
+        "stage_label": null,
+        "tficl_n_heads": 8,
+        "tficl_n_layers": 12
+      },
+      "model_size": {
+        "total_params": 7357894,
+        "trainable_params": 7357894
+      },
+      "parameter_accounting": {
+        "canonical_non_embedding_params": 7354094,
+        "expanded": {
+          "embedding_like_params": 11248,
+          "non_embedding_params": 7346646
+        },
+        "method": "inspected_parameter_partition_v1",
+        "module_breakdown": [
+          {
+            "expanded_embedding_like_params": 4864,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "parameter_names": [
+              "cell_bos",
+              "column_summary_query",
+              "latent_seed",
+              "row_summary_query",
+              "test_row_pool_query"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 4864,
+            "trainable_params": 4864
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn.in_proj_bias",
+              "cell_decoder_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn.out_proj.bias",
+              "cell_decoder_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn_norm.bias",
+              "cell_decoder_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff.0.bias",
+              "cell_decoder_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff.2.bias",
+              "cell_decoder_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff_norm.bias",
+              "cell_decoder_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn.in_proj_bias",
+              "cell_decoder_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn.out_proj.bias",
+              "cell_decoder_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn_norm.bias",
+              "cell_decoder_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff.0.bias",
+              "cell_decoder_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff.2.bias",
+              "cell_decoder_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff_norm.bias",
+              "cell_decoder_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn.in_proj_bias",
+              "cell_decoder_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn.out_proj.bias",
+              "cell_decoder_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn_norm.bias",
+              "cell_decoder_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff.0.bias",
+              "cell_decoder_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff.2.bias",
+              "cell_decoder_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff_norm.bias",
+              "cell_decoder_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn.in_proj_bias",
+              "cell_decoder_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn.out_proj.bias",
+              "cell_decoder_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn_norm.bias",
+              "cell_decoder_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff.0.bias",
+              "cell_decoder_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff.2.bias",
+              "cell_decoder_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff_norm.bias",
+              "cell_decoder_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn.in_proj_bias",
+              "cell_decoder_blocks.4.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn.out_proj.bias",
+              "cell_decoder_blocks.4.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn_norm.bias",
+              "cell_decoder_blocks.4.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff.0.bias",
+              "cell_decoder_blocks.4.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff.2.bias",
+              "cell_decoder_blocks.4.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff_norm.bias",
+              "cell_decoder_blocks.4.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_readout.attn.in_proj_bias",
+              "cell_readout.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_readout.attn.out_proj.bias",
+              "cell_readout.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_readout.ff.0.bias",
+              "cell_readout.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_readout.ff.2.bias",
+              "cell_readout.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.ff_norm.bias",
+              "cell_readout.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.kv_norm.bias",
+              "cell_readout.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.query_norm.bias",
+              "cell_readout.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "column_summary_builder.attn.in_proj_bias",
+              "column_summary_builder.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "column_summary_builder.attn.out_proj.bias",
+              "column_summary_builder.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "column_summary_builder.ff.0.bias",
+              "column_summary_builder.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "column_summary_builder.ff.2.bias",
+              "column_summary_builder.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.ff_norm.bias",
+              "column_summary_builder.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.kv_norm.bias",
+              "column_summary_builder.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.query_norm.bias",
+              "column_summary_builder.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "direct_head.net.0.bias",
+              "direct_head.net.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "direct_head.net.2.bias",
+              "direct_head.net.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 970,
+            "trainable_params": 970
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "discrete_oov.bias",
+              "discrete_oov.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 153,
+            "trainable_params": 153
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "discrete_query.bias",
+              "discrete_query.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "feature_encoder.linear",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "feature_encoder.linear.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 608,
+            "trainable_params": 608
+          },
+          {
+            "expanded_embedding_like_params": 1520,
+            "owner_module": "feature_type_film.params",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "feature_type_film.params.weight"
+            ],
+            "strict_embedding_params": 1520,
+            "total_params": 1520,
+            "trainable_params": 1520
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "gaussian_head.0.bias",
+              "gaussian_head.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "gaussian_head.2.bias",
+              "gaussian_head.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 194,
+            "trainable_params": 194
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "integer_gate.0.bias",
+              "integer_gate.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "integer_gate.2.bias",
+              "integer_gate.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 97,
+            "trainable_params": 97
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "latent_readout.attn.in_proj_bias",
+              "latent_readout.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "latent_readout.attn.out_proj.bias",
+              "latent_readout.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "latent_readout.ff.0.bias",
+              "latent_readout.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "latent_readout.ff.2.bias",
+              "latent_readout.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.ff_norm.bias",
+              "latent_readout.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.kv_norm.bias",
+              "latent_readout.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.query_norm.bias",
+              "latent_readout.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.attn.in_proj_bias",
+              "perceiver_stages.0.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.attn.out_proj.bias",
+              "perceiver_stages.0.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff.0.bias",
+              "perceiver_stages.0.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff.2.bias",
+              "perceiver_stages.0.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff_norm.bias",
+              "perceiver_stages.0.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.kv_norm.bias",
+              "perceiver_stages.0.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.query_norm.bias",
+              "perceiver_stages.0.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff.0.bias",
+              "perceiver_stages.0.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff.2.bias",
+              "perceiver_stages.0.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff.0.bias",
+              "perceiver_stages.0.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff.2.bias",
+              "perceiver_stages.0.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff.0.bias",
+              "perceiver_stages.0.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff.2.bias",
+              "perceiver_stages.0.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff.0.bias",
+              "perceiver_stages.0.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff.2.bias",
+              "perceiver_stages.0.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.attn.in_proj_bias",
+              "perceiver_stages.1.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.attn.out_proj.bias",
+              "perceiver_stages.1.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff.0.bias",
+              "perceiver_stages.1.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff.2.bias",
+              "perceiver_stages.1.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff_norm.bias",
+              "perceiver_stages.1.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.kv_norm.bias",
+              "perceiver_stages.1.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.query_norm.bias",
+              "perceiver_stages.1.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff.0.bias",
+              "perceiver_stages.1.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff.2.bias",
+              "perceiver_stages.1.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff.0.bias",
+              "perceiver_stages.1.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff.2.bias",
+              "perceiver_stages.1.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff.0.bias",
+              "perceiver_stages.1.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff.2.bias",
+              "perceiver_stages.1.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff.0.bias",
+              "perceiver_stages.1.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff.2.bias",
+              "perceiver_stages.1.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.attn.in_proj_bias",
+              "perceiver_stages.2.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.attn.out_proj.bias",
+              "perceiver_stages.2.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff.0.bias",
+              "perceiver_stages.2.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff.2.bias",
+              "perceiver_stages.2.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff_norm.bias",
+              "perceiver_stages.2.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.kv_norm.bias",
+              "perceiver_stages.2.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.query_norm.bias",
+              "perceiver_stages.2.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff.0.bias",
+              "perceiver_stages.2.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff.2.bias",
+              "perceiver_stages.2.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff.0.bias",
+              "perceiver_stages.2.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff.2.bias",
+              "perceiver_stages.2.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff.0.bias",
+              "perceiver_stages.2.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff.2.bias",
+              "perceiver_stages.2.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff.0.bias",
+              "perceiver_stages.2.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff.2.bias",
+              "perceiver_stages.2.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.attn.in_proj_bias",
+              "perceiver_stages.3.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.attn.out_proj.bias",
+              "perceiver_stages.3.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff.0.bias",
+              "perceiver_stages.3.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff.2.bias",
+              "perceiver_stages.3.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff_norm.bias",
+              "perceiver_stages.3.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.kv_norm.bias",
+              "perceiver_stages.3.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.query_norm.bias",
+              "perceiver_stages.3.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff.0.bias",
+              "perceiver_stages.3.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff.2.bias",
+              "perceiver_stages.3.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff.0.bias",
+              "perceiver_stages.3.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff.2.bias",
+              "perceiver_stages.3.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff.0.bias",
+              "perceiver_stages.3.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff.2.bias",
+              "perceiver_stages.3.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff.0.bias",
+              "perceiver_stages.3.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff.2.bias",
+              "perceiver_stages.3.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.attn.in_proj_bias",
+              "perceiver_stages.4.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.attn.out_proj.bias",
+              "perceiver_stages.4.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff.0.bias",
+              "perceiver_stages.4.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff.2.bias",
+              "perceiver_stages.4.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff_norm.bias",
+              "perceiver_stages.4.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.kv_norm.bias",
+              "perceiver_stages.4.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.query_norm.bias",
+              "perceiver_stages.4.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff.0.bias",
+              "perceiver_stages.4.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff.2.bias",
+              "perceiver_stages.4.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff.0.bias",
+              "perceiver_stages.4.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff.2.bias",
+              "perceiver_stages.4.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff.0.bias",
+              "perceiver_stages.4.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff.2.bias",
+              "perceiver_stages.4.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff.0.bias",
+              "perceiver_stages.4.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff.2.bias",
+              "perceiver_stages.4.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 2432,
+            "owner_module": "pre_column_attention_blocks.0",
+            "owner_type": "_InducedSetAttentionBlock",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_seed"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 2432,
+            "trainable_params": 2432
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.inducing_self.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.inducing_self.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn_norm.bias",
+              "pre_column_attention_blocks.0.inducing_self.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff.0.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff.2.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff_norm.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.0.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.2.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.query_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.0.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.2.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.query_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn.in_proj_bias",
+              "pre_row_attention_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn.out_proj.bias",
+              "pre_row_attention_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn_norm.bias",
+              "pre_row_attention_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff.0.bias",
+              "pre_row_attention_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff.2.bias",
+              "pre_row_attention_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff_norm.bias",
+              "pre_row_attention_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "row_summary_builder.attn.in_proj_bias",
+              "row_summary_builder.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "row_summary_builder.attn.out_proj.bias",
+              "row_summary_builder.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "row_summary_builder.ff.0.bias",
+              "row_summary_builder.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "row_summary_builder.ff.2.bias",
+              "row_summary_builder.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.ff_norm.bias",
+              "row_summary_builder.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.kv_norm.bias",
+              "row_summary_builder.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.query_norm.bias",
+              "row_summary_builder.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "test_row_pool.attn.in_proj_bias",
+              "test_row_pool.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "test_row_pool.attn.out_proj.bias",
+              "test_row_pool.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "test_row_pool.ff.0.bias",
+              "test_row_pool.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "test_row_pool.ff.2.bias",
+              "test_row_pool.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.ff_norm.bias",
+              "test_row_pool.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.kv_norm.bias",
+              "test_row_pool.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.query_norm.bias",
+              "test_row_pool.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 456,
+            "owner_module": "token_type_embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "token_type_embedding.weight"
+            ],
+            "strict_embedding_params": 456,
+            "total_params": 456,
+            "trainable_params": 456
+          },
+          {
+            "expanded_embedding_like_params": 152,
+            "owner_module": "y_conditioner",
+            "owner_type": "LabelTokenTargetConditioner",
+            "parameter_names": [
+              "y_conditioner.test_token"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 152,
+            "trainable_params": 152
+          },
+          {
+            "expanded_embedding_like_params": 1520,
+            "owner_module": "y_conditioner.embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "y_conditioner.embedding.weight"
+            ],
+            "strict_embedding_params": 1520,
+            "total_params": 1520,
+            "trainable_params": 1520
+          },
+          {
+            "expanded_embedding_like_params": 304,
+            "owner_module": "y_role_embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "y_role_embedding.weight"
+            ],
+            "strict_embedding_params": 304,
+            "total_params": 304,
+            "trainable_params": 304
+          }
+        ],
+        "parameter_breakdown": [
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "cell_bos",
+            "numel": 152,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.query_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.query_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.0.bias",
+            "numel": 304,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.2.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.query_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.query_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "column_summary_query",
+            "numel": 456,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.0.bias",
+            "numel": 96,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.0.weight",
+            "numel": 14592,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.2.bias",
+            "numel": 10,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.2.weight",
+            "numel": 960,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_oov.bias",
+            "numel": 1,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_oov.weight",
+            "numel": 152,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_query.bias",
+            "numel": 152,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_query.weight",
+            "numel": 23104,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "feature_encoder.linear.weight",
+            "numel": 608,
+            "owner_module": "feature_encoder.linear",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "feature_type_film.params.weight",
+            "numel": 1520,
+            "owner_module": "feature_type_film.params",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.0.bias",
+            "numel": 96,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.0.weight",
+            "numel": 14592,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.2.bias",
+            "numel": 2,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.2.weight",
+            "numel": 192,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.0.bias",
+            "numel": 96,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.0.weight",
+            "numel": 14592,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.2.bias",
+            "numel": 1,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.2.weight",
+            "numel": 96,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.0.bias",
+            "numel": 304,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.2.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.query_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.query_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "latent_seed",
+            "numel": 3648,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_inducing_seed",
+            "name": "pre_column_attention_blocks.0.inducing_seed",
+            "numel": 2432,
+            "owner_module": "pre_column_attention_blocks.0",
+            "owner_type": "_InducedSetAttentionBlock",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.query_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.query_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.query_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.query_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.0.bias",
+            "numel": 304,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.2.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.query_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.query_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "row_summary_query",
+            "numel": 456,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.0.bias",
+            "numel": 304,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.2.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.query_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.query_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "test_row_pool_query",
+            "numel": 152,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "token_type_embedding.weight",
+            "numel": 456,
+            "owner_module": "token_type_embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "y_conditioner.embedding.weight",
+            "numel": 1520,
+            "owner_module": "y_conditioner.embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_test_token",
+            "name": "y_conditioner.test_token",
+            "numel": 152,
+            "owner_module": "y_conditioner",
+            "owner_type": "LabelTokenTargetConditioner",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "y_role_embedding.weight",
+            "numel": 304,
+            "owner_module": "y_role_embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          }
+        ],
+        "schema": "tab-foundry-model-accounting-v1",
+        "strict": {
+          "embedding_params": 3800,
+          "non_embedding_params": 7354094
+        },
+        "total_params": 7357894,
+        "trainable_params": 7357894
+      },
+      "regime_budget": {
+        "curriculum_id": "tf_rd_010_dagzoo_medium_control",
+        "curriculum_mix": {
+          "config_refs": [
+            "configs/default.yaml"
+          ],
+          "corpus_variant": "tf_rd_010_dagzoo_medium_control",
+          "invocation_mix": [],
+          "source_families": []
+        },
+        "objective_metric": "final_log_loss_at_matched_regime_budget",
+        "scm_complexity_summary": {
+          "class_count_distribution": {
+            "count": 159984,
+            "max": 10,
+            "min": 2
+          },
+          "feature_count_distribution": {
+            "count": 159984,
+            "max": 20,
+            "min": 2
+          },
+          "row_count_distribution": {
+            "count": 159984,
+            "max": 1024,
+            "min": 128
+          }
+        },
+        "token_budget": 917716352,
+        "tokens_per_step": 367086.5408,
+        "tokens_seen": 917716352,
+        "unique_task_budget": 143976
+      },
+      "registered_at_utc": "2026-04-13T19:05:14Z",
+      "run_id": "sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+      "runtime_summary": {
+        "non_train_overhead_seconds": 31.184280645102262,
+        "peak_vram_allocated": 12625763840,
+        "peak_vram_reserved": 17811111936,
+        "throughput_examples_per_second": 15.217746456341361,
+        "throughput_tokens_per_second": 90652.58583615387
+      },
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_010_dagzoo_medium_control",
+        "model": "tabfoundry_sandwich",
+        "preprocessing": "runtime_default",
+        "training": "prior_cosine_warmup"
+      },
+      "sweep": {
+        "delta_id": "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1",
+        "parent_sweep_id": "tf_rd_009_width_depth_medium_v1",
+        "queue_order": 1,
+        "run_kind": "primary",
+        "sweep_id": "tf_rd_009_large_validation_152x5_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_bpc": 2.261271075101999,
+        "best_bpf": 2.261271130121671,
+        "best_brier_score": 0.5675577543042242,
+        "best_crps": null,
+        "best_log_loss": 0.9507625551301947,
+        "best_picp_90": null,
+        "best_roc_auc": 0.5967365187249479,
+        "best_step": 550.0,
+        "best_training_time": 2390.004813339561,
+        "final_avg_pinball_loss": null,
+        "final_bpc": 2.2686359478877143,
+        "final_bpf": 2.2686359680615937,
+        "final_brier_score": 0.5533658082117038,
+        "final_crps": null,
+        "final_log_loss": 0.9337034780913935,
+        "final_picp_90": null,
+        "final_roc_auc": 0.6083568021504234,
+        "final_step": 600.0,
+        "final_training_time": 2607.995172109455
+      },
+      "track": "system_delta_classification_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.6383590245212006,
+        "final_val_loss": null,
+        "max_grad_norm": 54.525353839842566,
+        "mean_grad_norm": 0.783315318898648,
+        "post_warmup_train_loss_var": 0.07188199894420934,
+        "train_elapsed_seconds": 10123.443733405322,
+        "wall_elapsed_seconds": 10154.10568357259
+      },
+      "wandb": null
+    },
     "sd_tf_rd_009_ns_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1": {
       "artifacts": {
         "accounting_artifact_path": "outputs/staged_ladder/research/tf_rd_009_ns_medium_v1/delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1/sd_tf_rd_009_ns_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1/benchmark/model_accounting.json",

--- a/src/tab_foundry/bench/benchmark_run_registry_v1.json
+++ b/src/tab_foundry/bench/benchmark_run_registry_v1.json
@@ -27665,6 +27665,11044 @@
       },
       "wandb": null
     },
+    "sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2": {
+      "artifacts": {
+        "accounting_artifact_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2/benchmark/model_accounting.json",
+        "benchmark_dir": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2/benchmark",
+        "benchmark_run_record_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2/benchmark/benchmark_run_record.json",
+        "best_checkpoint_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/checkpoints/best.pt",
+        "comparison_curve_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2/benchmark/comparison_curve.png",
+        "comparison_summary_path": "outputs/staged_ladder/research/tf_rd_009_large_validation_152x5_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2/benchmark/comparison_summary.json",
+        "history_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/train_history.jsonl",
+        "prior_dir": null,
+        "run_dir": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train",
+        "training_surface_record_path": "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train/training_surface_record.json"
+      },
+      "benchmark_bundle": {
+        "name": "nanotabpfn_openml_classification_large",
+        "source_path": "/private/tmp/frozen_local_large_3task_bundle.json",
+        "task_count": 3,
+        "task_ids": [
+          363685,
+          363699,
+          363707
+        ],
+        "version": 1
+      },
+      "benchmark_timing": {
+        "attempted_checkpoint_count": 25,
+        "failed_checkpoint_count": 0,
+        "host_fingerprint": "5b6826bab949|linux|x86_64",
+        "max_checkpoint_elapsed_seconds": 0.9242591061629355,
+        "mean_checkpoint_elapsed_seconds": 0.40011127119883894,
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "successful_checkpoint_count": 25,
+        "wall_elapsed_seconds": 10.053687729872763
+      },
+      "budget_class": "short-run",
+      "comparisons": {
+        "vs_anchor": {
+          "best_roc_auc_delta": -0.03561400034817397,
+          "best_training_time_delta": -4730.034552419791,
+          "final_avg_pinball_loss_delta": null,
+          "final_bpc_delta": 2.421422940034133,
+          "final_bpf_delta": 2.4214231527768644,
+          "final_brier_score_delta": -0.1176530938495744,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.15377743935891375,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.1327435146887801,
+          "final_training_time_delta": 2673.6898094417993,
+          "reference_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+        },
+        "vs_parent": {
+          "best_roc_auc_delta": -0.03561400034817397,
+          "best_training_time_delta": -4730.034552419791,
+          "final_avg_pinball_loss_delta": null,
+          "final_bpc_delta": 2.421422940034133,
+          "final_bpf_delta": 2.4214231527768644,
+          "final_brier_score_delta": -0.1176530938495744,
+          "final_crps_delta": null,
+          "final_log_loss_delta": -0.15377743935891375,
+          "final_picp_90_delta": null,
+          "final_roc_auc_delta": 0.1327435146887801,
+          "final_training_time_delta": 2673.6898094417993,
+          "reference_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+        }
+      },
+      "compute_accounting": {
+        "forward_flops_per_token": 7730862.6,
+        "method": "inspected_analytic_v1",
+        "module_forward_flop_totals": [
+          {
+            "forward_flops": 556320.0,
+            "module_op": "cell_readout.ff.0::linear"
+          },
+          {
+            "forward_flops": 14592.0,
+            "module_op": "cell_readout.ff.1::gelu"
+          },
+          {
+            "forward_flops": 555408.0,
+            "module_op": "cell_readout.ff.2::linear"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "cell_readout.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "cell_readout.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "cell_readout.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1112640.0,
+            "module_op": "column_summary_builder.ff.0::linear"
+          },
+          {
+            "forward_flops": 29184.0,
+            "module_op": "column_summary_builder.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1110816.0,
+            "module_op": "column_summary_builder.ff.2::linear"
+          },
+          {
+            "forward_flops": 16416.0,
+            "module_op": "column_summary_builder.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "column_summary_builder.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 16416.0,
+            "module_op": "column_summary_builder.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 58560.0,
+            "module_op": "direct_head.net.0::linear"
+          },
+          {
+            "forward_flops": 1536.0,
+            "module_op": "direct_head.net.1::gelu"
+          },
+          {
+            "forward_flops": 3860.0,
+            "module_op": "direct_head.net.2::linear"
+          },
+          {
+            "forward_flops": 24320.0,
+            "module_op": "feature_encoder.linear::linear"
+          },
+          {
+            "forward_flops": 556320.0,
+            "module_op": "latent_readout.ff.0::linear"
+          },
+          {
+            "forward_flops": 14592.0,
+            "module_op": "latent_readout.ff.1::gelu"
+          },
+          {
+            "forward_flops": 555408.0,
+            "module_op": "latent_readout.ff.2::linear"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "latent_readout.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "latent_readout.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "latent_readout.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 64296.0,
+            "module_op": "perceiver_stages.0.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.0.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.1.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.1.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.2.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.2.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.3.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.3.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.input_read.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.input_read.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.input_read.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.input_read.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 36936.0,
+            "module_op": "perceiver_stages.4.input_read.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.input_read.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.1.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.2.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2225280.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.0::linear"
+          },
+          {
+            "forward_flops": 58368.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.1::gelu"
+          },
+          {
+            "forward_flops": 2221632.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff.2::linear"
+          },
+          {
+            "forward_flops": 32832.0,
+            "module_op": "perceiver_stages.4.self_blocks.3.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 5934080.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.0::linear"
+          },
+          {
+            "forward_flops": 155648.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.1::gelu"
+          },
+          {
+            "forward_flops": 5924352.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff.2::linear"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.inducing_self.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1854400.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.0::linear"
+          },
+          {
+            "forward_flops": 48640.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1851360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff.2::linear"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_from_inducing.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 5934080.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.0::linear"
+          },
+          {
+            "forward_flops": 155648.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.1::gelu"
+          },
+          {
+            "forward_flops": 5924352.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff.2::linear"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 87552.0,
+            "module_op": "pre_column_attention_blocks.0.rows_to_inducing.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_row_attention_blocks.0.attn_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1854400.0,
+            "module_op": "pre_row_attention_blocks.0.ff.0::linear"
+          },
+          {
+            "forward_flops": 48640.0,
+            "module_op": "pre_row_attention_blocks.0.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1851360.0,
+            "module_op": "pre_row_attention_blocks.0.ff.2::linear"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "pre_row_attention_blocks.0.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 1390800.0,
+            "module_op": "row_summary_builder.ff.0::linear"
+          },
+          {
+            "forward_flops": 36480.0,
+            "module_op": "row_summary_builder.ff.1::gelu"
+          },
+          {
+            "forward_flops": 1388520.0,
+            "module_op": "row_summary_builder.ff.2::linear"
+          },
+          {
+            "forward_flops": 20520.0,
+            "module_op": "row_summary_builder.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 27360.0,
+            "module_op": "row_summary_builder.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 20520.0,
+            "module_op": "row_summary_builder.query_norm::layer_norm"
+          },
+          {
+            "forward_flops": 185440.0,
+            "module_op": "test_row_pool.ff.0::linear"
+          },
+          {
+            "forward_flops": 4864.0,
+            "module_op": "test_row_pool.ff.1::gelu"
+          },
+          {
+            "forward_flops": 185136.0,
+            "module_op": "test_row_pool.ff.2::linear"
+          },
+          {
+            "forward_flops": 2736.0,
+            "module_op": "test_row_pool.ff_norm::layer_norm"
+          },
+          {
+            "forward_flops": 8208.0,
+            "module_op": "test_row_pool.kv_norm::layer_norm"
+          },
+          {
+            "forward_flops": 2736.0,
+            "module_op": "test_row_pool.query_norm::layer_norm"
+          }
+        ],
+        "schema": "tab-foundry-model-accounting-v1",
+        "signature_breakdown": [
+          {
+            "contributions": [
+              {
+                "forward_flops": 24320.0,
+                "module": "feature_encoder.linear",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_row_attention_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_row_attention_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1854400.0,
+                "module": "pre_row_attention_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 48640.0,
+                "module": "pre_row_attention_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1851360.0,
+                "module": "pre_row_attention_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 5934080.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 155648.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 5924352.0,
+                "module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 5934080.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 155648.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 5924352.0,
+                "module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 87552.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1854400.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 48640.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1851360.0,
+                "module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 20520.0,
+                "module": "row_summary_builder.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "row_summary_builder.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 20520.0,
+                "module": "row_summary_builder.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1390800.0,
+                "module": "row_summary_builder.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 36480.0,
+                "module": "row_summary_builder.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1388520.0,
+                "module": "row_summary_builder.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 16416.0,
+                "module": "column_summary_builder.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "column_summary_builder.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 16416.0,
+                "module": "column_summary_builder.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 1112640.0,
+                "module": "column_summary_builder.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 29184.0,
+                "module": "column_summary_builder.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 1110816.0,
+                "module": "column_summary_builder.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 64296.0,
+                "module": "perceiver_stages.0.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.0.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.1.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.1.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.2.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.2.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.3.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.3.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.input_read.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 36936.0,
+                "module": "perceiver_stages.4.input_read.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.input_read.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.input_read.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.input_read.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.input_read.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.0.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.0.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.1.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.1.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.2.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.2.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.3.attn_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2225280.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58368.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 2221632.0,
+                "module": "perceiver_stages.4.self_blocks.3.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "latent_readout.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 32832.0,
+                "module": "latent_readout.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "latent_readout.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 556320.0,
+                "module": "latent_readout.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 14592.0,
+                "module": "latent_readout.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 555408.0,
+                "module": "latent_readout.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "cell_readout.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 27360.0,
+                "module": "cell_readout.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "cell_readout.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 556320.0,
+                "module": "cell_readout.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 14592.0,
+                "module": "cell_readout.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 555408.0,
+                "module": "cell_readout.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 2736.0,
+                "module": "test_row_pool.query_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 8208.0,
+                "module": "test_row_pool.kv_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 2736.0,
+                "module": "test_row_pool.ff_norm",
+                "module_type": "LayerNorm",
+                "op_kind": "layer_norm"
+              },
+              {
+                "forward_flops": 185440.0,
+                "module": "test_row_pool.ff.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 4864.0,
+                "module": "test_row_pool.ff.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 185136.0,
+                "module": "test_row_pool.ff.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 58560.0,
+                "module": "direct_head.net.0",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              },
+              {
+                "forward_flops": 1536.0,
+                "module": "direct_head.net.1",
+                "module_type": "GELU",
+                "op_kind": "gelu"
+              },
+              {
+                "forward_flops": 3860.0,
+                "module": "direct_head.net.2",
+                "module_type": "Linear",
+                "op_kind": "linear"
+              }
+            ],
+            "forward_flops_per_task": 154617252.0,
+            "forward_flops_per_token": 7730862.6,
+            "n_features": 4,
+            "n_test": 2,
+            "n_train": 3,
+            "num_classes": 2,
+            "signature": "3x2x4x2",
+            "task_count": 1,
+            "tokens_per_task": 20
+          }
+        ],
+        "tokens_per_step": 367086.5408,
+        "tokens_seen": 917716352,
+        "total_train_flops": 2.1284217069255704e+16,
+        "train_flops_per_step": 8513686827702.281,
+        "train_flops_per_token": 23192587.799999997,
+        "training_multiplier": 3.0,
+        "training_shape_summary": null
+      },
+      "conclusion": "Corrected benchmark-only large-rung transfer reused the retained 152x5 artifact, filtered telemetry-only missing late numbered checkpoints, finished on terminal latest.pt at step 2500, and beat the locked TF-RD-010 large anchor.",
+      "config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "decision": "keep",
+      "experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "hardware_summary": {
+        "device_type": "cuda",
+        "gpu_class": "rtx8000",
+        "hardware_profile_id": "rtx8000_44gb",
+        "raw_device_name": "Quadro RTX 8000",
+        "total_device_vram_bytes": 47560916992,
+        "vram_class_gb": 44
+      },
+      "inference_timing": {
+        "device_type": "cuda",
+        "fixture_id": "classification_medium_reference_v1",
+        "gpu_class": "nvidia-rtx-a6000",
+        "hardware_profile_id": "nvidia-rtx-a6000_44gb",
+        "max_ms": 14.760663732886314,
+        "mean_ms": 14.347890065982938,
+        "measured_iterations": 10,
+        "n_features": 10,
+        "n_test": 40,
+        "n_train": 160,
+        "num_classes": 10,
+        "p50_ms": 14.21988382935524,
+        "p95_ms": 14.696052460931242,
+        "raw_device_name": "NVIDIA RTX A6000",
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "total_measured_seconds": 0.14347890065982938,
+        "vram_class_gb": 44,
+        "warmup_iterations": 3
+      },
+      "lineage": {
+        "anchor_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1",
+        "control_baseline_id": "cls_benchmark_linear_multiclass_large_v1",
+        "parent_run_id": "sd_tf_rd_010_classification_evolution_large_v2_01_delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+      },
+      "manifest_path": "outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b/manifest.parquet",
+      "model": {
+        "arch": "tabfoundry_sandwich",
+        "architecture": {
+          "feature_type_encoding": "film",
+          "ff_expansion": 2,
+          "floating_likelihood": "single_gaussian",
+          "heads": 1,
+          "initial_input_token_count": "R_times_C_plus_K_times_(R_plus_C)",
+          "initial_input_tokens": "full_cell_plus_row_col_summary_stream",
+          "integer_likelihood": "hybrid_mixture",
+          "label_injection": "fused_into_row_summaries_and_feature_cells",
+          "latent_core": "stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages",
+          "latents": 24,
+          "layer_semantics": "stage0_hybrid_then_summary_repeated_stages",
+          "layers": 5,
+          "position_encoding": "shared_fourier_row_col",
+          "pre_column_attention_layers": 1,
+          "pre_column_inducing_tokens": 16,
+          "pre_perceiver_cell_mixer": "row_feature_self_attention_then_column_row_isab",
+          "pre_row_attention_layers": 1,
+          "readout": "latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool",
+          "repeated_input_token_count": "K_times_(R_plus_C)",
+          "repeated_input_tokens": "row_col_summary_stream",
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "self_attention_per_cross": 4,
+          "summary_builder": "summary_query_attention",
+          "summary_tokens_per_axis": 3
+        },
+        "build_spec": {
+          "arch": "tabfoundry_sandwich",
+          "d_col": 128,
+          "d_icl": 152,
+          "feature_group_size": 1,
+          "feature_type_conditioning": "film",
+          "floating_likelihood": "single_gaussian",
+          "head_hidden_dim": 96,
+          "input_normalization": "train_zscore_clip",
+          "integer_likelihood": "hybrid_mixture",
+          "many_class_base": 10,
+          "many_class_train_mode": "path_nll",
+          "max_mixed_radix_digits": 64,
+          "norm_type": "layernorm",
+          "pre_encoder_clip": null,
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "sandwich_ff_expansion": 2,
+          "sandwich_heads": 1,
+          "sandwich_latents": 24,
+          "sandwich_layers": 5,
+          "sandwich_pre_column_attention_layers": 1,
+          "sandwich_pre_column_inducing_tokens": 16,
+          "sandwich_pre_row_attention_layers": 1,
+          "sandwich_self_attention_per_cross": 4,
+          "sandwich_summary_tokens_per_axis": 3,
+          "task": "classification"
+        },
+        "d_icl": 152,
+        "feature_group_size": 1,
+        "head_hidden_dim": 96,
+        "input_normalization": "train_zscore_clip",
+        "many_class_base": 10,
+        "stage": null,
+        "stage_label": null,
+        "tficl_n_heads": 8,
+        "tficl_n_layers": 12
+      },
+      "model_size": {
+        "total_params": 7357894,
+        "trainable_params": 7357894
+      },
+      "parameter_accounting": {
+        "canonical_non_embedding_params": 7354094,
+        "expanded": {
+          "embedding_like_params": 11248,
+          "non_embedding_params": 7346646
+        },
+        "method": "inspected_parameter_partition_v1",
+        "module_breakdown": [
+          {
+            "expanded_embedding_like_params": 4864,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "parameter_names": [
+              "cell_bos",
+              "column_summary_query",
+              "latent_seed",
+              "row_summary_query",
+              "test_row_pool_query"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 4864,
+            "trainable_params": 4864
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn.in_proj_bias",
+              "cell_decoder_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn.out_proj.bias",
+              "cell_decoder_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.0.attn_norm.bias",
+              "cell_decoder_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff.0.bias",
+              "cell_decoder_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff.2.bias",
+              "cell_decoder_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.0.ff_norm.bias",
+              "cell_decoder_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn.in_proj_bias",
+              "cell_decoder_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn.out_proj.bias",
+              "cell_decoder_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.1.attn_norm.bias",
+              "cell_decoder_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff.0.bias",
+              "cell_decoder_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff.2.bias",
+              "cell_decoder_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.1.ff_norm.bias",
+              "cell_decoder_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn.in_proj_bias",
+              "cell_decoder_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn.out_proj.bias",
+              "cell_decoder_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.2.attn_norm.bias",
+              "cell_decoder_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff.0.bias",
+              "cell_decoder_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff.2.bias",
+              "cell_decoder_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.2.ff_norm.bias",
+              "cell_decoder_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn.in_proj_bias",
+              "cell_decoder_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn.out_proj.bias",
+              "cell_decoder_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.3.attn_norm.bias",
+              "cell_decoder_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff.0.bias",
+              "cell_decoder_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff.2.bias",
+              "cell_decoder_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.3.ff_norm.bias",
+              "cell_decoder_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn.in_proj_bias",
+              "cell_decoder_blocks.4.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn.out_proj.bias",
+              "cell_decoder_blocks.4.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.4.attn_norm.bias",
+              "cell_decoder_blocks.4.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff.0.bias",
+              "cell_decoder_blocks.4.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff.2.bias",
+              "cell_decoder_blocks.4.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_decoder_blocks.4.ff_norm.bias",
+              "cell_decoder_blocks.4.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "cell_readout.attn.in_proj_bias",
+              "cell_readout.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "cell_readout.attn.out_proj.bias",
+              "cell_readout.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_readout.ff.0.bias",
+              "cell_readout.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "cell_readout.ff.2.bias",
+              "cell_readout.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.ff_norm.bias",
+              "cell_readout.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.kv_norm.bias",
+              "cell_readout.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "cell_readout.query_norm.bias",
+              "cell_readout.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "column_summary_builder.attn.in_proj_bias",
+              "column_summary_builder.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "column_summary_builder.attn.out_proj.bias",
+              "column_summary_builder.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "column_summary_builder.ff.0.bias",
+              "column_summary_builder.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "column_summary_builder.ff.2.bias",
+              "column_summary_builder.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.ff_norm.bias",
+              "column_summary_builder.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.kv_norm.bias",
+              "column_summary_builder.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "column_summary_builder.query_norm.bias",
+              "column_summary_builder.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "direct_head.net.0.bias",
+              "direct_head.net.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "direct_head.net.2.bias",
+              "direct_head.net.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 970,
+            "trainable_params": 970
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "discrete_oov.bias",
+              "discrete_oov.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 153,
+            "trainable_params": 153
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "discrete_query.bias",
+              "discrete_query.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "feature_encoder.linear",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "feature_encoder.linear.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 608,
+            "trainable_params": 608
+          },
+          {
+            "expanded_embedding_like_params": 1520,
+            "owner_module": "feature_type_film.params",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "feature_type_film.params.weight"
+            ],
+            "strict_embedding_params": 1520,
+            "total_params": 1520,
+            "trainable_params": 1520
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "gaussian_head.0.bias",
+              "gaussian_head.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "gaussian_head.2.bias",
+              "gaussian_head.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 194,
+            "trainable_params": 194
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "integer_gate.0.bias",
+              "integer_gate.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 14688,
+            "trainable_params": 14688
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "integer_gate.2.bias",
+              "integer_gate.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 97,
+            "trainable_params": 97
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "latent_readout.attn.in_proj_bias",
+              "latent_readout.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "latent_readout.attn.out_proj.bias",
+              "latent_readout.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "latent_readout.ff.0.bias",
+              "latent_readout.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "latent_readout.ff.2.bias",
+              "latent_readout.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.ff_norm.bias",
+              "latent_readout.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.kv_norm.bias",
+              "latent_readout.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "latent_readout.query_norm.bias",
+              "latent_readout.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.attn.in_proj_bias",
+              "perceiver_stages.0.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.attn.out_proj.bias",
+              "perceiver_stages.0.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff.0.bias",
+              "perceiver_stages.0.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff.2.bias",
+              "perceiver_stages.0.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.ff_norm.bias",
+              "perceiver_stages.0.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.kv_norm.bias",
+              "perceiver_stages.0.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.input_read.query_norm.bias",
+              "perceiver_stages.0.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff.0.bias",
+              "perceiver_stages.0.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff.2.bias",
+              "perceiver_stages.0.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff.0.bias",
+              "perceiver_stages.0.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff.2.bias",
+              "perceiver_stages.0.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff.0.bias",
+              "perceiver_stages.0.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff.2.bias",
+              "perceiver_stages.0.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.0.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.0.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.0.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff.0.bias",
+              "perceiver_stages.0.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff.2.bias",
+              "perceiver_stages.0.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.0.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.0.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.attn.in_proj_bias",
+              "perceiver_stages.1.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.attn.out_proj.bias",
+              "perceiver_stages.1.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff.0.bias",
+              "perceiver_stages.1.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff.2.bias",
+              "perceiver_stages.1.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.ff_norm.bias",
+              "perceiver_stages.1.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.kv_norm.bias",
+              "perceiver_stages.1.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.input_read.query_norm.bias",
+              "perceiver_stages.1.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff.0.bias",
+              "perceiver_stages.1.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff.2.bias",
+              "perceiver_stages.1.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff.0.bias",
+              "perceiver_stages.1.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff.2.bias",
+              "perceiver_stages.1.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff.0.bias",
+              "perceiver_stages.1.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff.2.bias",
+              "perceiver_stages.1.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.1.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.1.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.1.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff.0.bias",
+              "perceiver_stages.1.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff.2.bias",
+              "perceiver_stages.1.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.1.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.1.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.attn.in_proj_bias",
+              "perceiver_stages.2.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.attn.out_proj.bias",
+              "perceiver_stages.2.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff.0.bias",
+              "perceiver_stages.2.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff.2.bias",
+              "perceiver_stages.2.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.ff_norm.bias",
+              "perceiver_stages.2.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.kv_norm.bias",
+              "perceiver_stages.2.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.input_read.query_norm.bias",
+              "perceiver_stages.2.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff.0.bias",
+              "perceiver_stages.2.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff.2.bias",
+              "perceiver_stages.2.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff.0.bias",
+              "perceiver_stages.2.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff.2.bias",
+              "perceiver_stages.2.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff.0.bias",
+              "perceiver_stages.2.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff.2.bias",
+              "perceiver_stages.2.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.2.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.2.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.2.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff.0.bias",
+              "perceiver_stages.2.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff.2.bias",
+              "perceiver_stages.2.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.2.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.2.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.attn.in_proj_bias",
+              "perceiver_stages.3.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.attn.out_proj.bias",
+              "perceiver_stages.3.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff.0.bias",
+              "perceiver_stages.3.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff.2.bias",
+              "perceiver_stages.3.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.ff_norm.bias",
+              "perceiver_stages.3.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.kv_norm.bias",
+              "perceiver_stages.3.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.input_read.query_norm.bias",
+              "perceiver_stages.3.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff.0.bias",
+              "perceiver_stages.3.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff.2.bias",
+              "perceiver_stages.3.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff.0.bias",
+              "perceiver_stages.3.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff.2.bias",
+              "perceiver_stages.3.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff.0.bias",
+              "perceiver_stages.3.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff.2.bias",
+              "perceiver_stages.3.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.3.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.3.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.3.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff.0.bias",
+              "perceiver_stages.3.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff.2.bias",
+              "perceiver_stages.3.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.3.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.3.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.attn.in_proj_bias",
+              "perceiver_stages.4.input_read.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.attn.out_proj.bias",
+              "perceiver_stages.4.input_read.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff.0.bias",
+              "perceiver_stages.4.input_read.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff.2.bias",
+              "perceiver_stages.4.input_read.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.ff_norm.bias",
+              "perceiver_stages.4.input_read.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.kv_norm.bias",
+              "perceiver_stages.4.input_read.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.input_read.query_norm.bias",
+              "perceiver_stages.4.input_read.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff.0.bias",
+              "perceiver_stages.4.self_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff.2.bias",
+              "perceiver_stages.4.self_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.0.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.1.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.1.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.1.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff.0.bias",
+              "perceiver_stages.4.self_blocks.1.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff.2.bias",
+              "perceiver_stages.4.self_blocks.1.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.1.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.1.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.2.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.2.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.2.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff.0.bias",
+              "perceiver_stages.4.self_blocks.2.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff.2.bias",
+              "perceiver_stages.4.self_blocks.2.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.2.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.2.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn.in_proj_bias",
+              "perceiver_stages.4.self_blocks.3.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn.out_proj.bias",
+              "perceiver_stages.4.self_blocks.3.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.attn_norm.bias",
+              "perceiver_stages.4.self_blocks.3.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff.0.bias",
+              "perceiver_stages.4.self_blocks.3.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff.2.bias",
+              "perceiver_stages.4.self_blocks.3.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "perceiver_stages.4.self_blocks.3.ff_norm.bias",
+              "perceiver_stages.4.self_blocks.3.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 2432,
+            "owner_module": "pre_column_attention_blocks.0",
+            "owner_type": "_InducedSetAttentionBlock",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_seed"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 2432,
+            "trainable_params": 2432
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.inducing_self.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.inducing_self.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.attn_norm.bias",
+              "pre_column_attention_blocks.0.inducing_self.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff.0.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff.2.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.inducing_self.ff_norm.bias",
+              "pre_column_attention_blocks.0.inducing_self.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.0.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.2.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_from_inducing.query_norm.bias",
+              "pre_column_attention_blocks.0.rows_from_inducing.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.0.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.2.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_column_attention_blocks.0.rows_to_inducing.query_norm.bias",
+              "pre_column_attention_blocks.0.rows_to_inducing.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn.in_proj_bias",
+              "pre_row_attention_blocks.0.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn.out_proj.bias",
+              "pre_row_attention_blocks.0.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.attn_norm.bias",
+              "pre_row_attention_blocks.0.attn_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff.0.bias",
+              "pre_row_attention_blocks.0.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff.2.bias",
+              "pre_row_attention_blocks.0.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "pre_row_attention_blocks.0.ff_norm.bias",
+              "pre_row_attention_blocks.0.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "row_summary_builder.attn.in_proj_bias",
+              "row_summary_builder.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "row_summary_builder.attn.out_proj.bias",
+              "row_summary_builder.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "row_summary_builder.ff.0.bias",
+              "row_summary_builder.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "row_summary_builder.ff.2.bias",
+              "row_summary_builder.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.ff_norm.bias",
+              "row_summary_builder.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.kv_norm.bias",
+              "row_summary_builder.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "row_summary_builder.query_norm.bias",
+              "row_summary_builder.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "parameter_names": [
+              "test_row_pool.attn.in_proj_bias",
+              "test_row_pool.attn.in_proj_weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 69768,
+            "trainable_params": 69768
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "parameter_names": [
+              "test_row_pool.attn.out_proj.bias",
+              "test_row_pool.attn.out_proj.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 23256,
+            "trainable_params": 23256
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "test_row_pool.ff.0.bias",
+              "test_row_pool.ff.0.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46512,
+            "trainable_params": 46512
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "parameter_names": [
+              "test_row_pool.ff.2.bias",
+              "test_row_pool.ff.2.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 46360,
+            "trainable_params": 46360
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.ff_norm.bias",
+              "test_row_pool.ff_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.kv_norm.bias",
+              "test_row_pool.kv_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 0,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "parameter_names": [
+              "test_row_pool.query_norm.bias",
+              "test_row_pool.query_norm.weight"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 304,
+            "trainable_params": 304
+          },
+          {
+            "expanded_embedding_like_params": 456,
+            "owner_module": "token_type_embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "token_type_embedding.weight"
+            ],
+            "strict_embedding_params": 456,
+            "total_params": 456,
+            "trainable_params": 456
+          },
+          {
+            "expanded_embedding_like_params": 152,
+            "owner_module": "y_conditioner",
+            "owner_type": "LabelTokenTargetConditioner",
+            "parameter_names": [
+              "y_conditioner.test_token"
+            ],
+            "strict_embedding_params": 0,
+            "total_params": 152,
+            "trainable_params": 152
+          },
+          {
+            "expanded_embedding_like_params": 1520,
+            "owner_module": "y_conditioner.embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "y_conditioner.embedding.weight"
+            ],
+            "strict_embedding_params": 1520,
+            "total_params": 1520,
+            "trainable_params": 1520
+          },
+          {
+            "expanded_embedding_like_params": 304,
+            "owner_module": "y_role_embedding",
+            "owner_type": "Embedding",
+            "parameter_names": [
+              "y_role_embedding.weight"
+            ],
+            "strict_embedding_params": 304,
+            "total_params": 304,
+            "trainable_params": 304
+          }
+        ],
+        "parameter_breakdown": [
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "cell_bos",
+            "numel": 152,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_decoder_blocks.4.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_decoder_blocks.4.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.4.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_decoder_blocks.4.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_decoder_blocks.4.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_decoder_blocks.4.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "cell_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "cell_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.0.bias",
+            "numel": 304,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "cell_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.2.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "cell_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.query_norm.bias",
+            "numel": 152,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "cell_readout.query_norm.weight",
+            "numel": 152,
+            "owner_module": "cell_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "column_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "column_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.0.bias",
+            "numel": 304,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "column_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.2.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "column_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.query_norm.bias",
+            "numel": 152,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "column_summary_builder.query_norm.weight",
+            "numel": 152,
+            "owner_module": "column_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "column_summary_query",
+            "numel": 456,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.0.bias",
+            "numel": 96,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.0.weight",
+            "numel": 14592,
+            "owner_module": "direct_head.net.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.2.bias",
+            "numel": 10,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "direct_head.net.2.weight",
+            "numel": 960,
+            "owner_module": "direct_head.net.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_oov.bias",
+            "numel": 1,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_oov.weight",
+            "numel": 152,
+            "owner_module": "discrete_oov",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_query.bias",
+            "numel": 152,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "discrete_query.weight",
+            "numel": 23104,
+            "owner_module": "discrete_query",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "feature_encoder.linear.weight",
+            "numel": 608,
+            "owner_module": "feature_encoder.linear",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "feature_type_film.params.weight",
+            "numel": 1520,
+            "owner_module": "feature_type_film.params",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.0.bias",
+            "numel": 96,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.0.weight",
+            "numel": 14592,
+            "owner_module": "gaussian_head.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.2.bias",
+            "numel": 2,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "gaussian_head.2.weight",
+            "numel": 192,
+            "owner_module": "gaussian_head.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.0.bias",
+            "numel": 96,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.0.weight",
+            "numel": 14592,
+            "owner_module": "integer_gate.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.2.bias",
+            "numel": 1,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "integer_gate.2.weight",
+            "numel": 96,
+            "owner_module": "integer_gate.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "latent_readout.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "latent_readout.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.0.bias",
+            "numel": 304,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "latent_readout.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.2.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "latent_readout.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.query_norm.bias",
+            "numel": 152,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "latent_readout.query_norm.weight",
+            "numel": 152,
+            "owner_module": "latent_readout.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "latent_seed",
+            "numel": 3648,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.0.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.0.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.1.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.1.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.2.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.2.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.3.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.3.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.input_read.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.input_read.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.input_read.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.input_read.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.query_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.input_read.query_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.input_read.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.1.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.1.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.2.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.2.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.0.bias",
+            "numel": 304,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.2.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "perceiver_stages.4.self_blocks.3.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "perceiver_stages.4.self_blocks.3.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_inducing_seed",
+            "name": "pre_column_attention_blocks.0.inducing_seed",
+            "numel": 2432,
+            "owner_module": "pre_column_attention_blocks.0",
+            "owner_type": "_InducedSetAttentionBlock",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.inducing_self.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.inducing_self.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.query_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_from_inducing.query_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_from_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.query_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_column_attention_blocks.0.rows_to_inducing.query_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_column_attention_blocks.0.rows_to_inducing.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "pre_row_attention_blocks.0.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "pre_row_attention_blocks.0.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.attn_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.attn_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.0.bias",
+            "numel": 304,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "pre_row_attention_blocks.0.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.2.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "pre_row_attention_blocks.0.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "pre_row_attention_blocks.0.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "pre_row_attention_blocks.0.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "row_summary_builder.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "row_summary_builder.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.0.bias",
+            "numel": 304,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "row_summary_builder.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.2.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "row_summary_builder.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.query_norm.bias",
+            "numel": 152,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "row_summary_builder.query_norm.weight",
+            "numel": 152,
+            "owner_module": "row_summary_builder.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "row_summary_query",
+            "numel": 456,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.in_proj_bias",
+            "numel": 456,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.in_proj_weight",
+            "numel": 69312,
+            "owner_module": "test_row_pool.attn",
+            "owner_type": "MultiheadAttention",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.out_proj.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.attn.out_proj.weight",
+            "numel": 23104,
+            "owner_module": "test_row_pool.attn.out_proj",
+            "owner_type": "NonDynamicallyQuantizableLinear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.0.bias",
+            "numel": 304,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.0.weight",
+            "numel": 46208,
+            "owner_module": "test_row_pool.ff.0",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.2.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff.2.weight",
+            "numel": 46208,
+            "owner_module": "test_row_pool.ff.2",
+            "owner_type": "Linear",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.ff_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.ff_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.kv_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.kv_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.kv_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.query_norm.bias",
+            "numel": 152,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "non_embedding",
+            "expanded_reason": "non_embedding_default",
+            "name": "test_row_pool.query_norm.weight",
+            "numel": 152,
+            "owner_module": "test_row_pool.query_norm",
+            "owner_type": "LayerNorm",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_query_or_seed",
+            "name": "test_row_pool_query",
+            "numel": 152,
+            "owner_module": "",
+            "owner_type": "TabFoundrySandwichClassifier",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "token_type_embedding.weight",
+            "numel": 456,
+            "owner_module": "token_type_embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "y_conditioner.embedding.weight",
+            "numel": 1520,
+            "owner_module": "y_conditioner.embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "learned_test_token",
+            "name": "y_conditioner.test_token",
+            "numel": 152,
+            "owner_module": "y_conditioner",
+            "owner_type": "LabelTokenTargetConditioner",
+            "requires_grad": true,
+            "strict_partition": "non_embedding",
+            "strict_reason": "non_embedding_default"
+          },
+          {
+            "expanded_partition": "embedding_like",
+            "expanded_reason": "explicit_nn_embedding",
+            "name": "y_role_embedding.weight",
+            "numel": 304,
+            "owner_module": "y_role_embedding",
+            "owner_type": "Embedding",
+            "requires_grad": true,
+            "strict_partition": "embedding",
+            "strict_reason": "explicit_nn_embedding"
+          }
+        ],
+        "schema": "tab-foundry-model-accounting-v1",
+        "strict": {
+          "embedding_params": 3800,
+          "non_embedding_params": 7354094
+        },
+        "total_params": 7357894,
+        "trainable_params": 7357894
+      },
+      "regime_budget": {
+        "curriculum_id": "tf_rd_010_dagzoo_medium_control",
+        "curriculum_mix": {
+          "config_refs": [
+            "configs/default.yaml"
+          ],
+          "corpus_variant": "tf_rd_010_dagzoo_medium_control",
+          "invocation_mix": [],
+          "source_families": []
+        },
+        "objective_metric": "final_log_loss_at_matched_regime_budget",
+        "scm_complexity_summary": {
+          "class_count_distribution": {
+            "count": 159984,
+            "max": 10,
+            "min": 2
+          },
+          "feature_count_distribution": {
+            "count": 159984,
+            "max": 20,
+            "min": 2
+          },
+          "row_count_distribution": {
+            "count": 159984,
+            "max": 1024,
+            "min": 128
+          }
+        },
+        "token_budget": 917716352,
+        "tokens_per_step": 367086.5408,
+        "tokens_seen": 917716352,
+        "unique_task_budget": 143976
+      },
+      "registered_at_utc": "2026-04-13T21:18:35Z",
+      "run_id": "sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2",
+      "runtime_summary": {
+        "non_train_overhead_seconds": 31.184280645102262,
+        "peak_vram_allocated": 12625763840,
+        "peak_vram_reserved": 17811111936,
+        "throughput_examples_per_second": 15.217746456341361,
+        "throughput_tokens_per_second": 90652.58583615387
+      },
+      "seed_set": [
+        1
+      ],
+      "surface_labels": {
+        "data": "tf_rd_010_dagzoo_medium_control",
+        "model": "tabfoundry_sandwich",
+        "preprocessing": "runtime_default",
+        "training": "prior_cosine_warmup"
+      },
+      "sweep": {
+        "delta_id": "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1",
+        "parent_sweep_id": "tf_rd_009_width_depth_medium_v1",
+        "queue_order": 1,
+        "run_kind": "primary",
+        "sweep_id": "tf_rd_009_large_validation_152x5_v1"
+      },
+      "tab_foundry_metrics": {
+        "best_avg_pinball_loss": null,
+        "best_bpc": 2.261271075101999,
+        "best_bpf": 2.261271130121671,
+        "best_brier_score": 0.5675577543042242,
+        "best_crps": null,
+        "best_log_loss": 0.9507625551301947,
+        "best_picp_90": null,
+        "best_roc_auc": 0.5967365187249479,
+        "best_step": 550.0,
+        "best_training_time": 2390.004813339561,
+        "final_avg_pinball_loss": null,
+        "final_bpc": 4.507453720386212,
+        "final_bpf": 4.5074539404649,
+        "final_brier_score": 0.42889399685905455,
+        "final_crps": null,
+        "final_log_loss": 0.7436636567836484,
+        "final_picp_90": null,
+        "final_roc_auc": 0.765094033761902,
+        "final_step": 2500.0,
+        "final_training_time": 10123.443733405322
+      },
+      "track": "system_delta_classification_medium_v1",
+      "training_diagnostics": {
+        "best_val_loss": null,
+        "best_val_step": null,
+        "final_grad_norm": 0.6383590245212006,
+        "final_val_loss": null,
+        "max_grad_norm": 54.525353839842566,
+        "mean_grad_norm": 0.783315318898648,
+        "post_warmup_train_loss_var": 0.07188199894420934,
+        "train_elapsed_seconds": 10123.443733405322,
+        "wall_elapsed_seconds": 10154.10568357259
+      },
+      "wandb": null
+    },
     "sd_tf_rd_009_ns_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1": {
       "artifacts": {
         "accounting_artifact_path": "outputs/staged_ladder/research/tf_rd_009_ns_medium_v1/delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1/sd_tf_rd_009_ns_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1/benchmark/model_accounting.json",

--- a/src/tab_foundry/bench/hardware_architecture_baselines_v1.json
+++ b/src/tab_foundry/bench/hardware_architecture_baselines_v1.json
@@ -1,5 +1,534 @@
 {
-  "baselines": {},
+  "baselines": {
+    "tf_rd_009_rtx8000_44gb_classification_medium_v1": {
+      "baseline_id": "tf_rd_009_rtx8000_44gb_classification_medium_v1",
+      "baseline_run_id": "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+      "benchmark_manifest_path": "outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v5/tf_rd_010_dagzoo_medium_control_curated_v5__192bd49fd87b/manifest.parquet",
+      "config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "constraint_model": {
+        "baseline_row": "96x2",
+        "effective_size_expression": "S(d, L) = L * d^2",
+        "evidence_run_ids": [
+          "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+          "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+          "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+          "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+          "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+          "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+          "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+        ],
+        "formulas": {
+          "benchmark_wall_seconds": {
+            "coefficients": {
+              "intercept": 1226.7976975049141,
+              "slope": 3.533970796892984e-05
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "benchmark_wall_seconds \u2248 1226.80 + 3.534e-05 * params",
+            "fit_kind": "linear"
+          },
+          "inference_mean_ms": {
+            "coefficients": {
+              "intercept": 15.2005108974451,
+              "slope": 1.1599956147180623e-06
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "inference_mean_ms \u2248 15.20 + 1.160e-06 * params",
+            "fit_kind": "linear"
+          },
+          "inference_p50_ms": {
+            "coefficients": {
+              "intercept": 15.207659851113638,
+              "slope": 1.1499748758041767e-06
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "inference_p50_ms \u2248 15.21 + 1.150e-06 * params",
+            "fit_kind": "linear"
+          },
+          "inference_p95_ms": {
+            "coefficients": {
+              "intercept": 15.215905188791128,
+              "slope": 1.1969575833418802e-06
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "inference_p95_ms \u2248 15.22 + 1.197e-06 * params",
+            "fit_kind": "linear"
+          },
+          "parameter_count": {
+            "coefficients": {
+              "d_squared_coefficient": 77.94284675392532,
+              "intercept": 18638.803760831244,
+              "layered_d_squared_coefficient": 47.93396570367903
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "P_local(d, L) \u2248 18638.80 + 77.94 * d^2 + 47.93 * L * d^2",
+            "fit_kind": "affine_depth_aware_least_squares"
+          },
+          "reserved_vram_gb": {
+            "coefficients": {
+              "intercept": 8.693003510381923,
+              "slope": 9.271353357607912e-07
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "reserved_vram_gb \u2248 8.69 + 9.271e-07 * params",
+            "fit_kind": "linear"
+          },
+          "train_wall_seconds": {
+            "coefficients": {
+              "intercept": 8298.449704577351,
+              "slope": 0.0002275449406958385
+            },
+            "evidence_run_ids": [
+              "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+            ],
+            "expression": "train_wall_seconds \u2248 8298.45 + 2.275e-04 * params",
+            "fit_kind": "linear"
+          }
+        },
+        "rows": [
+          {
+            "d_icl": 60,
+            "effective_size": 7200,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 35.9453125,
+              "train_wall_seconds_delta_vs_baseline": -62.34638564661145
+            },
+            "observed": {
+              "benchmark_wall_seconds": null,
+              "delta_ref": "delta_tf_rd_024_followup_cls_sandwich_heads1_v1",
+              "health": "warn",
+              "inference_mean_ms": null,
+              "inference_p50_ms": null,
+              "inference_p95_ms": null,
+              "reserved_vram_gb": 8.0546875,
+              "run_id": "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+              "total_params": 646970,
+              "train_wall_seconds": 8486.116041064262
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1249.569107098172,
+              "inference_mean_ms": 15.947962893719417,
+              "inference_p50_ms": 15.948654908059655,
+              "inference_p95_ms": 15.9871739106492,
+              "reserved_vram_gb": 9.290410214974761,
+              "total_params": 644358,
+              "train_wall_seconds": 8445.070017626176
+            },
+            "row": "60x2",
+            "sandwich_layers": 2
+          },
+          {
+            "d_icl": 72,
+            "effective_size": 5184,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 35.25390625,
+              "train_wall_seconds_delta_vs_baseline": -443.2188965268433
+            },
+            "observed": {
+              "benchmark_wall_seconds": 1230.0427722297609,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1",
+              "health": null,
+              "inference_mean_ms": 10.643807053565979,
+              "inference_p50_ms": 10.62655821442604,
+              "inference_p95_ms": 10.730049759149551,
+              "reserved_vram_gb": 8.74609375,
+              "run_id": "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+              "total_params": 668342,
+              "train_wall_seconds": 8105.2435301840305
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1250.5171511100548,
+              "inference_mean_ms": 15.979081625580774,
+              "inference_p50_ms": 15.979504817622585,
+              "inference_p95_ms": 16.01928420625104,
+              "reserved_vram_gb": 9.315282098580754,
+              "total_params": 671184,
+              "train_wall_seconds": 8451.174273457904
+            },
+            "row": "72x1",
+            "sandwich_layers": 1
+          },
+          {
+            "d_icl": 96,
+            "effective_size": 18432,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 33.8203125,
+              "train_wall_seconds_delta_vs_baseline": 0.0
+            },
+            "observed": {
+              "benchmark_wall_seconds": null,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl96_v1",
+              "health": "ok",
+              "inference_mean_ms": null,
+              "inference_p50_ms": null,
+              "inference_p95_ms": null,
+              "reserved_vram_gb": 10.1796875,
+              "run_id": "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+              "total_params": 1618286,
+              "train_wall_seconds": 8548.462426710874
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1284.0649498480495,
+              "inference_mean_ms": 17.08025935613055,
+              "inference_p50_ms": 17.071169913473042,
+              "inference_p95_ms": 17.155549739038516,
+              "reserved_vram_gb": 10.195406792150145,
+              "total_params": 1620479,
+              "train_wall_seconds": 8667.181487807957
+            },
+            "row": "96x2",
+            "sandwich_layers": 2
+          },
+          {
+            "d_icl": 112,
+            "effective_size": 37632,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 32.34765625,
+              "train_wall_seconds_delta_vs_baseline": 587.307597130537
+            },
+            "observed": {
+              "benchmark_wall_seconds": 1335.4799956046045,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1",
+              "health": "ok",
+              "inference_mean_ms": 20.392194762825966,
+              "inference_p50_ms": 20.363252609968185,
+              "inference_p95_ms": 20.558096654713154,
+              "reserved_vram_gb": 11.65234375,
+              "run_id": "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+              "total_params": 2800318,
+              "train_wall_seconds": 9135.77002384141
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1325.7561198922642,
+              "inference_mean_ms": 18.448736267888645,
+              "inference_p50_ms": 18.427825099641474,
+              "inference_p95_ms": 18.567631643809552,
+              "reserved_vram_gb": 11.28917239347279,
+              "total_params": 2800205,
+              "train_wall_seconds": 8935.6221558404
+            },
+            "row": "112x3",
+            "sandwich_layers": 3
+          },
+          {
+            "d_icl": 128,
+            "effective_size": 65536,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 29.4453125,
+              "train_wall_seconds_delta_vs_baseline": 1045.7216613180935
+            },
+            "observed": {
+              "benchmark_wall_seconds": 1390.6139281578362,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1",
+              "health": "warn",
+              "inference_mean_ms": 23.906192183494568,
+              "inference_p50_ms": 23.904958739876747,
+              "inference_p95_ms": 24.000087194144726,
+              "reserved_vram_gb": 14.5546875,
+              "run_id": "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+              "total_params": 4439694,
+              "train_wall_seconds": 9594.184088028967
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1383.601917719382,
+              "inference_mean_ms": 20.347474986055715,
+              "inference_p50_ms": 20.310161372213905,
+              "inference_p95_ms": 20.526871557011553,
+              "reserved_vram_gb": 12.806753784862536,
+              "total_params": 4437055,
+              "train_wall_seconds": 9308.079071660059
+            },
+            "row": "128x4",
+            "sandwich_layers": 4
+          },
+          {
+            "d_icl": 152,
+            "effective_size": 115520,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 27.412109375,
+              "train_wall_seconds_delta_vs_baseline": 1605.6432568617165
+            },
+            "observed": {
+              "benchmark_wall_seconds": 1508.5887077823281,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1",
+              "health": "ok",
+              "inference_mean_ms": 27.69562266767025,
+              "inference_p50_ms": 27.631128206849098,
+              "inference_p95_ms": 27.906852029263973,
+              "reserved_vram_gb": 16.587890625,
+              "run_id": "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+              "total_params": 7357894,
+              "train_wall_seconds": 10154.10568357259
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1486.783520063763,
+              "inference_mean_ms": 23.734322617742276,
+              "inference_p50_ms": 23.66775137962359,
+              "inference_p95_ms": 24.021637317273516,
+              "reserved_vram_gb": 15.513717566736448,
+              "total_params": 7356762,
+              "train_wall_seconds": 9972.443689698091
+            },
+            "row": "152x5",
+            "sandwich_layers": 5
+          },
+          {
+            "d_icl": 176,
+            "effective_size": 185856,
+            "headroom": {
+              "benchmark_wall_seconds_delta_vs_baseline": null,
+              "hardware_vram_ceiling_gb": 44.0,
+              "inference_mean_ms_delta_vs_baseline": null,
+              "inference_p50_ms_delta_vs_baseline": null,
+              "inference_p95_ms_delta_vs_baseline": null,
+              "reserved_vram_gb_to_ceiling": 26.15625,
+              "train_wall_seconds_delta_vs_baseline": 2086.4480181373656
+            },
+            "observed": {
+              "benchmark_wall_seconds": 1609.532487116754,
+              "delta_ref": "delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1",
+              "health": "ok",
+              "inference_mean_ms": 24.228274822235107,
+              "inference_p50_ms": 24.10932071506977,
+              "inference_p95_ms": 24.731409549713135,
+              "reserved_vram_gb": 17.84375,
+              "run_id": "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1",
+              "total_params": 11340350,
+              "train_wall_seconds": 10634.91044484824
+            },
+            "predicted": {
+              "benchmark_wall_seconds": 1627.6140056842924,
+              "inference_mean_ms": 28.356962563778485,
+              "inference_p50_ms": 28.25045818504755,
+              "inference_p95_ms": 28.791572537944127,
+              "reserved_vram_gb": 19.208397774222576,
+              "total_params": 11341812,
+              "train_wall_seconds": 10879.221542159783
+            },
+            "row": "176x6",
+            "sandwich_layers": 6
+          }
+        ]
+      },
+      "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+      "decision": "keep",
+      "evidence_run_ids": [
+        "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+        "sd_tf_rd_009_width_depth_medium_v1_01_delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1_v1",
+        "sd_tf_rd_009_width_transfer_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl96_v1_v1",
+        "sd_tf_rd_009_width_depth_medium_v1_02_delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1_v1",
+        "sd_tf_rd_009_width_depth_medium_v1_03_delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1_v1",
+        "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+        "sd_tf_rd_009_width_depth_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1_v1"
+      ],
+      "formal_anchor_run_id": "sd_tf_rd_009_anchor_replay_heads1_medium_v1_01_delta_tf_rd_024_followup_cls_sandwich_heads1_v1_v2",
+      "gpu_class": "rtx8000",
+      "hardware_profile_id": "rtx8000_44gb",
+      "objective_metric": "final_log_loss_at_matched_regime_budget",
+      "preferred_architecture": {
+        "arch": "tabfoundry_sandwich",
+        "architecture": {
+          "feature_type_encoding": "film",
+          "ff_expansion": 2,
+          "floating_likelihood": "single_gaussian",
+          "heads": 1,
+          "initial_input_token_count": "R_times_C_plus_K_times_(R_plus_C)",
+          "initial_input_tokens": "full_cell_plus_row_col_summary_stream",
+          "integer_likelihood": "hybrid_mixture",
+          "label_injection": "fused_into_row_summaries_and_feature_cells",
+          "latent_core": "stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages",
+          "latents": 24,
+          "layer_semantics": "stage0_hybrid_then_summary_repeated_stages",
+          "layers": 5,
+          "position_encoding": "shared_fourier_row_col",
+          "pre_column_attention_layers": 1,
+          "pre_column_inducing_tokens": 16,
+          "pre_perceiver_cell_mixer": "row_feature_self_attention_then_column_row_isab",
+          "pre_row_attention_layers": 1,
+          "readout": "latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool",
+          "repeated_input_token_count": "K_times_(R_plus_C)",
+          "repeated_input_tokens": "row_col_summary_stream",
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "self_attention_per_cross": 4,
+          "summary_builder": "summary_query_attention",
+          "summary_tokens_per_axis": 3
+        },
+        "build_spec": {
+          "arch": "tabfoundry_sandwich",
+          "d_col": 128,
+          "d_icl": 152,
+          "feature_group_size": 1,
+          "feature_type_conditioning": "film",
+          "floating_likelihood": "single_gaussian",
+          "head_hidden_dim": 96,
+          "input_normalization": "train_zscore_clip",
+          "integer_likelihood": "hybrid_mixture",
+          "many_class_base": 10,
+          "many_class_train_mode": "path_nll",
+          "max_mixed_radix_digits": 64,
+          "norm_type": "layernorm",
+          "pre_encoder_clip": null,
+          "sandwich_activation": "gelu",
+          "sandwich_block_norm": "layernorm",
+          "sandwich_ff_expansion": 2,
+          "sandwich_heads": 1,
+          "sandwich_latents": 24,
+          "sandwich_layers": 5,
+          "sandwich_pre_column_attention_layers": 1,
+          "sandwich_pre_column_inducing_tokens": 16,
+          "sandwich_pre_row_attention_layers": 1,
+          "sandwich_self_attention_per_cross": 4,
+          "sandwich_summary_tokens_per_axis": 3,
+          "task": "classification"
+        },
+        "d_icl": 152,
+        "head_hidden_dim": 96,
+        "sandwich_heads": 1,
+        "sandwich_layers": 5,
+        "tficl_n_heads": 8,
+        "tficl_n_layers": 12
+      },
+      "preferred_benchmark_timing": {
+        "attempted_checkpoint_count": 100,
+        "failed_checkpoint_count": 0,
+        "host_fingerprint": "ab1abe79e533|linux|x86_64",
+        "max_checkpoint_elapsed_seconds": 15.588431265205145,
+        "mean_checkpoint_elapsed_seconds": 15.081290940344333,
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "successful_checkpoint_count": 100,
+        "wall_elapsed_seconds": 1508.5887077823281
+      },
+      "preferred_delta_ref": "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1",
+      "preferred_inference_timing": {
+        "device_type": "cuda",
+        "fixture_id": "classification_medium_reference_v1",
+        "gpu_class": "rtx8000",
+        "hardware_profile_id": "rtx8000_44gb",
+        "max_ms": 27.96143665909767,
+        "mean_ms": 27.69562266767025,
+        "measured_iterations": 10,
+        "n_features": 10,
+        "n_test": 40,
+        "n_train": 160,
+        "num_classes": 10,
+        "p50_ms": 27.631128206849098,
+        "p95_ms": 27.906852029263973,
+        "raw_device_name": "Quadro RTX 8000",
+        "requested_device": "cuda",
+        "resolved_device": "cuda",
+        "total_measured_seconds": 0.2769562266767025,
+        "vram_class_gb": 44,
+        "warmup_iterations": 3
+      },
+      "preferred_run_id": "sd_tf_rd_009_width_depth_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1",
+      "preferred_runtime_summary": {
+        "non_train_overhead_seconds": 31.184280645102262,
+        "peak_vram_allocated": 12625763840,
+        "peak_vram_reserved": 17811111936,
+        "throughput_examples_per_second": 15.217746456341361,
+        "throughput_tokens_per_second": 90652.58583615387
+      },
+      "rationale": "RTX 8000 medium classification baseline freezes on 152x5 after the corrected TF-RD-009 large validation consumed latest.pt at step 2500 and beat the TF-RD-010 large anchor.",
+      "runtime_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+      "selection_rule": "best_loss_healthy_only",
+      "surface_labels": {
+        "data": "tf_rd_010_dagzoo_medium_control",
+        "model": "tabfoundry_sandwich",
+        "preprocessing": "runtime_default",
+        "training": "prior_cosine_warmup"
+      },
+      "surface_role": "classification_scaling_law",
+      "sweep_id": "tf_rd_009_width_depth_medium_v1",
+      "track": "system_delta_classification_medium_v1",
+      "vram_class_gb": 44
+    }
+  },
   "schema": "tab-foundry-hardware-architecture-baselines-v1",
   "version": 1
 }

--- a/src/tab_foundry/bench/openml_benchmark/artifacts.py
+++ b/src/tab_foundry/bench/openml_benchmark/artifacts.py
@@ -12,6 +12,7 @@ import torch
 
 from tab_foundry.bench.artifacts import (
     checkpoint_snapshots_from_history,
+    load_history,
     resolve_train_elapsed_seconds,
 )
 from tab_foundry.device import resolve_device
@@ -80,31 +81,97 @@ def resolve_tab_foundry_best_checkpoint(run_dir: Path) -> Path:
     raise RuntimeError(f"missing best checkpoint under {resolved_run_dir}; checked {expected}")
 
 
+def _resolve_telemetry_checkpoint_path(*, checkpoint_path: str, checkpoint_dir: Path) -> Path | None:
+    recorded_path = Path(str(checkpoint_path)).expanduser()
+    if recorded_path.exists():
+        return recorded_path.resolve()
+    candidate = checkpoint_dir / recorded_path.name
+    if candidate.exists():
+        return candidate.resolve()
+    return None
+
+
+def _history_step_elapsed_seconds(history_path: Path) -> dict[int, float]:
+    return {
+        int(record["step"]): resolve_train_elapsed_seconds(
+            record,
+            context=f"history step={record['step']}",
+        )
+        for record in load_history(history_path)
+    }
+
+
 def collect_checkpoint_snapshots(run_dir: Path) -> list[dict[str, Any]]:
     """Resolve step checkpoints and their elapsed training times."""
 
     resolved_run_dir = run_dir.expanduser().resolve()
+    history_path, checkpoint_dir = resolve_tab_foundry_run_artifact_paths(resolved_run_dir)
     telemetry_path = resolved_run_dir / "telemetry.json"
     if telemetry_path.exists():
         payload = json.loads(telemetry_path.read_text(encoding="utf-8"))
         snapshots = payload.get("checkpoint_snapshots")
         if isinstance(snapshots, list) and snapshots:
-            return sorted(
-                [
+            resolved_snapshots: list[dict[str, Any]] = []
+            elapsed_seconds_by_step: dict[int, float] = {}
+            for snapshot in snapshots:
+                step = int(snapshot["step"])
+                elapsed_seconds = resolve_train_elapsed_seconds(
+                    snapshot,
+                    context=f"telemetry checkpoint step={snapshot['step']}",
+                )
+                elapsed_seconds_by_step[step] = elapsed_seconds
+                resolved_checkpoint_path = _resolve_telemetry_checkpoint_path(
+                    checkpoint_path=str(snapshot["path"]),
+                    checkpoint_dir=checkpoint_dir,
+                )
+                if resolved_checkpoint_path is None:
+                    continue
+                resolved_snapshots.append(
                     {
-                        "step": int(snapshot["step"]),
-                        "path": str(Path(str(snapshot["path"])).expanduser().resolve()),
-                        "elapsed_seconds": resolve_train_elapsed_seconds(
-                            snapshot,
-                            context=f"telemetry checkpoint step={snapshot['step']}",
-                        ),
+                        "step": step,
+                        "path": str(resolved_checkpoint_path),
+                        "elapsed_seconds": elapsed_seconds,
                     }
-                    for snapshot in snapshots
-                ],
-                key=lambda snapshot: int(snapshot["step"]),
-            )
+                )
 
-    history_path, checkpoint_dir = resolve_tab_foundry_run_artifact_paths(resolved_run_dir)
+            latest_checkpoint_path = resolve_latest_checkpoint_path(resolved_run_dir)
+            if latest_checkpoint_path is not None:
+                resolved_latest_checkpoint_path = latest_checkpoint_path.expanduser().resolve()
+                latest_checkpoint_step = _checkpoint_global_step(resolved_latest_checkpoint_path)
+                highest_retained_step = max(
+                    (int(snapshot["step"]) for snapshot in resolved_snapshots),
+                    default=0,
+                )
+                if (
+                    latest_checkpoint_step is not None
+                    and str(resolved_latest_checkpoint_path)
+                    not in {str(snapshot["path"]) for snapshot in resolved_snapshots}
+                    and int(latest_checkpoint_step) > int(highest_retained_step)
+                ):
+                    latest_elapsed_seconds = elapsed_seconds_by_step.get(int(latest_checkpoint_step))
+                    if latest_elapsed_seconds is None:
+                        latest_elapsed_seconds = _history_step_elapsed_seconds(history_path).get(
+                            int(latest_checkpoint_step)
+                        )
+                    if latest_elapsed_seconds is None:
+                        raise RuntimeError(
+                            "missing elapsed time for terminal latest checkpoint "
+                            f"step={latest_checkpoint_step}"
+                        )
+                    resolved_snapshots.append(
+                        {
+                            "step": int(latest_checkpoint_step),
+                            "path": str(resolved_latest_checkpoint_path),
+                            "elapsed_seconds": float(latest_elapsed_seconds),
+                        }
+                    )
+
+            if resolved_snapshots:
+                return sorted(
+                    resolved_snapshots,
+                    key=lambda snapshot: int(snapshot["step"]),
+                )
+
     snapshots = checkpoint_snapshots_from_history(history_path, checkpoint_dir)
     return [
         {

--- a/tests/benchmark/test_openml_benchmark_summary.py
+++ b/tests/benchmark/test_openml_benchmark_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tests.support.openml_benchmark_compare_cases import (
     test_build_comparison_summary_averages_external_scalar_metrics_across_seeds,
     test_collect_checkpoint_snapshots_falls_back_to_latest_checkpoint_when_no_step_snapshots,
+    test_collect_checkpoint_snapshots_filters_missing_telemetry_steps_and_appends_latest,
     test_build_comparison_summary_preserves_model_identity_metadata,
     test_build_comparison_summary_uses_log_loss_as_classification_best_step,
     test_collect_checkpoint_snapshots_prefers_train_elapsed_seconds,

--- a/tests/research/test_tf_rd_009_large_validation_152x5_v1.py
+++ b/tests/research/test_tf_rd_009_large_validation_152x5_v1.py
@@ -1,0 +1,1 @@
+from tests.support_research.tf_rd_009_large_validation_152x5_v1 import *  # noqa: F401,F403

--- a/tests/support/openml_benchmark_compare_cases.py
+++ b/tests/support/openml_benchmark_compare_cases.py
@@ -2488,6 +2488,97 @@ def test_collect_checkpoint_snapshots_falls_back_to_latest_checkpoint_when_no_st
     ]
 
 
+def test_collect_checkpoint_snapshots_filters_missing_telemetry_steps_and_appends_latest(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    checkpoint_dir = run_dir / "checkpoints"
+    checkpoint_dir.mkdir(parents=True)
+    (checkpoint_dir / "step_000025.pt").write_bytes(b"step25")
+    (checkpoint_dir / "step_000600.pt").write_bytes(b"step600")
+    torch.save({"model": {}, "config": {}, "global_step": 2500}, checkpoint_dir / "latest.pt")
+    history_path = run_dir / "train_history.jsonl"
+    history_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "step": 25,
+                        "stage": "stage1",
+                        "train_loss": 0.8,
+                        "lr": 1.0e-3,
+                        "elapsed_seconds": 5.0,
+                        "train_elapsed_seconds": 1.0,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "step": 600,
+                        "stage": "stage1",
+                        "train_loss": 0.5,
+                        "lr": 1.0e-3,
+                        "elapsed_seconds": 12.0,
+                        "train_elapsed_seconds": 8.0,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "step": 2500,
+                        "stage": "stage1",
+                        "train_loss": 0.4,
+                        "lr": 1.0e-3,
+                        "elapsed_seconds": 30.0,
+                        "train_elapsed_seconds": 25.0,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    telemetry_path = run_dir / "telemetry.json"
+    telemetry_path.write_text(
+        json.dumps(
+            {
+                "checkpoint_snapshots": [
+                    {
+                        "step": 25,
+                        "path": "/remote-retained-artifact/run/checkpoints/step_000025.pt",
+                        "elapsed_seconds": 5.0,
+                        "train_elapsed_seconds": 1.0,
+                    },
+                    {
+                        "step": 600,
+                        "path": "/remote-retained-artifact/run/checkpoints/step_000600.pt",
+                        "elapsed_seconds": 12.0,
+                        "train_elapsed_seconds": 8.0,
+                    },
+                    {
+                        "step": 2500,
+                        "path": "/remote-retained-artifact/run/checkpoints/step_002500.pt",
+                        "elapsed_seconds": 30.0,
+                        "train_elapsed_seconds": 25.0,
+                    },
+                ]
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    snapshots = benchmark_module.collect_checkpoint_snapshots(run_dir)
+
+    assert [int(snapshot["step"]) for snapshot in snapshots] == [25, 600, 2500]
+    assert [Path(str(snapshot["path"])).name for snapshot in snapshots] == [
+        "step_000025.pt",
+        "step_000600.pt",
+        "latest.pt",
+    ]
+    assert snapshots[-1]["elapsed_seconds"] == pytest.approx(25.0)
+
+
 def test_selected_checkpoint_snapshots_best_and_final_falls_back_to_latest_when_best_missing(
     tmp_path: Path,
 ) -> None:

--- a/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
+++ b/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
@@ -91,12 +91,22 @@ def test_tf_rd_009_large_validation_152x5_v1_tracks_the_reused_large_gate() -> N
     assert len(rows) == 1
     row = rows[0]
     assert row["delta_ref"] == EXPECTED_ROW
-    assert row["status"] == "ready"
-    assert row["run_id"] is None
-    assert row["decision"] is None
-    assert row["interpretation_status"] == "pending"
+    assert row["status"] == "completed"
+    assert (
+        row["run_id"]
+        == "sd_tf_rd_009_large_validation_152x5_v1_01_"
+        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
+    )
+    assert row["decision"] == "defer"
+    assert row["interpretation_status"] == "completed"
     assert row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
     assert row["benchmark_checkpoint_selection"] == "all"
+    benchmark_metrics = row["benchmark_metrics"]
+    assert benchmark_metrics["objective_metric"] == "final_log_loss_at_matched_regime_budget"
+    assert benchmark_metrics["final_log_loss"] == 0.9337034780913935
+    assert benchmark_metrics["delta_final_log_loss"] == 0.03626238194883136
+    assert benchmark_metrics["final_roc_auc"] == 0.6083568021504234
+    assert benchmark_metrics["delta_final_roc_auc"] == -0.02399371692269847
     assert row["model"]["d_icl"] == 152
     assert row["model"]["sandwich_layers"] == 5
     assert row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
@@ -111,6 +121,8 @@ def test_tf_rd_009_large_validation_152x5_v1_tracks_the_reused_large_gate() -> N
     assert any("training-surface fingerprint" in note for note in row["notes"])
     assert any("do not add the large validation row to the medium constraint model" in note for note in row["notes"])
     assert any("current local workstation does not expose the required GPU surface" in note for note in row["notes"])
+    assert any("Execution attempt" in note for note in row["notes"])
+    assert any("Canonical rerun registered" in note for note in row["notes"])
 
 
 def test_tf_rd_009_large_validation_152x5_v1_resolved_queue_captures_reuse_surface() -> None:
@@ -144,11 +156,17 @@ def test_tf_rd_009_large_validation_152x5_v1_resolved_queue_captures_reuse_surfa
     assert resolved["sweep_status"] == "draft"
 
     resolved_row = resolved["rows"][0]
-    assert resolved_row["status"] == "ready"
-    assert resolved_row["run_id"] is None
-    assert resolved_row["decision"] is None
+    assert resolved_row["status"] == "completed"
+    assert (
+        resolved_row["run_id"]
+        == "sd_tf_rd_009_large_validation_152x5_v1_01_"
+        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
+    )
+    assert resolved_row["decision"] == "defer"
     assert resolved_row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
     assert resolved_row["resolved_surface_fingerprint"] == TRAINING_SURFACE_FINGERPRINT
+    assert resolved_row["benchmark_metrics"]["final_log_loss"] == 0.9337034780913935
+    assert resolved_row["benchmark_metrics"]["delta_final_log_loss"] == 0.03626238194883136
     assert resolved_row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
 
     resolved_surface = resolved_row["resolved_surface"]

--- a/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
+++ b/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
@@ -19,6 +19,10 @@ TRAIN_RUN_ID = (
     "sd_tf_rd_009_width_depth_medium_v1_04_"
     "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
 )
+VALIDATION_RUN_ID = (
+    "sd_tf_rd_009_large_validation_152x5_v1_01_"
+    "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2"
+)
 EXPECTED_ROW = "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1"
 TRAINING_SURFACE_FINGERPRINT = "8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253"
 REUSE_TRAIN_ARTIFACT = {
@@ -92,21 +96,17 @@ def test_tf_rd_009_large_validation_152x5_v1_tracks_the_reused_large_gate() -> N
     row = rows[0]
     assert row["delta_ref"] == EXPECTED_ROW
     assert row["status"] == "completed"
-    assert (
-        row["run_id"]
-        == "sd_tf_rd_009_large_validation_152x5_v1_01_"
-        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
-    )
-    assert row["decision"] == "defer"
+    assert row["run_id"] == VALIDATION_RUN_ID
+    assert row["decision"] == "keep"
     assert row["interpretation_status"] == "completed"
     assert row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
     assert row["benchmark_checkpoint_selection"] == "all"
     benchmark_metrics = row["benchmark_metrics"]
     assert benchmark_metrics["objective_metric"] == "final_log_loss_at_matched_regime_budget"
-    assert benchmark_metrics["final_log_loss"] == 0.9337034780913935
-    assert benchmark_metrics["delta_final_log_loss"] == 0.03626238194883136
-    assert benchmark_metrics["final_roc_auc"] == 0.6083568021504234
-    assert benchmark_metrics["delta_final_roc_auc"] == -0.02399371692269847
+    assert benchmark_metrics["final_log_loss"] == 0.7436636567836484
+    assert benchmark_metrics["delta_final_log_loss"] == -0.15377743935891375
+    assert benchmark_metrics["final_roc_auc"] == 0.765094033761902
+    assert benchmark_metrics["delta_final_roc_auc"] == 0.1327435146887801
     assert row["model"]["d_icl"] == 152
     assert row["model"]["sandwich_layers"] == 5
     assert row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
@@ -116,12 +116,15 @@ def test_tf_rd_009_large_validation_152x5_v1_tracks_the_reused_large_gate() -> N
     assert "no extra seeds" in row["anchor_delta"]
     assert "0.8974410961" in " ".join(row["parameter_adequacy_plan"])
     assert "[363685, 363699, 363707]" in " ".join(row["parameter_adequacy_plan"])
-    assert "tf_rd_009_rtx8000_44gb_classification_medium_v1" in row["next_action"]
+    assert "frozen hardware baseline" in row["next_action"]
     assert any("do not retrain this row" in note for note in row["notes"])
     assert any("training-surface fingerprint" in note for note in row["notes"])
     assert any("do not add the large validation row to the medium constraint model" in note for note in row["notes"])
     assert any("current local workstation does not expose the required GPU surface" in note for note in row["notes"])
     assert any("Execution attempt" in note for note in row["notes"])
+    assert any("latest.pt" in note for note in row["notes"])
+    assert any("25/25" in note for note in row["notes"])
+    assert any("Hardware baseline `tf_rd_009_rtx8000_44gb_classification_medium_v1` is now frozen" in note for note in row["notes"])
     assert any("Canonical rerun registered" in note for note in row["notes"])
 
 
@@ -157,16 +160,12 @@ def test_tf_rd_009_large_validation_152x5_v1_resolved_queue_captures_reuse_surfa
 
     resolved_row = resolved["rows"][0]
     assert resolved_row["status"] == "completed"
-    assert (
-        resolved_row["run_id"]
-        == "sd_tf_rd_009_large_validation_152x5_v1_01_"
-        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
-    )
-    assert resolved_row["decision"] == "defer"
+    assert resolved_row["run_id"] == VALIDATION_RUN_ID
+    assert resolved_row["decision"] == "keep"
     assert resolved_row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
     assert resolved_row["resolved_surface_fingerprint"] == TRAINING_SURFACE_FINGERPRINT
-    assert resolved_row["benchmark_metrics"]["final_log_loss"] == 0.9337034780913935
-    assert resolved_row["benchmark_metrics"]["delta_final_log_loss"] == 0.03626238194883136
+    assert resolved_row["benchmark_metrics"]["final_log_loss"] == 0.7436636567836484
+    assert resolved_row["benchmark_metrics"]["delta_final_log_loss"] == -0.15377743935891375
     assert resolved_row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
 
     resolved_surface = resolved_row["resolved_surface"]
@@ -199,9 +198,12 @@ def test_tf_rd_009_large_validation_152x5_v1_matrix_records_the_single_candidate
     assert "openml_classification_large_v1" in matrix
     assert "`0.8974410961`" in matrix
     assert TRAIN_RUN_ID in matrix
+    assert VALIDATION_RUN_ID in matrix
     assert REUSE_TRAIN_ARTIFACT["run_dir"] in matrix
     assert TRAINING_SURFACE_FINGERPRINT in matrix
     assert "do not retrain this row" in matrix
     assert "tf_rd_009_rtx8000_44gb_classification_medium_v1" in matrix
+    assert "Decision: `keep`" in matrix
+    assert "latest.pt" in matrix
     assert "do not add the large validation row to the medium constraint model" in matrix
     assert "current local workstation does not expose the required GPU surface" in matrix

--- a/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
+++ b/tests/support_research/tf_rd_009_large_validation_152x5_v1.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+from tests.support_research.helpers import assert_training_surface_semantics
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEP_ID = "tf_rd_009_large_validation_152x5_v1"
+ANCHOR_RUN_ID = (
+    "sd_tf_rd_010_classification_evolution_large_v2_01_"
+    "delta_data_manifest_root_tf_rd_010_dagzoo_medium_control_v1"
+)
+TRAIN_RUN_ID = (
+    "sd_tf_rd_009_width_depth_medium_v1_04_"
+    "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1"
+)
+EXPECTED_ROW = "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1"
+TRAINING_SURFACE_FINGERPRINT = "8fbebcbeb4951b28d1a1f26e007b427e0686d9fc58fb5b281107dca7c0f69253"
+REUSE_TRAIN_ARTIFACT = {
+    "run_dir": (
+        "outputs/staged_ladder/research/tf_rd_009_width_depth_medium_v1/"
+        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1/"
+        "sd_tf_rd_009_width_depth_medium_v1_04_"
+        "delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v1/train"
+    ),
+    "training_surface_fingerprint": TRAINING_SURFACE_FINGERPRINT,
+}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tf_rd_009_large_validation_152x5_v1_is_registered() -> None:
+    index = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml")
+
+    assert index["schema"] == "tab-foundry-system-delta-sweep-index-v2"
+    sweeps = index["sweeps"]
+    assert isinstance(sweeps, dict)
+    assert sweeps[SWEEP_ID] == {
+        "parent_sweep_id": "tf_rd_009_width_depth_medium_v1",
+        "status": "draft",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "classification_lg",
+        "benchmark_manifest_path": "data/manifests/bench/openml_classification_large_v1/manifest.parquet",
+        "control_baseline_id": "cls_benchmark_linear_multiclass_large_v1",
+        "external_benchmarks": [],
+    }
+
+
+def test_tf_rd_009_large_validation_152x5_v1_tracks_the_reused_large_gate() -> None:
+    sweep_root = REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+
+    assert sweep["sweep_id"] == SWEEP_ID
+    assert sweep["parent_sweep_id"] == "tf_rd_009_width_depth_medium_v1"
+    assert sweep["status"] == "draft"
+    assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
+    assert sweep["benchmark_manifest_path"] == (
+        "data/manifests/bench/openml_classification_large_v1/manifest.parquet"
+    )
+    assert sweep["control_baseline_id"] == "cls_benchmark_linear_multiclass_large_v1"
+    assert_training_surface_semantics(
+        sweep,
+        training_experiment="cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+        surface_role="classification_scaling_law",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+
+    notes = sweep["anchor_surface"]["notes"]
+    assert isinstance(notes, list)
+    assert any("issue 257" in note for note in notes)
+    assert any("152x5" in note for note in notes)
+    assert any("[363685, 363699, 363707]" in note for note in notes)
+    assert any("0.8974410961" in note for note in notes)
+    assert any("do not retrain or add extra seeds" in note for note in notes)
+    assert any("tf_rd_009_rtx8000_44gb_classification_medium_v1" in note for note in notes)
+    assert any("issues 259 and 260" in note for note in notes)
+
+    rows = queue["rows"]
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["delta_ref"] == EXPECTED_ROW
+    assert row["status"] == "ready"
+    assert row["run_id"] is None
+    assert row["decision"] is None
+    assert row["interpretation_status"] == "pending"
+    assert row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
+    assert row["benchmark_checkpoint_selection"] == "all"
+    assert row["model"]["d_icl"] == 152
+    assert row["model"]["sandwich_layers"] == 5
+    assert row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
+    assert "benchmark-only validate" in row["rationale"].lower()
+    assert "large clean-control anchor" in row["rationale"]
+    assert "no retraining" in row["anchor_delta"]
+    assert "no extra seeds" in row["anchor_delta"]
+    assert "0.8974410961" in " ".join(row["parameter_adequacy_plan"])
+    assert "[363685, 363699, 363707]" in " ".join(row["parameter_adequacy_plan"])
+    assert "tf_rd_009_rtx8000_44gb_classification_medium_v1" in row["next_action"]
+    assert any("do not retrain this row" in note for note in row["notes"])
+    assert any("training-surface fingerprint" in note for note in row["notes"])
+    assert any("do not add the large validation row to the medium constraint model" in note for note in row["notes"])
+    assert any("current local workstation does not expose the required GPU surface" in note for note in row["notes"])
+
+
+def test_tf_rd_009_large_validation_152x5_v1_resolved_queue_captures_reuse_surface() -> None:
+    queue = load_system_delta_queue(
+        sweep_id=SWEEP_ID,
+        index_path=REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml",
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
+    )
+
+    assert_training_surface_semantics(
+        queue,
+        training_experiment="cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
+        surface_role="classification_scaling_law",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+
+    row = queue["rows"][0]
+    assert row["delta_id"] == EXPECTED_ROW
+    assert row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
+    runtime_overrides = row["training"]["overrides"]["runtime"]
+    assert runtime_overrides["mixed_precision"] == "bf16"
+    assert runtime_overrides["grad_accum_steps"] == 4
+    assert runtime_overrides["activation_checkpointing"] is True
+    assert runtime_overrides["max_steps"] == 2500
+
+    resolved = _load_yaml(REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "resolved_queue.yaml")
+    assert resolved["schema"] == "tab-foundry-system-delta-resolved-queue-v1"
+    assert resolved["sweep_id"] == SWEEP_ID
+    assert resolved["anchor_run_id"] == ANCHOR_RUN_ID
+    assert resolved["sweep_status"] == "draft"
+
+    resolved_row = resolved["rows"][0]
+    assert resolved_row["status"] == "ready"
+    assert resolved_row["run_id"] is None
+    assert resolved_row["decision"] is None
+    assert resolved_row["reuse_train_artifact"] == REUSE_TRAIN_ARTIFACT
+    assert resolved_row["resolved_surface_fingerprint"] == TRAINING_SURFACE_FINGERPRINT
+    assert resolved_row["data"]["corpus_ref"] == "tf_rd_010_dagzoo_medium_control_curated_v5"
+
+    resolved_surface = resolved_row["resolved_surface"]
+    training = resolved_surface["training"]
+    runtime = resolved_surface["runtime"]
+    assert training["task_batch_size"] == 16
+    assert training["optimizer_min_lr"] == 1.0e-5
+    assert training["schedule_stages"][0]["steps"] == 2500
+    assert training["schedule_stages"][0]["lr_max"] == 1.0e-3
+    assert training["schedule_stages"][0]["lr_schedule"] == "linear"
+    assert training["schedule_stages"][0]["warmup_ratio"] == 0.10
+    assert runtime["mixed_precision"] == "bf16"
+    assert runtime["grad_accum_steps"] == 4
+    assert runtime["activation_checkpointing"] is True
+    assert runtime["compile_model"] is True
+    assert runtime["compile_dynamic"] is True
+    assert runtime["compile_backend"] == "eager"
+    assert runtime["max_steps"] == 2500
+
+
+def test_tf_rd_009_large_validation_152x5_v1_matrix_records_the_single_candidate_gate() -> None:
+    matrix = (
+        REPO_ROOT / "reference" / "system_delta_sweeps" / SWEEP_ID / "matrix.md"
+    ).read_text(encoding="utf-8")
+
+    assert "# System Delta Matrix" in matrix
+    assert SWEEP_ID in matrix
+    assert "Sweep status: `draft`" in matrix
+    assert f"Anchor run id: `{ANCHOR_RUN_ID}`" in matrix
+    assert "openml_classification_large_v1" in matrix
+    assert "`0.8974410961`" in matrix
+    assert TRAIN_RUN_ID in matrix
+    assert REUSE_TRAIN_ARTIFACT["run_dir"] in matrix
+    assert TRAINING_SURFACE_FINGERPRINT in matrix
+    assert "do not retrain this row" in matrix
+    assert "tf_rd_009_rtx8000_44gb_classification_medium_v1" in matrix
+    assert "do not add the large validation row to the medium constraint model" in matrix
+    assert "current local workstation does not expose the required GPU surface" in matrix


### PR DESCRIPTION
## What changed

- fixed telemetry-backed benchmark checkpoint selection so `benchmark_checkpoint_selection=all` drops missing retained `step_*.pt` entries and appends terminal `latest.pt` when it is newer than the highest retained numbered snapshot
- reran `tf_rd_009_large_validation_152x5_v1` with the corrected artifact-selection path and recorded the corrected v2 benchmark result
- froze `tf_rd_009_rtx8000_44gb_classification_medium_v1` from the medium evidence rows after the corrected large-rung gate passed
- updated the TF-RD-009 sweep artifacts, benchmark registry, roadmap evidence, roadmap, and changelog to reflect the corrected result

## Why it changed

The original large-rung validation reused a retained artifact tree whose telemetry still listed checkpoints through step 2500, but the durable artifact only kept numbered `step_*.pt` files through step 600 plus `latest.pt` and `best.pt`. The old `all` path trusted the telemetry entries directly, so the benchmark stopped at the last retained numbered snapshot instead of evaluating the terminal retained checkpoint.

## Impact

The corrected rerun now evaluates the retained artifact set faithfully and changes the TF-RD-009 #257 decision from defer to keep:

- run: `sd_tf_rd_009_large_validation_152x5_v1_01_delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1_v2`
- final log loss at matched regime budget: `0.7436636568`
- anchor: `0.8974410961`
- delta final log loss: `-0.1537774394`
- terminal checkpoint: `latest.pt` at step `2500`
- successful checkpoints: `25/25`

That gate now freezes `tf_rd_009_rtx8000_44gb_classification_medium_v1` with preferred `152x5`, formal anchor `60x2`, and baseline `96x2`.

## Validation

- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_009_large_validation_152x5_v1 --order 1 --json`
- `.venv/bin/tab-foundry research sweep summarize --sweep-id tf_rd_009_large_validation_152x5_v1 --json`
- `.venv/bin/pytest tests/test_portability_audit.py tests/benchmark/test_openml_benchmark_summary.py tests/research/test_tf_rd_009_large_validation_152x5_v1.py tests/benchmark/test_hardware_architecture_freeze.py -q`
- `./scripts/dev verify paths src/tab_foundry/bench/openml_benchmark/artifacts.py tests/support/openml_benchmark_compare_cases.py tests/benchmark/test_openml_benchmark_summary.py tests/support_research/tf_rd_009_large_validation_152x5_v1.py src/tab_foundry/bench/benchmark_run_registry_v1.json src/tab_foundry/bench/hardware_architecture_baselines_v1.json reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/queue.yaml reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/resolved_queue.yaml reference/system_delta_sweeps/tf_rd_009_large_validation_152x5_v1/matrix.md docs/development/roadmap.md reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md CHANGELOG.md`

Closes #257.
