### PR TITLE
Add benchmark-safe CUDA graph benchmarking lane for training runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-04-14
+
+### Changed
+
+- User-facing note: the training runtime now exposes
+  `runtime.cuda_graph_capture_mode` and `runtime.cuda_graph_max_families`,
+  records those settings in training-surface and runtime telemetry artifacts,
+  and the signature-family compile dispatcher now reports CUDA-graph capture,
+  reuse, cap, and fallback statistics alongside the existing compile-family
+  cache summary.
+- User-facing note: tab-foundry now ships an explicit benchmark-safe TF-RD-009
+  heads-1 replay comparison lane:
+  `cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1`,
+  `cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1`, and
+  `cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1`.
+  These configs keep the heads-1 + compile-eager-dynamic replay surface fixed,
+  preserve checkpoint cadence, enable per-step timing, and isolate packed
+  attention plus the optional signature-family CUDA-graph training lane from
+  the broader cached-loader speedrun surfaces.
+- User-facing note: the TF-RD-022 runtime and sandwich benchmark profiles now
+  default `module_grad_norm_every=25` so benchmark and scaling telemetry retain
+  gradient diagnostics without spending per-step wall time on module-norm
+  logging.
+
 ## [0.17.1] - 2026-04-14
 
 ### Changed

--- a/configs/experiment/cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_legacy_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_legacy_v1.yaml
@@ -46,6 +46,7 @@ runtime:
   checkpoint_every: 25
   val_batches: 0
   max_steps: 2500
+  module_grad_norm_every: 25
 optimizer:
   name: schedulefree_adamw
   require_requested: true

--- a/configs/experiment/cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1.yaml
@@ -48,6 +48,7 @@ runtime:
   compile_shape_dispatch_mode: signature_family
   compile_shape_dispatch_max_families: 16
   signature_family_run_length: 4
+  module_grad_norm_every: 25
 schedule:
   stages:
     - name: prior_dump

--- a/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_sandwich_speedrun_baseline_v1
+  - _self_
+
+runtime:
+  output_dir: outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1
+
+logging:
+  run_name: cls-benchmark-sandwich-tf-rd-009-heads1-benchmark-safe-baseline-v1

--- a/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1.yaml
@@ -1,0 +1,15 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1
+  - _self_
+
+runtime:
+  compile_shape_dispatch_mode: signature_family
+  compile_shape_dispatch_max_families: 16
+  cuda_graph_capture_mode: signature_family
+  cuda_graph_max_families: 16
+  output_dir: outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1
+
+logging:
+  run_name: cls-benchmark-sandwich-tf-rd-009-heads1-benchmark-safe-packed-cuda-graph-v1

--- a/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1.yaml
+++ b/configs/experiment/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+
+defaults:
+  - cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1
+  - _self_
+
+model:
+  sandwich_packed_attention: true
+
+runtime:
+  output_dir: outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1
+
+logging:
+  run_name: cls-benchmark-sandwich-tf-rd-009-heads1-benchmark-safe-packed-v1

--- a/configs/runtime/smoke.yaml
+++ b/configs/runtime/smoke.yaml
@@ -17,6 +17,8 @@ compile_backend: inductor
 compile_mode: max-autotune-no-cudagraphs
 compile_shape_dispatch_mode: "off"
 compile_shape_dispatch_max_families: 16
+cuda_graph_capture_mode: "off"
+cuda_graph_max_families: 16
 trace_activations: false
 signature_family_run_length: 1
 module_grad_norm_every: 1

--- a/configs/runtime/tf_rd_022_policy.yaml
+++ b/configs/runtime/tf_rd_022_policy.yaml
@@ -17,9 +17,11 @@ compile_backend: inductor
 compile_mode: max-autotune-no-cudagraphs
 compile_shape_dispatch_mode: "off"
 compile_shape_dispatch_max_families: 16
+cuda_graph_capture_mode: "off"
+cuda_graph_max_families: 16
 trace_activations: false
 signature_family_run_length: 1
-module_grad_norm_every: 1
+module_grad_norm_every: 25
 profile_step_timing: false
 activation_checkpointing: true
 eval_every: 25

--- a/configs/runtime/workstation.yaml
+++ b/configs/runtime/workstation.yaml
@@ -17,6 +17,8 @@ compile_backend: inductor
 compile_mode: max-autotune-no-cudagraphs
 compile_shape_dispatch_mode: "off"
 compile_shape_dispatch_max_families: 16
+cuda_graph_capture_mode: "off"
+cuda_graph_max_families: 16
 trace_activations: false
 signature_family_run_length: 1
 module_grad_norm_every: 1

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -157,6 +157,24 @@ use `cls_benchmark_sandwich_speedrun_cached_packed_v1` as the
 benchmark surface. Regression remains intentionally removed in the current repo
 state.
 
+For the benchmark-safe TF-RD-009 heads-1 replay lane, use the explicit
+comparison configs instead of the cached speedrun surfaces:
+
+```bash
+tab-foundry train run \
+  experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1
+tab-foundry train run \
+  experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1
+tab-foundry train run \
+  experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1
+```
+
+Those three configs keep the heads-1 + compile-eager-dynamic replay surface
+fixed and differ only in packed attention and the optional signature-family
+CUDA-graph lane. They also keep `profile_step_timing=true` and
+`module_grad_norm_every=25` so the dominant `forward_backward` bucket can be
+compared directly from per-step telemetry without changing checkpoint density.
+
 The prior-trained staged control surface is still available:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.17.1"
+version = "0.17.2"
 description = "Tabular foundation model that generates its own training data via dagzoo, trains on it, and predicts on new tasks"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tab_foundry/research/sweep/queue_updates.py
+++ b/src/tab_foundry/research/sweep/queue_updates.py
@@ -132,6 +132,7 @@ def runtime_and_regime_metrics(
             "loader_effective_num_workers",
             "loader_effective_prefetch_factor",
             "compile_shape_dispatch_max_families",
+            "cuda_graph_max_families",
         ):
             integer_value = optional_int(runtime_summary, key)
             if integer_value is not None:
@@ -139,6 +140,7 @@ def runtime_and_regime_metrics(
         for key in (
             "loader_task_batch_cache_mode",
             "compile_shape_dispatch_mode",
+            "cuda_graph_capture_mode",
         ):
             text_value = optional_text(runtime_summary, key)
             if text_value is not None:
@@ -148,6 +150,8 @@ def runtime_and_regime_metrics(
             for source_key, metric_key in (
                 ("compiled_family_count", "compile_dispatch_compiled_family_count"),
                 ("family_switch_count", "compile_dispatch_family_switch_count"),
+                ("cuda_graph_captured_family_count", "cuda_graph_captured_family_count"),
+                ("cuda_graph_capture_failure_count", "cuda_graph_capture_failure_count"),
             ):
                 integer_value = optional_int(
                     cast(Mapping[str, Any], compile_shape_dispatch),

--- a/src/tab_foundry/research/sweep/summarize.py
+++ b/src/tab_foundry/research/sweep/summarize.py
@@ -86,11 +86,19 @@ def _runtime_summary_excerpt(metrics: Mapping[str, Any]) -> dict[str, Any] | Non
         "compile_shape_dispatch_max_families": _optional_int(
             metrics.get("compile_shape_dispatch_max_families")
         ),
+        "cuda_graph_capture_mode": _optional_text(metrics.get("cuda_graph_capture_mode")),
+        "cuda_graph_max_families": _optional_int(metrics.get("cuda_graph_max_families")),
         "compile_dispatch_compiled_family_count": _optional_int(
             metrics.get("compile_dispatch_compiled_family_count")
         ),
         "compile_dispatch_family_switch_count": _optional_int(
             metrics.get("compile_dispatch_family_switch_count")
+        ),
+        "cuda_graph_captured_family_count": _optional_int(
+            metrics.get("cuda_graph_captured_family_count")
+        ),
+        "cuda_graph_capture_failure_count": _optional_int(
+            metrics.get("cuda_graph_capture_failure_count")
         ),
     }
     return payload if any(value is not None for value in payload.values()) else None
@@ -171,6 +179,12 @@ def summarize_sweep(
                 ),
                 "compile_dispatch_family_switch_count": _optional_int(
                     metrics.get("compile_dispatch_family_switch_count")
+                ),
+                "cuda_graph_captured_family_count": _optional_int(
+                    metrics.get("cuda_graph_captured_family_count")
+                ),
+                "cuda_graph_capture_failure_count": _optional_int(
+                    metrics.get("cuda_graph_capture_failure_count")
                 ),
                 "one_family_step_count": _optional_int(metrics.get("one_family_step_count")),
                 "mixed_family_step_count": _optional_int(metrics.get("mixed_family_step_count")),

--- a/src/tab_foundry/training/compile_dispatch.py
+++ b/src/tab_foundry/training/compile_dispatch.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
+from typing import Any, Callable
 
 import torch
 
-from tab_foundry.task_batching import task_batch_signature
+from tab_foundry.feature_types import metadata_has_explicit_feature_types
+from tab_foundry.task_batching import task_batch_signature, task_batch_signature_text
 from tab_foundry.types import TaskBatch
 
-from .runtime import CompilePolicy
+from .runtime import CompilePolicy, CudaGraphCapturePolicy
+from .trainer_metrics import _compute_loss_and_metrics
 
 SignatureFamily = tuple[int, int, int]
+CudaGraphSignature = tuple[int, int, int, int, int | None, bool]
+_SINGLE_TASK_TENSOR_DIMENSIONS = 2
+_CUDA_GRAPH_WARMUP_STEPS = 3
 
 
 def _signature_family(batch: TaskBatch) -> SignatureFamily:
@@ -23,6 +30,80 @@ def _signature_family_text(family: SignatureFamily) -> str:
     return f"{int(family[0])}x{int(family[1])}x{int(family[2])}"
 
 
+def _task_batch_task_count(batch: TaskBatch) -> int:
+    if batch.x_train.ndim == _SINGLE_TASK_TENSOR_DIMENSIONS:
+        return 1
+    return int(batch.x_train.shape[0])
+
+
+def _cuda_graph_signature(batch: TaskBatch) -> CudaGraphSignature:
+    n_train, n_test, n_features, num_classes = task_batch_signature(batch)
+    return (
+        _task_batch_task_count(batch),
+        int(n_train),
+        int(n_test),
+        int(n_features),
+        None if num_classes is None else int(num_classes),
+        batch.feature_type_ids is not None,
+    )
+
+
+def _cuda_graph_signature_text(signature: CudaGraphSignature) -> str:
+    task_count, n_train, n_test, n_features, num_classes, has_feature_type_ids = signature
+    base_text = task_batch_signature_text((n_train, n_test, n_features, num_classes))
+    feature_type_text = "feature_type_ids" if has_feature_type_ids else "no_feature_type_ids"
+    return f"tasks{int(task_count)}:{base_text}:{feature_type_text}"
+
+
+def _cuda_graph_fallback_reason(exc: Exception) -> str:
+    message = str(exc).strip()
+    return message if message else type(exc).__name__
+
+
+def _clone_static_task_batch(batch: TaskBatch) -> TaskBatch:
+    return TaskBatch(
+        x_train=torch.empty_like(batch.x_train),
+        y_train=torch.empty_like(batch.y_train),
+        x_test=torch.empty_like(batch.x_test),
+        y_test=torch.empty_like(batch.y_test),
+        metadata=dict(batch.metadata),
+        num_classes=batch.num_classes,
+        feature_type_ids=(
+            None if batch.feature_type_ids is None else torch.empty_like(batch.feature_type_ids)
+        ),
+    )
+
+
+def _copy_task_batch_tensors(target: TaskBatch, source: TaskBatch) -> None:
+    target.x_train.copy_(source.x_train)
+    target.y_train.copy_(source.y_train)
+    target.x_test.copy_(source.x_test)
+    target.y_test.copy_(source.y_test)
+    if target.feature_type_ids is not None and source.feature_type_ids is not None:
+        target.feature_type_ids.copy_(source.feature_type_ids)
+
+
+@dataclass(slots=True)
+class _CudaGraphReplay:
+    static_batch: TaskBatch
+    captured_output: Any
+    graph: torch.cuda.CUDAGraph
+    task: str
+    autocast_context_factory: Callable[[], AbstractContextManager[object]]
+
+    def replay(self, batch: TaskBatch) -> tuple[torch.Tensor, dict[str, float]]:
+        _copy_task_batch_tensors(self.static_batch, batch)
+        self.graph.replay()
+        with torch.no_grad():
+            with self.autocast_context_factory():
+                loss, metrics = _compute_loss_and_metrics(
+                    self.captured_output,
+                    self.static_batch,
+                    task=self.task,
+                )
+        return loss.detach(), metrics
+
+
 class SignatureFamilyCompileDispatcher:
     """Compile one callable per shape family and dispatch lazily at runtime."""
 
@@ -32,6 +113,12 @@ class SignatureFamilyCompileDispatcher:
         *,
         compile_policy: CompilePolicy,
         max_families: int,
+        task: str,
+        grad_accum_steps: int,
+        cuda_graph_policy: CudaGraphCapturePolicy | None = None,
+        cuda_graph_autocast_context_factory: (
+            Callable[[], AbstractContextManager[object]] | None
+        ) = None,
     ) -> None:
         if not compile_policy.enabled:
             raise ValueError("SignatureFamilyCompileDispatcher requires compile_policy.enabled=True")
@@ -42,6 +129,8 @@ class SignatureFamilyCompileDispatcher:
         self._compile_fn = compile_fn
         self._compile_kwargs = compile_policy.torch_compile_kwargs()
         self._max_families = int(max_families)
+        self._task = str(task)
+        self._grad_accum_steps = int(grad_accum_steps)
         self._compiled_by_family: dict[SignatureFamily, Any] = {}
         self._family_hits = 0
         self._family_misses = 0
@@ -49,8 +138,28 @@ class SignatureFamilyCompileDispatcher:
         self._uncached_family_calls = 0
         self._last_family: SignatureFamily | None = None
         self._family_call_counts: dict[str, int] = {}
+        self._cuda_graph_policy = (
+            cuda_graph_policy
+            if cuda_graph_policy is not None
+            else CudaGraphCapturePolicy(enabled=False, mode="off", max_families=0)
+        )
+        self._cuda_graph_autocast_context_factory = (
+            cuda_graph_autocast_context_factory or nullcontext
+        )
+        self._cuda_graphs_by_signature: dict[CudaGraphSignature, _CudaGraphReplay] = {}
+        self._cuda_graph_hits = 0
+        self._cuda_graph_misses = 0
+        self._cuda_graph_fallback_calls = 0
+        self._cuda_graph_uncached_family_calls = 0
+        self._cuda_graph_capture_failures = 0
+        self._cuda_graph_call_counts: dict[str, int] = {}
+        self._cuda_graph_failure_messages: dict[str, str] = {}
 
     def __call__(self, batch: TaskBatch):
+        resolved_callable, _compiled = self._resolve_callable(batch)
+        return resolved_callable(batch)
+
+    def _resolve_callable(self, batch: TaskBatch) -> tuple[Callable[[TaskBatch], Any], bool]:
         family = _signature_family(batch)
         family_text = _signature_family_text(family)
         if self._last_family is not None and family != self._last_family:
@@ -61,20 +170,163 @@ class SignatureFamilyCompileDispatcher:
         compiled = self._compiled_by_family.get(family)
         if compiled is not None:
             self._family_hits += 1
-            return compiled(batch)
+            return compiled, True
 
         self._family_misses += 1
         if len(self._compiled_by_family) >= self._max_families:
             self._uncached_family_calls += 1
-            return self._model(batch)
+            return self._model, False
 
         compiled = self._compile_fn(self._model, **self._compile_kwargs)
         self._compiled_by_family[family] = compiled
-        return compiled(batch)
+        return compiled, True
+
+    def _weighted_microstep_loss(self, loss: torch.Tensor, *, actual_task_count: int) -> torch.Tensor:
+        resolved_task_count = int(actual_task_count)
+        if resolved_task_count <= 0:
+            raise RuntimeError(
+                "task-batch accumulation requires a positive actual_task_count, "
+                f"got {resolved_task_count}"
+            )
+        return loss * float(resolved_task_count) * float(self._grad_accum_steps)
+
+    def _fallback_training_step(
+        self,
+        *,
+        batch: TaskBatch,
+        task: str,
+        actual_task_count: int,
+        accelerator: Any,
+        resolved_callable: Callable[[TaskBatch], Any],
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        with self._cuda_graph_autocast_context_factory():
+            output = resolved_callable(batch)
+            loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
+        accelerator.backward(
+            self._weighted_microstep_loss(loss, actual_task_count=actual_task_count)
+        )
+        return loss, metrics
+
+    def _build_cuda_graph_replay(
+        self,
+        *,
+        compiled_callable: Callable[[TaskBatch], Any],
+        batch: TaskBatch,
+        task: str,
+        actual_task_count: int,
+    ) -> _CudaGraphReplay:
+        if batch.x_train.device.type != "cuda":
+            raise RuntimeError("CUDA graph capture requires CUDA device tensors")
+        if actual_task_count != _task_batch_task_count(batch):
+            raise RuntimeError(
+                "CUDA graph capture requires a stable task-count signature, "
+                f"expected {actual_task_count}, got {_task_batch_task_count(batch)}"
+            )
+        if batch.feature_type_ids is None and metadata_has_explicit_feature_types(batch.metadata):
+            raise RuntimeError(
+                "CUDA graph capture requires batch.feature_type_ids when explicit feature types are present"
+            )
+
+        static_batch = _clone_static_task_batch(batch)
+        _copy_task_batch_tensors(static_batch, batch)
+        self._model.zero_grad(set_to_none=True)
+        stream = torch.cuda.Stream()
+        current_stream = torch.cuda.current_stream()
+        stream.wait_stream(current_stream)
+        with torch.cuda.stream(stream):
+            for _ in range(_CUDA_GRAPH_WARMUP_STEPS):
+                self._model.zero_grad(set_to_none=True)
+                with self._cuda_graph_autocast_context_factory():
+                    output = compiled_callable(static_batch)
+                    loss, _metrics = _compute_loss_and_metrics(output, static_batch, task=task)
+                self._weighted_microstep_loss(loss, actual_task_count=actual_task_count).backward()
+        current_stream.wait_stream(stream)
+        self._model.zero_grad(set_to_none=True)
+
+        graph = torch.cuda.CUDAGraph()
+        captured_output = None
+        with torch.cuda.graph(graph):
+            with self._cuda_graph_autocast_context_factory():
+                captured_output = compiled_callable(static_batch)
+                loss, _metrics = _compute_loss_and_metrics(captured_output, static_batch, task=task)
+            self._weighted_microstep_loss(loss, actual_task_count=actual_task_count).backward()
+        self._model.zero_grad(set_to_none=True)
+        return _CudaGraphReplay(
+            static_batch=static_batch,
+            captured_output=captured_output,
+            graph=graph,
+            task=task,
+            autocast_context_factory=self._cuda_graph_autocast_context_factory,
+        )
+
+    def training_step(
+        self,
+        *,
+        batch: TaskBatch,
+        task: str,
+        actual_task_count: int,
+        accelerator: Any,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        resolved_callable, compiled = self._resolve_callable(batch)
+        if not self._cuda_graph_policy.enabled or not compiled:
+            return self._fallback_training_step(
+                batch=batch,
+                task=task,
+                actual_task_count=actual_task_count,
+                accelerator=accelerator,
+                resolved_callable=resolved_callable,
+            )
+
+        graph_signature = _cuda_graph_signature(batch)
+        graph_signature_text = _cuda_graph_signature_text(graph_signature)
+        self._cuda_graph_call_counts[graph_signature_text] = (
+            self._cuda_graph_call_counts.get(graph_signature_text, 0) + 1
+        )
+
+        graph_replay = self._cuda_graphs_by_signature.get(graph_signature)
+        if graph_replay is not None:
+            self._cuda_graph_hits += 1
+            return graph_replay.replay(batch)
+
+        self._cuda_graph_misses += 1
+        if len(self._cuda_graphs_by_signature) >= self._cuda_graph_policy.max_families:
+            self._cuda_graph_uncached_family_calls += 1
+            self._cuda_graph_fallback_calls += 1
+            return self._fallback_training_step(
+                batch=batch,
+                task=task,
+                actual_task_count=actual_task_count,
+                accelerator=accelerator,
+                resolved_callable=resolved_callable,
+            )
+
+        try:
+            graph_replay = self._build_cuda_graph_replay(
+                compiled_callable=resolved_callable,
+                batch=batch,
+                task=task,
+                actual_task_count=actual_task_count,
+            )
+        except Exception as exc:
+            self._cuda_graph_capture_failures += 1
+            self._cuda_graph_fallback_calls += 1
+            self._cuda_graph_failure_messages[graph_signature_text] = _cuda_graph_fallback_reason(
+                exc
+            )
+            return self._fallback_training_step(
+                batch=batch,
+                task=task,
+                actual_task_count=actual_task_count,
+                accelerator=accelerator,
+                resolved_callable=resolved_callable,
+            )
+
+        self._cuda_graphs_by_signature[graph_signature] = graph_replay
+        return graph_replay.replay(batch)
 
     def summary(self) -> dict[str, Any]:
         compiled_families = sorted(_signature_family_text(family) for family in self._compiled_by_family)
-        return {
+        summary: dict[str, Any] = {
             "family_cache_hits": int(self._family_hits),
             "family_cache_misses": int(self._family_misses),
             "compiled_family_count": int(len(self._compiled_by_family)),
@@ -82,4 +334,30 @@ class SignatureFamilyCompileDispatcher:
             "uncached_family_call_count": int(self._uncached_family_calls),
             "compiled_families": compiled_families,
             "family_call_counts": dict(sorted(self._family_call_counts.items())),
+            "cuda_graph_capture_mode": str(self._cuda_graph_policy.mode),
+            "cuda_graph_max_families": int(self._cuda_graph_policy.max_families),
         }
+        if not self._cuda_graph_policy.enabled:
+            return summary
+        summary.update(
+            {
+                "cuda_graph_cache_hits": int(self._cuda_graph_hits),
+                "cuda_graph_cache_misses": int(self._cuda_graph_misses),
+                "cuda_graph_captured_family_count": int(len(self._cuda_graphs_by_signature)),
+                "cuda_graph_fallback_call_count": int(self._cuda_graph_fallback_calls),
+                "cuda_graph_uncached_family_call_count": int(
+                    self._cuda_graph_uncached_family_calls
+                ),
+                "cuda_graph_capture_failure_count": int(self._cuda_graph_capture_failures),
+                "cuda_graph_captured_families": sorted(
+                    _cuda_graph_signature_text(signature)
+                    for signature in self._cuda_graphs_by_signature
+                ),
+                "cuda_graph_call_counts": dict(sorted(self._cuda_graph_call_counts.items())),
+            }
+        )
+        if self._cuda_graph_failure_messages:
+            summary["cuda_graph_failure_messages"] = dict(
+                sorted(self._cuda_graph_failure_messages.items())
+            )
+        return summary

--- a/src/tab_foundry/training/instability.py
+++ b/src/tab_foundry/training/instability.py
@@ -1282,6 +1282,8 @@ def build_runtime_summary(
     loader_task_batch_cache_mode: str | None = None,
     compile_shape_dispatch_mode: str | None = None,
     compile_shape_dispatch_max_families: int | None = None,
+    cuda_graph_capture_mode: str | None = None,
+    cuda_graph_max_families: int | None = None,
     compile_shape_dispatch_summary: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build runtime telemetry derived from loop counters."""
@@ -1326,6 +1328,10 @@ def build_runtime_summary(
         summary["compile_shape_dispatch_max_families"] = int(
             compile_shape_dispatch_max_families
         )
+    if cuda_graph_capture_mode is not None:
+        summary["cuda_graph_capture_mode"] = str(cuda_graph_capture_mode)
+    if cuda_graph_max_families is not None:
+        summary["cuda_graph_max_families"] = int(cuda_graph_max_families)
     if isinstance(compile_shape_dispatch_summary, Mapping):
         summary["compile_shape_dispatch"] = dict(compile_shape_dispatch_summary)
     return summary

--- a/src/tab_foundry/training/runtime.py
+++ b/src/tab_foundry/training/runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass
+from typing import Any
 
 from accelerate import Accelerator
 from accelerate.utils import DataLoaderConfiguration
@@ -18,6 +20,8 @@ from .trainer_runtime_config import (
     _resolve_compile_model,
     _resolve_compile_shape_dispatch_max_families,
     _resolve_compile_shape_dispatch_mode,
+    _resolve_cuda_graph_capture_mode,
+    _resolve_cuda_graph_max_families,
     _resolve_trace_activations,
 )
 
@@ -42,6 +46,15 @@ class CompilePolicy:
         if self.dynamic:
             kwargs["dynamic"] = True
         return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class CudaGraphCapturePolicy:
+    """Resolved CUDA graph policy layered on top of compile dispatch."""
+
+    enabled: bool
+    mode: str
+    max_families: int
 
 
 def resolve_training_device_name(runtime_cfg: DictConfig) -> str:
@@ -134,6 +147,74 @@ def resolve_compile_shape_dispatch_policy(runtime_cfg: DictConfig) -> tuple[str,
     return (
         _resolve_compile_shape_dispatch_mode(runtime_cfg),
         _resolve_compile_shape_dispatch_max_families(runtime_cfg),
+    )
+
+
+def resolve_cuda_graph_capture_policy(runtime_cfg: DictConfig) -> CudaGraphCapturePolicy:
+    """Resolve and validate CUDA-graph capture controls."""
+
+    mode = _resolve_cuda_graph_capture_mode(runtime_cfg)
+    max_families = _resolve_cuda_graph_max_families(runtime_cfg)
+    if mode == "off":
+        return CudaGraphCapturePolicy(enabled=False, mode=mode, max_families=max_families)
+    compile_policy = resolve_compile_policy(runtime_cfg)
+    if not compile_policy.enabled:
+        raise ValueError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires runtime.compile_model=true"
+        )
+    if compile_policy.backend != "eager":
+        raise ValueError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires "
+            "runtime.compile_backend='eager'"
+        )
+    if not compile_policy.dynamic:
+        raise ValueError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires "
+            "runtime.compile_dynamic=true"
+        )
+    compile_shape_dispatch_mode = _resolve_compile_shape_dispatch_mode(runtime_cfg)
+    if compile_shape_dispatch_mode != "signature_family":
+        raise ValueError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires "
+            "runtime.compile_shape_dispatch_mode='signature_family'"
+        )
+    if _resolve_trace_activations(runtime_cfg):
+        raise ValueError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires "
+            "runtime.trace_activations=false"
+        )
+    cuda_graph_cls = getattr(torch.cuda, "CUDAGraph", None)
+    graph_context = getattr(torch.cuda, "graph", None)
+    if cuda_graph_cls is None or not callable(graph_context):
+        raise RuntimeError(
+            "runtime.cuda_graph_capture_mode='signature_family' requires torch.cuda graph support"
+        )
+    return CudaGraphCapturePolicy(enabled=True, mode=mode, max_families=max_families)
+
+
+def build_cuda_graph_autocast_context_factory(
+    runtime_cfg: DictConfig,
+) -> Any:
+    """Return an autocast context factory that is safe to use during CUDA graph capture."""
+
+    mixed_precision = resolve_mixed_precision(runtime_cfg)
+    if mixed_precision == "no":
+        return nullcontext
+    if mixed_precision == "bf16":
+        return lambda: torch.amp.autocast(
+            device_type="cuda",
+            dtype=torch.bfloat16,
+            cache_enabled=False,
+        )
+    if mixed_precision == "fp16":
+        return lambda: torch.amp.autocast(
+            device_type="cuda",
+            dtype=torch.float16,
+            cache_enabled=False,
+        )
+    raise ValueError(
+        "runtime.cuda_graph_capture_mode='signature_family' supports mixed_precision "
+        f"'no', 'bf16', or 'fp16', got {mixed_precision!r}"
     )
 
 

--- a/src/tab_foundry/training/surface.py
+++ b/src/tab_foundry/training/surface.py
@@ -30,6 +30,8 @@ from .trainer_runtime_config import (
     _resolve_compile_model,
     _resolve_compile_shape_dispatch_max_families,
     _resolve_compile_shape_dispatch_mode,
+    _resolve_cuda_graph_capture_mode,
+    _resolve_cuda_graph_max_families,
     _resolve_loader_task_batch_cache_mode,
     _resolve_signature_family_optimizer_step_block_length,
     _resolve_signature_family_run_length,
@@ -71,6 +73,10 @@ def _normalize_runtime_surface_cfg(raw_runtime_cfg: Mapping[str, Any]) -> dict[s
     )
     runtime_cfg["compile_shape_dispatch_max_families"] = (
         _resolve_compile_shape_dispatch_max_families(resolved_runtime_cfg)
+    )
+    runtime_cfg["cuda_graph_capture_mode"] = _resolve_cuda_graph_capture_mode(resolved_runtime_cfg)
+    runtime_cfg["cuda_graph_max_families"] = _resolve_cuda_graph_max_families(
+        resolved_runtime_cfg
     )
     runtime_cfg["trace_activations"] = _resolve_trace_activations(resolved_runtime_cfg)
     runtime_cfg["activation_checkpointing"] = _resolve_activation_checkpointing(

--- a/src/tab_foundry/training/trainer.py
+++ b/src/tab_foundry/training/trainer.py
@@ -27,7 +27,9 @@ from .loss_surface import configure_model_loss_surface, resolve_training_loss_su
 from .optimizer import build_optimizer
 from .runtime import (
     build_accelerator_from_runtime,
+    build_cuda_graph_autocast_context_factory,
     resolve_compile_policy,
+    resolve_cuda_graph_capture_policy,
     resolve_compile_shape_dispatch_policy,
 )
 from .schedule import build_stage_configs
@@ -115,6 +117,7 @@ def train(cfg: DictConfig, *, profiler: Any | None = None) -> TrainResult:
     compile_shape_dispatch_mode, compile_shape_dispatch_max_families = (
         resolve_compile_shape_dispatch_policy(cfg.runtime)
     )
+    cuda_graph_capture_policy = resolve_cuda_graph_capture_policy(cfg.runtime)
     if loader_task_batch_cache_mode == "bounded_streaming" and max_steps is None:
         raise ValueError(
             "runtime.loader_task_batch_cache_mode='bounded_streaming' requires runtime.max_steps"
@@ -237,6 +240,14 @@ def train(cfg: DictConfig, *, profiler: Any | None = None) -> TrainResult:
             model,
             compile_policy=compile_policy,
             max_families=compile_shape_dispatch_max_families,
+            task=task,
+            grad_accum_steps=grad_accum_steps,
+            cuda_graph_policy=cuda_graph_capture_policy,
+            cuda_graph_autocast_context_factory=(
+                build_cuda_graph_autocast_context_factory(cfg.runtime)
+                if cuda_graph_capture_policy.enabled
+                else None
+            ),
         )
     trace_activations = _resolve_trace_activations(cfg.runtime)
     enable_activation_trace = getattr(base_model, "enable_activation_trace", None)
@@ -439,6 +450,8 @@ def train(cfg: DictConfig, *, profiler: Any | None = None) -> TrainResult:
             loader_task_batch_cache_mode=loader_task_batch_cache_mode,
             compile_shape_dispatch_mode=compile_shape_dispatch_mode,
             compile_shape_dispatch_max_families=compile_shape_dispatch_max_families,
+            cuda_graph_capture_mode=cuda_graph_capture_policy.mode,
+            cuda_graph_max_families=cuda_graph_capture_policy.max_families,
             compile_shape_dispatch_summary=(
                 None if compile_dispatcher is None else compile_dispatcher.summary()
             ),
@@ -470,6 +483,8 @@ def train(cfg: DictConfig, *, profiler: Any | None = None) -> TrainResult:
             loader_task_batch_cache_mode=loader_task_batch_cache_mode,
             compile_shape_dispatch_mode=compile_shape_dispatch_mode,
             compile_shape_dispatch_max_families=compile_shape_dispatch_max_families,
+            cuda_graph_capture_mode=cuda_graph_capture_policy.mode,
+            cuda_graph_max_families=cuda_graph_capture_policy.max_families,
             compile_shape_dispatch_summary=(
                 None if compile_dispatcher is None else compile_dispatcher.summary()
             ),

--- a/src/tab_foundry/training/trainer_finalize.py
+++ b/src/tab_foundry/training/trainer_finalize.py
@@ -49,6 +49,8 @@ def finalize_training_run(
     loader_task_batch_cache_mode: str,
     compile_shape_dispatch_mode: str,
     compile_shape_dispatch_max_families: int,
+    cuda_graph_capture_mode: str,
+    cuda_graph_max_families: int,
     compile_shape_dispatch_summary: Mapping[str, Any] | None,
     success: bool,
     error: Exception | None = None,
@@ -77,6 +79,8 @@ def finalize_training_run(
             loader_task_batch_cache_mode=loader_task_batch_cache_mode,
             compile_shape_dispatch_mode=compile_shape_dispatch_mode,
             compile_shape_dispatch_max_families=compile_shape_dispatch_max_families,
+            cuda_graph_capture_mode=cuda_graph_capture_mode,
+            cuda_graph_max_families=cuda_graph_max_families,
             compile_shape_dispatch_summary=compile_shape_dispatch_summary,
         )
         hardware_summary = build_hardware_summary(accelerator.device)

--- a/src/tab_foundry/training/trainer_loop.py
+++ b/src/tab_foundry/training/trainer_loop.py
@@ -523,16 +523,25 @@ def run_training_loop(
                 _accumulate_step_timing(step_timing_sums, "h2d_transfer", timing_start)
                 timing_start = time.perf_counter()
                 with accelerator.accumulate(model):
-                    with accelerator.autocast():
-                        output = model(batch) if model_forward is None else model_forward(batch)
-                        loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
-                    accelerator.backward(
-                        _task_weighted_microstep_loss(
-                            loss,
+                    training_step = getattr(model_forward, "training_step", None)
+                    if callable(training_step):
+                        loss, metrics = training_step(
+                            batch=batch,
+                            task=task,
                             actual_task_count=actual_task_count,
                             accelerator=accelerator,
                         )
-                    )
+                    else:
+                        with accelerator.autocast():
+                            output = model(batch) if model_forward is None else model_forward(batch)
+                            loss, metrics = _compute_loss_and_metrics(output, batch, task=task)
+                        accelerator.backward(
+                            _task_weighted_microstep_loss(
+                                loss,
+                                actual_task_count=actual_task_count,
+                                accelerator=accelerator,
+                            )
+                        )
                 _accumulate_step_timing(step_timing_sums, "forward_backward", timing_start)
                 train_loss_sum += float(loss.detach().item()) * float(actual_task_count)
                 train_loss_count += actual_task_count

--- a/src/tab_foundry/training/trainer_runtime_config.py
+++ b/src/tab_foundry/training/trainer_runtime_config.py
@@ -12,6 +12,7 @@ _VALID_COMPILE_MODES = frozenset(
     {"max-autotune-no-cudagraphs", "default", "reduce-overhead"}
 )
 _VALID_COMPILE_SHAPE_DISPATCH_MODES = frozenset({"off", "signature_family"})
+_VALID_CUDA_GRAPH_CAPTURE_MODES = frozenset({"off", "signature_family"})
 _AUTO_SENTINEL = "auto"
 _VALID_TASK_BATCH_CACHE_MODES = frozenset({"off", "eager_full", "bounded_streaming"})
 _RESERVED_CPU_LARGE_HOST_THRESHOLD = 8
@@ -129,6 +130,26 @@ def _resolve_compile_shape_dispatch_max_families(runtime_cfg: DictConfig) -> int
             "runtime.compile_shape_dispatch_max_families must be >= 1, "
             f"got {value}"
         )
+    return value
+
+
+def _resolve_cuda_graph_capture_mode(runtime_cfg: DictConfig) -> str:
+    raw_value = getattr(runtime_cfg, "cuda_graph_capture_mode", "off")
+    if isinstance(raw_value, bool):
+        return "signature_family" if raw_value else "off"
+    return _coerce_runtime_choice(
+        raw_value=raw_value,
+        name="runtime.cuda_graph_capture_mode",
+        default="off",
+        valid_values=_VALID_CUDA_GRAPH_CAPTURE_MODES,
+    )
+
+
+def _resolve_cuda_graph_max_families(runtime_cfg: DictConfig) -> int:
+    raw_value = getattr(runtime_cfg, "cuda_graph_max_families", 16)
+    value = int(raw_value)
+    if value <= 0:
+        raise ValueError(f"runtime.cuda_graph_max_families must be >= 1, got {value}")
     return value
 
 

--- a/tests/config/test_experiment_resolution.py
+++ b/tests/config/test_experiment_resolution.py
@@ -129,6 +129,8 @@ def test_runtime_smoke_override_resolution() -> None:
     assert str(cfg.runtime.compile_mode) == "max-autotune-no-cudagraphs"
     assert str(cfg.runtime.compile_shape_dispatch_mode) == "off"
     assert int(cfg.runtime.compile_shape_dispatch_max_families) == 16
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert int(cfg.runtime.cuda_graph_max_families) == 16
     assert int(cfg.runtime.signature_family_run_length) == 1
     assert bool(cfg.runtime.activation_checkpointing) is False
 
@@ -148,6 +150,8 @@ def test_runtime_workstation_resolution() -> None:
     assert str(cfg.runtime.compile_mode) == "max-autotune-no-cudagraphs"
     assert str(cfg.runtime.compile_shape_dispatch_mode) == "off"
     assert int(cfg.runtime.compile_shape_dispatch_max_families) == 16
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert int(cfg.runtime.cuda_graph_max_families) == 16
     assert int(cfg.runtime.signature_family_run_length) == 1
 
 
@@ -167,7 +171,10 @@ def test_runtime_tf_rd_022_policy_resolution() -> None:
     assert str(cfg.runtime.compile_mode) == "max-autotune-no-cudagraphs"
     assert str(cfg.runtime.compile_shape_dispatch_mode) == "off"
     assert int(cfg.runtime.compile_shape_dispatch_max_families) == 16
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert int(cfg.runtime.cuda_graph_max_families) == 16
     assert int(cfg.runtime.signature_family_run_length) == 1
+    assert int(cfg.runtime.module_grad_norm_every) == 25
     assert bool(cfg.runtime.trace_activations) is False
     assert bool(cfg.runtime.activation_checkpointing) is True
     assert int(cfg.runtime.max_steps) == 2500
@@ -560,7 +567,10 @@ def test_cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1_res
     assert str(cfg.runtime.compile_backend) == "eager"
     assert str(cfg.runtime.compile_shape_dispatch_mode) == "signature_family"
     assert int(cfg.runtime.compile_shape_dispatch_max_families) == 16
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert int(cfg.runtime.cuda_graph_max_families) == 16
     assert int(cfg.runtime.signature_family_run_length) == 4
+    assert int(cfg.runtime.module_grad_norm_every) == 25
     assert int(cfg.runtime.eval_every) == 25
     assert int(cfg.runtime.checkpoint_every) == 25
     assert int(cfg.runtime.max_steps) == 2500
@@ -575,6 +585,53 @@ def test_cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1_res
     assert (
         str(cfg.logging.history_jsonl_path)
         == "outputs/cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1/train_history.jsonl"
+    )
+
+
+def test_cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1")
+
+    assert int(cfg.model.d_icl) == 96
+    assert int(cfg.model.sandwich_heads) == 1
+    assert bool(cfg.model.sandwich_packed_attention) is False
+    assert bool(cfg.runtime.compile_model) is True
+    assert bool(cfg.runtime.compile_dynamic) is True
+    assert str(cfg.runtime.compile_backend) == "eager"
+    assert str(cfg.runtime.compile_shape_dispatch_mode) == "off"
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert bool(cfg.runtime.profile_step_timing) is True
+    assert int(cfg.runtime.module_grad_norm_every) == 25
+    assert str(cfg.runtime.output_dir) == (
+        "outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_baseline_v1"
+    )
+
+
+def test_cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_resolution() -> None:
+    cfg = _compose("experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1")
+
+    assert bool(cfg.model.sandwich_packed_attention) is True
+    assert str(cfg.runtime.compile_shape_dispatch_mode) == "off"
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "off"
+    assert bool(cfg.runtime.profile_step_timing) is True
+    assert int(cfg.runtime.module_grad_norm_every) == 25
+    assert str(cfg.runtime.output_dir) == (
+        "outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_v1"
+    )
+
+
+def test_cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_resolution() -> None:
+    cfg = _compose(
+        "experiment=cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1"
+    )
+
+    assert bool(cfg.model.sandwich_packed_attention) is True
+    assert str(cfg.runtime.compile_shape_dispatch_mode) == "signature_family"
+    assert int(cfg.runtime.compile_shape_dispatch_max_families) == 16
+    assert str(cfg.runtime.cuda_graph_capture_mode) == "signature_family"
+    assert int(cfg.runtime.cuda_graph_max_families) == 16
+    assert bool(cfg.runtime.profile_step_timing) is True
+    assert str(cfg.runtime.output_dir) == (
+        "outputs/cls_benchmark_sandwich_tf_rd_009_heads1_benchmark_safe_packed_cuda_graph_v1"
     )
 
 

--- a/tests/research/test_sweep_summarize.py
+++ b/tests/research/test_sweep_summarize.py
@@ -127,8 +127,12 @@ def test_summarize_sweep_preserves_runtime_and_regime_budget_fields(monkeypatch)
                     "loader_task_batch_cache_mode": "bounded_streaming",
                     "compile_shape_dispatch_mode": "signature_family",
                     "compile_shape_dispatch_max_families": 16,
+                    "cuda_graph_capture_mode": "signature_family",
+                    "cuda_graph_max_families": 8,
                     "compile_dispatch_compiled_family_count": 16,
                     "compile_dispatch_family_switch_count": 63,
+                    "cuda_graph_captured_family_count": 8,
+                    "cuda_graph_capture_failure_count": 1,
                     "one_family_step_count": 112,
                     "mixed_family_step_count": 16,
                     "consecutive_repeated_family_step_count": 48,
@@ -166,6 +170,8 @@ def test_summarize_sweep_preserves_runtime_and_regime_budget_fields(monkeypatch)
     assert row["loader_setup_seconds"] == 8.7
     assert row["compile_dispatch_compiled_family_count"] == 16
     assert row["compile_dispatch_family_switch_count"] == 63
+    assert row["cuda_graph_captured_family_count"] == 8
+    assert row["cuda_graph_capture_failure_count"] == 1
     assert row["one_family_step_count"] == 112
     assert row["mixed_family_step_count"] == 16
     assert row["consecutive_repeated_family_step_count"] == 48
@@ -185,8 +191,12 @@ def test_summarize_sweep_preserves_runtime_and_regime_budget_fields(monkeypatch)
         "loader_task_batch_cache_mode": "bounded_streaming",
         "compile_shape_dispatch_mode": "signature_family",
         "compile_shape_dispatch_max_families": 16,
+        "cuda_graph_capture_mode": "signature_family",
+        "cuda_graph_max_families": 8,
         "compile_dispatch_compiled_family_count": 16,
         "compile_dispatch_family_switch_count": 63,
+        "cuda_graph_captured_family_count": 8,
+        "cuda_graph_capture_failure_count": 1,
     }
     assert row["regime_budget"] == {
         "tokens_per_step": 512.0,

--- a/tests/runtime/test_runtime_policy.py
+++ b/tests/runtime/test_runtime_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 from omegaconf import OmegaConf
 import pytest
 
@@ -9,6 +11,7 @@ from tab_foundry.training.runtime import (
     resolve_compile_model,
     resolve_compile_shape_dispatch_policy,
     resolve_cpu_mode,
+    resolve_cuda_graph_capture_policy,
     resolve_grad_accum_steps,
     resolve_mixed_precision,
 )
@@ -213,3 +216,69 @@ def test_runtime_compile_shape_dispatch_resolution() -> None:
     )
 
     assert resolve_compile_shape_dispatch_policy(cfg) == ("signature_family", 12)
+
+
+def test_runtime_cuda_graph_capture_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(training_runtime_module, "resolve_device", lambda _device: "cuda")
+    monkeypatch.setattr(training_runtime_module.torch, "compile", lambda model, **_kwargs: model)
+    monkeypatch.setattr(training_runtime_module.torch.cuda, "CUDAGraph", object, raising=False)
+    monkeypatch.setattr(
+        training_runtime_module.torch.cuda,
+        "graph",
+        lambda *_args, **_kwargs: nullcontext(),
+        raising=False,
+    )
+    cfg = OmegaConf.create(
+        {
+            "device": "cuda",
+            "mixed_precision": "bf16",
+            "compile_model": True,
+            "compile_backend": "eager",
+            "compile_dynamic": True,
+            "compile_shape_dispatch_mode": "signature_family",
+            "compile_shape_dispatch_max_families": 12,
+            "cuda_graph_capture_mode": "signature_family",
+            "cuda_graph_max_families": 5,
+            "trace_activations": False,
+        }
+    )
+
+    policy = resolve_cuda_graph_capture_policy(cfg)
+
+    assert policy.enabled is True
+    assert policy.mode == "signature_family"
+    assert policy.max_families == 5
+
+
+def test_runtime_cuda_graph_capture_requires_signature_family_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(training_runtime_module, "resolve_device", lambda _device: "cuda")
+    monkeypatch.setattr(training_runtime_module.torch, "compile", lambda model, **_kwargs: model)
+    monkeypatch.setattr(training_runtime_module.torch.cuda, "CUDAGraph", object, raising=False)
+    monkeypatch.setattr(
+        training_runtime_module.torch.cuda,
+        "graph",
+        lambda *_args, **_kwargs: nullcontext(),
+        raising=False,
+    )
+    cfg = OmegaConf.create(
+        {
+            "device": "cuda",
+            "mixed_precision": "bf16",
+            "compile_model": True,
+            "compile_backend": "eager",
+            "compile_dynamic": True,
+            "compile_shape_dispatch_mode": "off",
+            "cuda_graph_capture_mode": "signature_family",
+            "trace_activations": False,
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runtime.compile_shape_dispatch_mode='signature_family'",
+    ):
+        _ = resolve_cuda_graph_capture_policy(cfg)

--- a/tests/support/train_eval_smoke_cases.py
+++ b/tests/support/train_eval_smoke_cases.py
@@ -2322,6 +2322,8 @@ def test_train_logs_enriched_wandb_metrics_and_summary(
         "loader_task_batch_cache_mode": "off",
         "compile_shape_dispatch_mode": "off",
         "compile_shape_dispatch_max_families": 16,
+        "cuda_graph_capture_mode": "off",
+        "cuda_graph_max_families": 16,
     }
     assert telemetry["hardware_summary"]["device_type"] == "cpu"
     assert telemetry["hardware_summary"]["hardware_profile_id"] == "cpu"

--- a/tests/support_research/system_delta_execute.py
+++ b/tests/support_research/system_delta_execute.py
@@ -1853,9 +1853,13 @@ def test_queue_metrics_capture_log_loss_and_anchor_deltas(tmp_path: Path) -> Non
             'loader_task_batch_cache_mode': 'bounded_streaming',
             'compile_shape_dispatch_mode': 'signature_family',
             'compile_shape_dispatch_max_families': 16,
+            'cuda_graph_capture_mode': 'signature_family',
+            'cuda_graph_max_families': 8,
             'compile_shape_dispatch': {
                 'compiled_family_count': 16,
                 'family_switch_count': 63,
+                'cuda_graph_captured_family_count': 8,
+                'cuda_graph_capture_failure_count': 1,
             },
         },
         'regime_budget': {
@@ -1902,8 +1906,12 @@ def test_queue_metrics_capture_log_loss_and_anchor_deltas(tmp_path: Path) -> Non
     assert queue_metrics['loader_task_batch_cache_mode'] == 'bounded_streaming'
     assert queue_metrics['compile_shape_dispatch_mode'] == 'signature_family'
     assert queue_metrics['compile_shape_dispatch_max_families'] == 16
+    assert queue_metrics['cuda_graph_capture_mode'] == 'signature_family'
+    assert queue_metrics['cuda_graph_max_families'] == 8
     assert queue_metrics['compile_dispatch_compiled_family_count'] == 16
     assert queue_metrics['compile_dispatch_family_switch_count'] == 63
+    assert queue_metrics['cuda_graph_captured_family_count'] == 8
+    assert queue_metrics['cuda_graph_capture_failure_count'] == 1
     assert queue_metrics['tokens_per_step'] == pytest.approx(512.0)
     assert queue_metrics['token_budget'] == 38400
     assert queue_metrics['unique_task_budget'] == 96

--- a/tests/training/test_compile_dispatch.py
+++ b/tests/training/test_compile_dispatch.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+from tab_foundry.model.outputs import ClassificationOutput
+from tab_foundry.training.compile_dispatch import SignatureFamilyCompileDispatcher
+from tab_foundry.training.runtime import CompilePolicy, CudaGraphCapturePolicy
+from tab_foundry.types import TaskBatch
+
+from tests.support.train_eval_smoke_cases import _FakeAccelerator
+
+
+class _TinyClassifier(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 3)
+
+    def forward(self, batch: TaskBatch) -> ClassificationOutput:
+        return ClassificationOutput(logits=self.linear(batch.x_test.to(torch.float32)), num_classes=3)
+
+
+def _classification_batch() -> TaskBatch:
+    return TaskBatch(
+        x_train=torch.randn(6, 4),
+        y_train=torch.tensor([0, 1, 2, 0, 1, 2], dtype=torch.int64),
+        x_test=torch.randn(3, 4),
+        y_test=torch.tensor([0, 1, 2], dtype=torch.int64),
+        metadata={"dataset_index": 1},
+        num_classes=3,
+    )
+
+
+def test_signature_family_compile_dispatcher_records_cuda_graph_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch, "compile", lambda model, **_kwargs: model)
+    dispatcher = SignatureFamilyCompileDispatcher(
+        _TinyClassifier(),
+        compile_policy=CompilePolicy(
+            enabled=True,
+            backend="eager",
+            mode="default",
+            dynamic=True,
+        ),
+        max_families=4,
+        task="classification",
+        grad_accum_steps=1,
+        cuda_graph_policy=CudaGraphCapturePolicy(
+            enabled=True,
+            mode="signature_family",
+            max_families=2,
+        ),
+        cuda_graph_autocast_context_factory=nullcontext,
+    )
+    monkeypatch.setattr(
+        dispatcher,
+        "_build_cuda_graph_replay",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("graph unsupported")),
+    )
+
+    loss, metrics = dispatcher.training_step(
+        batch=_classification_batch(),
+        task="classification",
+        actual_task_count=1,
+        accelerator=_FakeAccelerator(),
+    )
+
+    assert float(loss.item()) >= 0.0
+    assert 0.0 <= metrics["acc"] <= 1.0
+    assert dispatcher.summary()["cuda_graph_capture_failure_count"] == 1
+    assert dispatcher.summary()["cuda_graph_fallback_call_count"] == 1
+
+
+def test_signature_family_compile_dispatcher_reuses_captured_cuda_graph_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch, "compile", lambda model, **_kwargs: model)
+    dispatcher = SignatureFamilyCompileDispatcher(
+        _TinyClassifier(),
+        compile_policy=CompilePolicy(
+            enabled=True,
+            backend="eager",
+            mode="default",
+            dynamic=True,
+        ),
+        max_families=4,
+        task="classification",
+        grad_accum_steps=1,
+        cuda_graph_policy=CudaGraphCapturePolicy(
+            enabled=True,
+            mode="signature_family",
+            max_families=2,
+        ),
+        cuda_graph_autocast_context_factory=nullcontext,
+    )
+
+    class _FakeGraphReplay:
+        def replay(self, _batch: TaskBatch) -> tuple[torch.Tensor, dict[str, float]]:
+            return torch.tensor(1.0), {"acc": 0.5}
+
+    monkeypatch.setattr(dispatcher, "_build_cuda_graph_replay", lambda **_kwargs: _FakeGraphReplay())
+    batch = _classification_batch()
+    accelerator = _FakeAccelerator()
+
+    first_loss, first_metrics = dispatcher.training_step(
+        batch=batch,
+        task="classification",
+        actual_task_count=1,
+        accelerator=accelerator,
+    )
+    second_loss, second_metrics = dispatcher.training_step(
+        batch=batch,
+        task="classification",
+        actual_task_count=1,
+        accelerator=accelerator,
+    )
+
+    assert float(first_loss.item()) == pytest.approx(1.0)
+    assert float(second_loss.item()) == pytest.approx(1.0)
+    assert first_metrics == {"acc": 0.5}
+    assert second_metrics == {"acc": 0.5}
+    summary = dispatcher.summary()
+    assert summary["cuda_graph_captured_family_count"] == 1
+    assert summary["cuda_graph_cache_misses"] == 1
+    assert summary["cuda_graph_cache_hits"] == 1

--- a/tests/training/test_surface.py
+++ b/tests/training/test_surface.py
@@ -328,6 +328,8 @@ def test_build_training_surface_record_includes_compile_runtime_flags(
     assert record["runtime"]["compile_mode"] == "max-autotune-no-cudagraphs"
     assert record["runtime"]["compile_shape_dispatch_mode"] == "off"
     assert record["runtime"]["compile_shape_dispatch_max_families"] == 16
+    assert record["runtime"]["cuda_graph_capture_mode"] == "off"
+    assert record["runtime"]["cuda_graph_max_families"] == 16
     assert record["runtime"]["loader_task_batch_cache_mode"] == "off"
     assert record["runtime"]["signature_family_run_length"] == 1
     assert record["runtime"]["trace_activations"] is False

--- a/tests/training/test_trainer_runtime_config.py
+++ b/tests/training/test_trainer_runtime_config.py
@@ -7,6 +7,8 @@ import tab_foundry.training.trainer_runtime_config as runtime_config_module
 from tab_foundry.training.trainer_runtime_config import (
     _resolve_compile_shape_dispatch_max_families,
     _resolve_compile_shape_dispatch_mode,
+    _resolve_cuda_graph_capture_mode,
+    _resolve_cuda_graph_max_families,
     _resolve_loader_task_batch_cache_mode,
     _resolve_signature_family_optimizer_step_block_length,
     _resolve_signature_family_run_length,
@@ -88,6 +90,8 @@ def test_resolve_compile_shape_dispatch_controls() -> None:
         {
             "compile_shape_dispatch_mode": "signature_family",
             "compile_shape_dispatch_max_families": 8,
+            "cuda_graph_capture_mode": "signature_family",
+            "cuda_graph_max_families": 6,
             "signature_family_run_length": 4,
             "signature_family_optimizer_step_block_length": 2,
         }
@@ -95,5 +99,7 @@ def test_resolve_compile_shape_dispatch_controls() -> None:
 
     assert _resolve_compile_shape_dispatch_mode(runtime_cfg) == "signature_family"
     assert _resolve_compile_shape_dispatch_max_families(runtime_cfg) == 8
+    assert _resolve_cuda_graph_capture_mode(runtime_cfg) == "signature_family"
+    assert _resolve_cuda_graph_max_families(runtime_cfg) == 6
     assert _resolve_signature_family_run_length(runtime_cfg) == 4
     assert _resolve_signature_family_optimizer_step_block_length(runtime_cfg) == 2


### PR DESCRIPTION
## Summary
- add `runtime.cuda_graph_capture_mode` and `runtime.cuda_graph_max_families` with validation and telemetry/training-surface persistence
- extend signature-family compile dispatch to support CUDA-graph capture with strict fallback and capture/cache statistics
- add explicit TF-RD-009 heads-1 benchmark-safe baseline, packed, and packed-plus-CUDA-graph experiment configs
- update TF-RD-022 benchmark/runtime profiles to use sparser module grad-norm logging and document the new benchmark workflow
- bump the package version and changelog for the new runtime/config surface

## Testing
- `uv run pytest tests/runtime/test_runtime_policy.py tests/training/test_trainer_runtime_config.py tests/training/test_compile_dispatch.py tests/training/test_surface.py tests/config/test_experiment_resolution.py tests/research/test_sweep_summarize.py tests/support_research/system_delta_execute.py tests/training/test_trainer_compile.py -q`
- `./scripts/dev verify paths ...` (full repo verification)
- `ruff check`
- `mypy src`
- full `pytest -q` via repo verification