### PR TITLE
[codex] Record TF-RD-009 Muon architecture-isolation negative evidence

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1130,6 +1130,25 @@ Legacy wording note:
     matched-budget final log loss landed at `0.4135`, `0.4137`, `0.4116`,
     `0.4146`, and `0.4009` respectively, so `264x6` is the current benchmark-
     backed Muon Phase-1 winner
+  - as of April 16, 2026 PT, the bounded architecture-isolation sweep
+    `tf_rd_009_muon_arch_isolation_medium_v1` has completed against the same
+    closed medium benchmark, using the carried `128x2` row
+    `sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+    as the locked anchor at `0.3951`; the isolated alternatives all lost:
+    final full-cell refresh
+    `sd_tf_rd_009_muon_arch_isolation_medium_v1_01_delta_tf_rd_009_muon_cls_sandwich_last_full_refresh_v1_v1=0.3994`,
+    split role-conditioned column summaries
+    `sd_tf_rd_009_muon_arch_isolation_medium_v1_02_delta_tf_rd_009_muon_cls_sandwich_split_column_summary_v1_v1=0.4018`,
+    `mlp2` feature encoder
+    `sd_tf_rd_009_muon_arch_isolation_medium_v1_03_delta_tf_rd_009_muon_cls_sandwich_feature_encoder_mlp2_v1_v1=0.3984`,
+    and class memory
+    `sd_tf_rd_009_muon_arch_isolation_medium_v1_04_delta_tf_rd_009_muon_cls_sandwich_class_memory_v1_v1=0.4044`;
+    code review of the experimental implementation branch
+    `codex/tf-rd-009-muon-arch-isolation-v1` at `1c52c4f` found no concrete
+    implementation defect, so record this lane as negative evidence only and
+    do not open combinations or follow-up capacity reads from it; the TF-RD-009
+    evidence note now carries the compact table of the four exact deltas, run
+    ids, and final losses for this lane
   - April 15, 2026 A6000 W&B system-memory evidence recorded peak allocated
     memory `4.28 GB` at `72x1`, `5.48 GB` at `112x3`, `8.11 GB` at `144x4`, and
     the winning `264x6` row still fit comfortably with `peak_vram_reserved`
@@ -1169,6 +1188,12 @@ Legacy wording note:
     Kaplan-style laws on Muon-family points only and keep `L(N,S)` on
     validation loss as the primary kept law, with benchmark loss as external
     ranking evidence
+  - treat the completed architecture-isolation sweep as closed negative
+    evidence under [#253](https://github.com/bensonlee5/tab-foundry/issues/253)
+    and [#274](https://github.com/bensonlee5/tab-foundry/issues/274): keep the
+    carried `128x2` Muon anchor unchanged for Phase 2, and do not open
+    combinations, latent-count follow-ups, or benchmark-surface replays from
+    that lane
   - keep `Bcrit` and derived `Cmin` diagnostic-only in the fresh Muon base
     family until the redesigned multi-geometry batch lane exists; do not make
     Chinchilla-like claims from the base Muon Phase-2 study alone

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -402,6 +402,29 @@ winning `264x6` row still fit comfortably at `peak_vram_reserved=17.20 GB`.
 Keep that headroom evidence for later planning, but do not reopen a larger-
 model Muon Phase-1 extension before Phase 2.
 
+Muon architecture-isolation note, April 16, 2026 PT: the bounded follow-up
+sweep `tf_rd_009_muon_arch_isolation_medium_v1` kept the original closed medium
+benchmark surface fixed and tested four isolated changes against the carried
+`128x2` Muon baseline
+`sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+at final matched-budget log loss `0.3951`. The four tried architecture
+alternatives were:
+
+| Delta id | Architecture change | Run id | Final log loss | Delta vs anchor |
+| --- | --- | --- | --- | --- |
+| `delta_tf_rd_009_muon_cls_sandwich_last_full_refresh_v1` | final-stage full-cell refresh | `sd_tf_rd_009_muon_arch_isolation_medium_v1_01_delta_tf_rd_009_muon_cls_sandwich_last_full_refresh_v1_v1` | `0.3994` | `+0.0043` |
+| `delta_tf_rd_009_muon_cls_sandwich_split_column_summary_v1` | split role-conditioned column summaries | `sd_tf_rd_009_muon_arch_isolation_medium_v1_02_delta_tf_rd_009_muon_cls_sandwich_split_column_summary_v1_v1` | `0.4018` | `+0.0067` |
+| `delta_tf_rd_009_muon_cls_sandwich_feature_encoder_mlp2_v1` | shared `mlp2` feature encoder | `sd_tf_rd_009_muon_arch_isolation_medium_v1_03_delta_tf_rd_009_muon_cls_sandwich_feature_encoder_mlp2_v1_v1` | `0.3984` | `+0.0033` |
+| `delta_tf_rd_009_muon_cls_sandwich_class_memory_v1` | train-only class memory | `sd_tf_rd_009_muon_arch_isolation_medium_v1_04_delta_tf_rd_009_muon_cls_sandwich_class_memory_v1_v1` | `0.4044` | `+0.0093` |
+
+The implementation reference remains the experiment branch
+`codex/tf-rd-009-muon-arch-isolation-v1` at commit `1c52c4f`. A direct code
+review of that implementation found no concrete defect in the four alternative
+paths, so the correct interpretation is negative architectural evidence rather
+than an invalid run. TF-RD-009 Phase 2 should therefore continue from the
+carried Muon anchor unchanged, and this lane should not open combinations,
+capacity follow-ups, or benchmark-surface replays.
+
 The current C axis has also been audited. Five reused 2,500-step NS rows
 (`07`, `11`, `15`, `19`, and `23`) and the reused batch-critical 96x2 row
 (`11`) originally carried `compute_accounting.training_shape_summary: null`,


### PR DESCRIPTION
## Summary
- record the completed TF-RD-009 Muon architecture-isolation sweep as negative evidence on the unchanged closed medium benchmark
- document that none of the four isolated architecture ideas improved the carried Muon `128x2` anchor
- cite experimental implementation branch `codex/tf-rd-009-muon-arch-isolation-v1` at commit `1c52c4f` as the reviewed code reference
- leave benchmark datasets, TF-RD-014 replay work, and losing experimental model knobs out of `main`

## Why
The completed architecture-isolation lane answered a bounded question: whether four targeted sandwich architecture alternatives could beat the carried `128x2` Muon leader on the locked benchmark surface. They did not, and the implementation review did not find a concrete defect that would invalidate those negative results.

## Recorded results
- `last_full_refresh`: `0.3994` vs anchor `0.3951` (`+0.0043`)
- `split_column_summary`: `0.4018` (`+0.0067`)
- `feature_encoder_mlp2`: `0.3984` (`+0.0033`)
- `class_memory`: `0.4044` (`+0.0093`)

## Impact
- TF-RD-009 Phase 2 remains anchored on the carried Muon `128x2` baseline
- no combinations, latent-count follow-ups, or benchmark-surface replays should be opened from the architecture-isolation lane
- `main` records the evidence without inheriting dead-end experimental knobs

## Validation
- `./scripts/dev verify paths docs/development/roadmap.md reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md`

Refs #253
Refs #274
