### PR TITLE
Refactor TF-RD-009 muon navigation and scaling sweep plumbing

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -959,8 +959,12 @@ Legacy wording note:
   [#257](https://github.com/bensonlee5/tab-foundry/issues/257),
   completed Muon Phase-1 child
   [#275](https://github.com/bensonlee5/tab-foundry/issues/275),
-  active Muon Phase-2 child
+  completed corrected Muon Phase-2 child
   [#274](https://github.com/bensonlee5/tab-foundry/issues/274),
+  active Muon cleanup child
+  [#283](https://github.com/bensonlee5/tab-foundry/issues/283),
+  active compact Muon training-dynamics selector child
+  [#284](https://github.com/bensonlee5/tab-foundry/issues/284),
   post-fit frontier and robustness umbrella
   [#258](https://github.com/bensonlee5/tab-foundry/issues/258),
   later Muon upper-family reopen child
@@ -1141,8 +1145,9 @@ Legacy wording note:
     while carrying `264x6` as the current preferred candidate; the freeze still
     waits for a later large-rung Muon validation on the candidate architecture
   - [#274](https://github.com/bensonlee5/tab-foundry/issues/274) is now
-    complete on this branch under corrected sparse multiclass replay against
-    `openml_classification_medium_v1`: the earlier provisional binary-backed
+    complete and merged via [#280](https://github.com/bensonlee5/tab-foundry/pull/280)
+    under corrected sparse multiclass replay against
+    `openml_classification_medium_v1`; the earlier provisional binary-backed
     interpretation is superseded. The corrected NS family prefers
     `144x4 @ 5000 = 0.4914031270`, while the corrected batch-critical family
     prefers `264x6 @ grad_accum=16 @ 5000 = 0.4646411887`, which is the
@@ -1150,6 +1155,25 @@ Legacy wording note:
     validation-backed, the primary `L(N,S)` validation fit lands at
     `log_space_r2=0.9123` with `rmse=0.0172`, and the audit explicitly keeps
     `Bcrit` and derived `Cmin` diagnostic-only with `ready_for_cmin=false`
+  - the corrected Phase-2 result changes the next defended move: batch-side
+    gains now dominate geometry-only gains on the active Muon surface, so the
+    next lane is training-dynamics-first rather than immediate upper-family
+    reopen or compute-frontier work
+  - the active Muon lineage is now the canonical TF-RD-009 path:
+    `tf_rd_009_muon_width_screen_medium_v1` ->
+    `tf_rd_009_muon_width_depth_medium_v1` ->
+    `tf_rd_009_muon_ns_one_epoch_medium_v1` ->
+    `tf_rd_009_muon_batch_critical_one_epoch_medium_v1` ->
+    `tf_rd_009_muon_phase2_one_epoch_v1`; the historical schedulefree family
+    under [#254](https://github.com/bensonlee5/tab-foundry/issues/254),
+    [#255](https://github.com/bensonlee5/tab-foundry/issues/255),
+    [#256](https://github.com/bensonlee5/tab-foundry/issues/256), and
+    [#257](https://github.com/bensonlee5/tab-foundry/issues/257) remains
+    preserved context only
+  - the next executable selector surface is now
+    `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`, a compact `12`-row
+    endpoint study over `128x2`, `144x4`, and `264x6` that ranks rows on a
+    corrected quality/time Pareto frontier before any later Muon Phase-2B rerun
 - Required work:
   - keep [#253](https://github.com/bensonlee5/tab-foundry/issues/253) as the
     authoritative umbrella for TF-RD-009, but treat the historical
@@ -1163,25 +1187,32 @@ Legacy wording note:
     anchor, keep `128x2` as the carried in-family baseline, and carry the now-
     benchmark-backed `264x6` winner into later Muon planning without reopening
     a larger-model Phase-1 extension first
-  - land [#274](https://github.com/bensonlee5/tab-foundry/issues/274) from
-    draft PR [#280](https://github.com/bensonlee5/tab-foundry/pull/280) with
-    the corrected multiclass Phase-2 closeout: keep `L(N,S)` on validation
-    loss as the primary kept law, keep benchmark loss as external ranking
-    evidence, and document that the corrected Muon base study is directional
-    rather than compute-optimal
-  - keep `Bcrit` and derived `Cmin` diagnostic-only in the fresh Muon base
-    family until the redesigned multi-geometry batch lane exists; do not make
-    Chinchilla-like claims from the base Muon Phase-2 study alone
-  - run [#269](https://github.com/bensonlee5/tab-foundry/issues/269) only after
-    `tf_rd_009_muon_phase2_one_epoch_v1` lands, using the Muon upper-extension
-    ids `tf_rd_009_muon_width_depth_upper_extension_one_epoch_medium_v1`,
-    `tf_rd_009_muon_ns_upper_extension_one_epoch_medium_v1`, and
-    `tf_rd_009_muon_phase2_upper_extension_one_epoch_v1`; if a later larger-
-    model Muon probe is still needed, treat it as post-Phase-2 work instead of
-    as a blocker on the current reboot path
-  - after the Muon upper-family and redesigned batch lane land, return to
-    [#259](https://github.com/bensonlee5/tab-foundry/issues/259) for the later
-    compute-frontier / Chinchilla-style branch, and keep
+  - keep [#274](https://github.com/bensonlee5/tab-foundry/issues/274) and
+    merged PR [#280](https://github.com/bensonlee5/tab-foundry/pull/280) as the
+    corrected Muon Phase-2 closeout: keep `L(N,S)` on validation loss as the
+    primary directional law, keep benchmark loss as external ranking evidence,
+    and keep `Bcrit` / `Cmin` diagnostic-only with `ready_for_cmin=false`
+  - land [#283](https://github.com/bensonlee5/tab-foundry/issues/283) next so
+    one sweep/scaling inspection path can show the active benchmark, corpus,
+    formal external anchor, carried in-family baseline, linked study lineage,
+    kept winner, and fit/audit readiness, while failing fast on benchmark,
+    baseline, corpus, anchor, and replay-completeness contract drift
+  - after the cleanup child lands, execute
+    [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the compact
+    Muon training-dynamics selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`:
+    keep the corrected `openml_classification_medium_v1` benchmark and
+    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, run the
+    `128x2` / `144x4` / `264x6` endpoint matrix with carried low-batch,
+    carried high-batch, linear LR/batch, and momentum-timescale prescriptions,
+    and rank rows on the corrected quality/time Pareto frontier
+  - only after the cleanup child and compact selector land should
+    [#269](https://github.com/bensonlee5/tab-foundry/issues/269) be revisited
+    for any Muon upper-family move; treat any later larger-model probe as
+    post-selector work instead of as a blocker on the current active reboot path
+  - only after a later Muon Phase-2B rerun produces a better-conditioned
+    multi-geometry batch surface should
+    [#259](https://github.com/bensonlee5/tab-foundry/issues/259) be revisited
+    for the compute-frontier / Chinchilla-style branch; keep
     [#260](https://github.com/bensonlee5/tab-foundry/issues/260) separate as a
     repetition or curriculum slice
   - maintain hardware baselines statefully in

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -482,14 +482,16 @@ Treat the current `Bcrit(L)` output as weak diagnostic evidence: the completed
 lower envelope has only two points.
 
 The April 12 to April 13 schedulefree TF-RD-009 studies above are historical
-diagnostics only. The active reboot path is now the fresh Muon family on the
-same benchmark slice but a different frozen training surface:
+diagnostics only. The canonical active TF-RD-009 operator path is now the fresh
+Muon lineage on the corrected multiclass benchmark plus the fixed `v6`
+training surface:
 
 ```bash
+tab-foundry research sweep list-sweeps
 tab-foundry dev resolve-config \
   experiment=cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 tab-foundry research sweep inspect \
-  --sweep-id tf_rd_009_muon_width_screen_medium_v1 \
+  --sweep-id tf_rd_009_muon_training_dynamics_endpoint_medium_v1 \
   --order 1 \
   --json
 tab-foundry research scaling inspect \
@@ -497,14 +499,47 @@ tab-foundry research scaling inspect \
   --json
 ```
 
-`tf_rd_009_muon_width_screen_medium_v1` has now completed the fresh Muon width
-screen on the full 2500-step `v6` contract, with `60x2=0.4172`,
-`48x2=0.4147`, `96x2=0.4128`, and `128x2=0.3951` final matched-budget log
-loss. Keep `60x2` as the formal external Muon anchor, but carry `128x2`
-forward as the current in-family baseline for the rederived Phase-1 family
-`72x1/112x3/144x4/192x5/264x6`. The Muon width-depth queue is now populated;
-the Muon Phase-2 study ids remain scaffolded until those fresh Phase-1 rows are
-benchmark-backed and promoted into later Muon scaling-law work.
+Use that sequence for operator triage:
+
+- `research sweep list-sweeps` now renders the sweep index as a parent/child
+  tree, which makes the active Muon lineage easy to locate without guessing
+  whether an older schedulefree branch is still active
+- `research sweep inspect` now surfaces lineage, active benchmark manifest,
+  control baseline, carried in-family baseline, corpus ref, linked scaling
+  studies, and the sweep winner with throughput and wall-time context by
+  default
+- `research scaling inspect` is now the canonical lane-level inspection
+  entrypoint; it shows linked sweeps, kept winner, fit/audit readiness, and
+  fails fast if benchmark, baseline, corpus, anchor, or full-surface
+  completeness contracts drift
+
+The active Muon lineage is:
+
+- `tf_rd_009_muon_width_screen_medium_v1`
+- `tf_rd_009_muon_width_depth_medium_v1`
+- `tf_rd_009_muon_ns_one_epoch_medium_v1`
+- `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
+- `tf_rd_009_muon_phase2_one_epoch_v1`
+- next selector sweep: `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
+
+`tf_rd_009_muon_width_screen_medium_v1` completed the fresh Muon width screen
+on the full 2500-step `v6` contract, with `60x2=0.4172`, `48x2=0.4147`,
+`96x2=0.4128`, and `128x2=0.3951` final matched-budget log loss. Keep `60x2`
+as the formal external Muon anchor, but carry `128x2` forward as the current
+in-family baseline. The corrected Muon Phase-2 closeout in merged PR
+[#280](https://github.com/bensonlee5/tab-foundry/pull/280) keeps `L(N,S)` as a
+directional signal only, so the next defended execution lane is the compact
+training-dynamics selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
+over `128x2`, `144x4`, and `264x6` at the fixed 5000-step endpoint.
+
+The selector keeps the corrected `openml_classification_medium_v1` benchmark,
+the fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus, and ranks rows
+on a quality/time Pareto frontier across four prescriptions per geometry:
+
+- carried low-batch baseline
+- carried high-batch empirical reference
+- linear LR/batch prescription
+- momentum-timescale prescription
 
 For the historical corrected one-epoch schedulefree rerun, materialize
 `tf_rd_010_dagzoo_medium_control_curated_v6` remotely first rather than

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -502,20 +502,38 @@ papers.
 
 Next sweep ordering after the corrected Phase-2 closeout:
 
-- first: land the corrected Muon Phase-2 study as a directional result and do
-  not claim compute-optimality from it
-- second: run the redesigned multi-geometry batch lane with at least three
-  geometries before revisiting `Bcrit(L)` or any `Cmin` story
-- third: keep larger-model follow-on work separate from this base study; the
-  next priority is training-dynamics and batch redesign, not another aggressive
-  size extension
+- first: keep merged PR [#280](https://github.com/bensonlee5/tab-foundry/pull/280)
+  as a directional Muon Phase-2 result and do not claim compute-optimality from
+  it
+- second: land
+  [#283](https://github.com/bensonlee5/tab-foundry/issues/283) so the active
+  Muon lineage is easy to inspect and hard to misuse; the canonical operator
+  path should expose the active benchmark, corpus, formal anchor, carried
+  baseline, linked study, kept winner, and fit/audit readiness from one place
+- third: run
+  [#284](https://github.com/bensonlee5/tab-foundry/issues/284), the compact
+  `12`-row Muon training-dynamics selector over `128x2`, `144x4`, and `264x6`
+  at a fixed 5000-step endpoint, and rank rows on the corrected quality/time
+  Pareto frontier
+- fourth: only after the selector keeps one dynamics contract should a later
+  Muon Phase-2B rerun redesign the multi-geometry batch surface before
+  revisiting `Bcrit(L)` or any `Cmin` story
+- fifth: keep larger-model follow-on work separate from this base study;
+  [#269](https://github.com/bensonlee5/tab-foundry/issues/269) and
+  [#259](https://github.com/bensonlee5/tab-foundry/issues/259) are both
+  downstream of the cleanup and selector work, not the immediate next action
 - last: keep missingness as inference-time evaluation only, after the corrected
   multiclass benchmark contract is trusted
 
 TF-RD-009 adoption decision: use the corrected Muon Phase-2 study as the fresh
 directional `L(N,S)` surface for the Muon family, but do not use `Bcrit(L)` to
 derive `Cmin` and do not make Chinchilla-like compute-optimal claims until the
-redesigned multi-geometry batch sweep lands.
+cleanup lane and compact training-dynamics selector land, a kept dynamics
+contract is chosen, and a later multi-geometry batch rerun materially improves
+the conditioning of the batch surface. The corrected empirical lesson is
+training-dynamics-first: on the trusted multiclass benchmark, batch-side gains
+were larger than geometry-only gains, so the next defended study should test
+optimizer and batch invariants before reopening larger-family work.
 
 ## Joint Width-Depth Derivation For [#255](https://github.com/bensonlee5/tab-foundry/issues/255)
 
@@ -736,9 +754,10 @@ The reopened upper-family child under
 [#269](https://github.com/bensonlee5/tab-foundry/issues/269) keeps these
 frozen formulas as the historical design surface and preserves the old
 selector artifact as schedulefree-branch context only. The active Muon reboot
-does not inherit that continuation in place; after Muon Phase 2 lands, rerun
-the upper-family selector on Muon-only evidence before choosing any fresh
-continuation under the retained `~40 GB` target.
+does not inherit that continuation in place; after corrected Muon Phase 2, the
+next work is the cleanup lane plus the compact training-dynamics selector, and
+only after those land should the upper-family selector be reconsidered on
+Muon-only evidence under the retained `~40 GB` target.
 
 ### Capacity Table
 
@@ -1060,8 +1079,9 @@ Exact handoff to [#255](https://github.com/bensonlee5/tab-foundry/issues/255):
   the broadened family is complete enough to choose the best
   matched-regime-budget row among `health=ok` runs on `rtx8000_44gb`
 - keep compute-optimal parameter-token work in
-  [#259](https://github.com/bensonlee5/tab-foundry/issues/259) and curriculum or
-  repeated-data slice work in
+  [#259](https://github.com/bensonlee5/tab-foundry/issues/259) blocked until a
+  later Muon Phase-2B rerun produces a better-conditioned multi-geometry batch
+  surface, and keep curriculum or repeated-data slice work in
   [#260](https://github.com/bensonlee5/tab-foundry/issues/260)
 
 ## Hardware-Aware Preferred Architecture State

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -3828,6 +3828,342 @@ deltas:
     default_next_action: Execute as order 5 in `tf_rd_009_muon_width_depth_medium_v1` after `192x5` is benchmark-backed; treat failure as fresh-Muon ceiling evidence.
     applicability_guards: []
 
+  delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`) as the selector floor.
+    upstream_delta: This is the compact endpoint selector baseline that follows corrected Muon Phase 2 and the cleanup-first navigation lane; it keeps the corrected multiclass benchmark contract and the `v6` training corpus fixed while measuring the carried low-batch dynamics point directly.
+    expected_effect: If the carried low-batch Muon surface is still on the quality/time frontier after the corrected Phase-2 closeout, this row should remain the compact selector floor that later higher-batch prescriptions must beat.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the `128x2` low-batch selector floor after the active Muon lineage cleanup is landed.
+        - Compare directly against the high-batch and literature-backed `128x2` prescriptions on corrected benchmark loss and end-to-end train wall time.
+        - Carry forward only if the corrected Pareto frontier still prefers the low-batch contract once the selector is complete.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `128x2` low-batch endpoint in `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` and keep it only if it remains on the corrected quality/time Pareto frontier.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`) and the original Muon LR/beta surface unchanged.
+    upstream_delta: Corrected Muon Phase 2 showed that batch-side movement dominated geometry-only movement; this row tests whether the measured high-batch gain transfers to the compact `128x2` selector geometry without opening the optimizer prescription yet.
+    expected_effect: If the Phase-2 batch-side gain transfers cleanly, this row should beat or match the low-batch `128x2` floor at acceptable extra training time and justify keeping high-batch dynamics in the next law-conditioning lane.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon LR, beta, and weight-decay surface
+      - high-batch empirical reference only; no broader optimizer reopen
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the empirical high-batch carry-forward row for `128x2`.
+        - Compare directly against the low-batch `128x2` row on corrected benchmark loss, throughput, and wall time.
+        - Keep this contract only if the measured gain justifies the time cost before any later Phase-2B rerun.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `128x2` high-batch empirical reference and compare it directly against the low-batch selector floor.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the literature-backed linear LR/batch prescription on `128x2` at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping `betas=(0.9, 0.95)` and `weight_decay=0.01`.
+    upstream_delta: This row encodes the first defended optimizer-timescale variant for the compact selector after corrected Muon Phase 2, testing the simplest `eta proportional to batch` prescription under the fixed corpus, benchmark, and horizon contract.
+    expected_effect: If the corrected Muon surface follows the linear LR/batch invariant closely enough, this row should improve quality at the high-batch endpoint without requiring a separate geometry change.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with linear LR scaling
+      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the first literature-backed high-batch prescription for `128x2`.
+        - Compare directly against both carried `128x2` rows to test whether linear LR scaling is a better kept invariant than the pure carry-forward contract.
+        - Promote only if it lands on the corrected quality/time Pareto frontier.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `128x2` linear LR/batch prescription and keep it only if it materially improves the corrected quality/time frontier.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the momentum-timescale Muon selector prescription on `128x2` at `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising `beta1` to `0.975`.
+    upstream_delta: Corrected Muon Phase 2 justified training-dynamics-first work; this row is the second defended invariant-backed probe, testing whether a larger effective momentum timescale transfers better than simple linear LR scaling on the compact selector geometry.
+    expected_effect: If momentum-timescale coupling matters on the corrected Muon surface, this row should outperform the linear LR/batch prescription at comparable wall time on `128x2`.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with `beta1=0.975`
+      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the momentum-timescale comparator for the `128x2` selector geometry.
+        - Compare directly against the carried high-batch and linear LR/batch `128x2` rows.
+        - Promote only if the corrected benchmark gain is real enough to justify the additional training-time cost.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `128x2` momentum-timescale prescription and compare it against the other `128x2` selector rows on corrected loss and wall time.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run the corrected Muon NS winner geometry `144x4` at the fixed 5000-step endpoint with the carried low-batch `B_eff=64` contract.
+    upstream_delta: Corrected Muon Phase 2 showed that `144x4` is the best NS geometry while `264x6` only wins after batch tuning; this row carries the NS winner into the compact training-dynamics selector without changing the geometry.
+    expected_effect: If `144x4` remains the best compact geometry under the selector contract, this low-batch row should establish the geometry’s time-efficient frontier point before any higher-batch or literature-backed prescription is kept.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the `144x4` low-batch selector floor.
+        - Compare against the corresponding high-batch and literature-backed `144x4` rows plus the carried `128x2` floor.
+        - Keep the geometry only if at least one `144x4` dynamics contract stays on the corrected Pareto frontier.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `144x4` low-batch endpoint and use it as the corrected NS-winner floor for the selector.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+    upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+    expected_effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon LR, beta, and weight-decay surface
+      - empirical high-batch reference only; no broader optimizer reopen
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the empirical high-batch carry-forward row for `144x4`.
+        - Compare directly against the `144x4` low-batch floor and the two literature-backed `144x4` prescriptions.
+        - Keep this contract only if the corrected gain is large enough to offset the extra train time.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `144x4` high-batch empirical reference and compare it against the other `144x4` selector rows.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the linear LR/batch Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+    upstream_delta: This row applies the simplest defended high-batch optimizer invariant to the corrected NS-winner geometry so the selector can decide whether `144x4` wants a new dynamics contract before any later Phase-2B rerun.
+    expected_effect: If `eta proportional to batch` is a better organizing invariant than pure carry-forward at `144x4`, this row should improve corrected benchmark quality enough to stay on the Pareto frontier.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with linear LR scaling
+      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the first literature-backed high-batch prescription for `144x4`.
+        - Compare directly against both carried `144x4` rows and the momentum-timescale `144x4` variant.
+        - Promote only if it lands on the corrected quality/time Pareto frontier.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `144x4` linear LR/batch prescription and keep it only if it improves the corrected Pareto frontier.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the momentum-timescale Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
+    upstream_delta: This row is the second invariant-backed training-dynamics probe for the corrected NS-winner geometry, testing whether a longer effective momentum timescale gives a cleaner high-batch transfer than the linear LR/batch rule.
+    expected_effect: If momentum-timescale coupling is the better invariant on `144x4`, this row should outperform the linear LR/batch `144x4` prescription at comparable high-batch wall time.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with `beta1=0.975`
+      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the momentum-timescale comparator for `144x4`.
+        - Compare directly against the carried high-batch and linear LR/batch `144x4` rows.
+        - Promote only if the corrected gain is large enough to justify the same or higher wall time.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `144x4` momentum-timescale prescription and compare it against the other `144x4` selector rows on corrected loss and wall time.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run the corrected overall Muon Phase-2 winner geometry `264x6` at the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward contract.
+    upstream_delta: Corrected Muon Phase 2 showed that `264x6` only wins once effective batch is pushed up; this row measures the larger geometry’s low-batch floor inside the compact selector so the later high-batch gain can be interpreted cleanly.
+    expected_effect: If `264x6` is genuinely under-optimized at low batch, this row should underperform the high-batch `264x6` rows and justify training-dynamics-first sequencing over immediate larger-family reopen.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the `264x6` low-batch floor so the selector can separate geometry size from optimization effects.
+        - Compare directly against the corresponding high-batch and literature-backed `264x6` rows plus the compact `128x2` and `144x4` candidates.
+        - Keep the larger geometry only if at least one `264x6` dynamics contract justifies its time cost on the corrected Pareto frontier.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `264x6` low-batch endpoint and use it as the larger-geometry floor for the selector.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Re-run `264x6` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+    upstream_delta: This row carries forward the corrected Phase-2 result that made `264x6` the best overall row, but now inside the compact selector where quality is judged jointly with training time.
+    expected_effect: If the corrected Phase-2 high-batch gain is robust enough to survive the selector replay, this row should stay on the corrected quality/time Pareto frontier and justify keeping `264x6` in later Phase-2B planning.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - carried Muon LR, beta, and weight-decay surface
+      - empirical high-batch reference only; no broader optimizer reopen
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the empirical high-batch carry-forward row for `264x6`.
+        - Compare directly against the `264x6` low-batch floor and both literature-backed `264x6` prescriptions.
+        - Keep this contract only if the corrected gain remains large enough to justify its wall-time cost.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `264x6` high-batch empirical reference and compare it against the other `264x6` selector rows.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the linear LR/batch Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+    upstream_delta: This row asks whether the larger corrected winner geometry wants the simple `eta proportional to batch` prescription strongly enough to beat the empirical carry-forward contract once quality and time are judged together.
+    expected_effect: If linear LR scaling is the better invariant for the larger geometry, this row should improve corrected benchmark quality enough to remain Pareto-admissible despite the geometry’s higher training cost.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with linear LR scaling
+      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the first literature-backed high-batch prescription for `264x6`.
+        - Compare directly against both carried `264x6` rows and the momentum-timescale `264x6` variant.
+        - Promote only if it stays on the corrected quality/time Pareto frontier.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `264x6` linear LR/batch prescription and keep it only if it improves the corrected Pareto frontier.
+    applicability_guards: []
+
+  delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Test the momentum-timescale Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
+    upstream_delta: This row is the second invariant-backed high-batch probe for the larger corrected winner geometry, testing whether a longer momentum timescale produces a better kept dynamics contract than simple linear LR scaling.
+    expected_effect: If momentum-timescale coupling is the better organizing invariant for the larger geometry, this row should beat the linear LR/batch `264x6` prescription on corrected benchmark quality at comparable wall time.
+    adequacy_knobs:
+      - corrected `openml_classification_medium_v1` benchmark contract
+      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+      - fixed `5000`-step one-epoch endpoint
+      - high-batch `B_eff=256` endpoint with `beta1=0.975`
+      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    parameter_adequacy_policy:
+      default_plan:
+        - Execute as the momentum-timescale comparator for `264x6`.
+        - Compare directly against the carried high-batch and linear LR/batch `264x6` rows.
+        - Promote only if the corrected gain is real enough to justify the larger geometry’s time cost.
+      default_negative_decision: defer
+      reject_requires:
+        - isolated_change
+        - adequacy_plan_complete
+        - clearly_worse_without_offsetting_benefit
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Benchmark this `264x6` momentum-timescale prescription and compare it against the other `264x6` selector rows on corrected loss and wall time.
+    applicability_guards: []
+
   delta_tf_rd_009_cls_sandwich_dicl192_layers7_upper_v1:
     dimension_family: model
     family: classification_scaling_law

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -475,6 +475,14 @@ sweeps:
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
     control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
     external_benchmarks: []
+  tf_rd_009_muon_training_dynamics_endpoint_medium_v1:
+    parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+    status: draft
+    anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+    complexity_level: classification_md
+    benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+    external_benchmarks: []
   tf_rd_009_muon_width_depth_upper_extension_one_epoch_medium_v1:
     parent_sweep_id: tf_rd_009_muon_width_depth_medium_v1
     status: draft

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/matrix.md
@@ -1,0 +1,494 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml` (derived from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/queue.yaml` plus `reference/system_delta_catalog.yaml`) and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
+- Sweep status: `draft`
+- Parent sweep id: `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
+- Complexity level: `classification_md`
+- Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml`
+- Resolved queue inputs fingerprint: `de30d58f0cbf8ffb299d5f2670f2152987dfc7017dc6cd16289ab2b63d891b6e`
+
+## Locked Surface
+
+- Anchor run id: `sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+- Benchmark manifest: local benchmark-manifest id `openml_classification_medium_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_medium_v1`
+- External benchmarks: `none`
+- Training experiment: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Training config profile: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Surface role: `classification_training_dynamics_selector`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final BPC `2.1383`, final BPF `2.1383`, final log loss `0.3951`, final Brier score `0.2585`, best ROC AUC `0.7563`, final ROC AUC `0.7583`, final training time `8686.8s`
+
+## Anchor Comparison
+
+Upstream reference: `PerceiverIO` from `https://openreview.net/forum?id=fILj7WpI-g`.
+
+| Dimension | Upstream PerceiverIO | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1` | classification_scaling_law | no | ready | none | Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`) as the selector floor. | Benchmark this low-batch endpoint row and rank it on the corrected medium loss/time Pareto frontier before any larger-family work. |
+| 2 | `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`) and the original Muon LR/beta surface unchanged. | Benchmark this high-batch carried reference and compare it against the low-batch row on the corrected medium loss/time Pareto frontier. |
+| 3 | `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1` | classification_scaling_law | no | ready | none | Test the literature-backed linear LR/batch prescription on `128x2` at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping `betas=(0.9, 0.95)` and `weight_decay=0.01`. | Benchmark this linear LR/batch row and keep it only if it improves the corrected medium loss/time Pareto frontier. |
+| 4 | `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1` | classification_scaling_law | no | ready | none | Test the momentum-timescale Muon selector prescription on `128x2` at `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising `beta1` to `0.975`. | Benchmark this momentum-timescale row and keep it only if it improves the corrected medium loss/time Pareto frontier versus the simpler high-batch rows. |
+| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1` | classification_scaling_law | no | ready | none | Re-run the corrected Muon NS winner geometry `144x4` at the fixed 5000-step endpoint with the carried low-batch `B_eff=64` contract. | Benchmark this low-batch endpoint row and rank it on the corrected medium loss/time Pareto frontier before any larger-family work. |
+| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this high-batch carried reference and compare it against the low-batch row on the corrected medium loss/time Pareto frontier. |
+| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1` | classification_scaling_law | no | ready | none | Test the linear LR/batch Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`. | Benchmark this linear LR/batch row and keep it only if it improves the corrected medium loss/time Pareto frontier. |
+| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1` | classification_scaling_law | no | ready | none | Test the momentum-timescale Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`. | Benchmark this momentum-timescale row and keep it only if it improves the corrected medium loss/time Pareto frontier versus the simpler high-batch rows. |
+| 9 | `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1` | classification_scaling_law | no | ready | none | Re-run the corrected overall Muon Phase-2 winner geometry `264x6` at the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward contract. | Benchmark this low-batch endpoint row and rank it on the corrected medium loss/time Pareto frontier before any larger-family work. |
+| 10 | `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `264x6` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this high-batch carried reference and compare it against the low-batch row on the corrected medium loss/time Pareto frontier. |
+| 11 | `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1` | classification_scaling_law | no | ready | none | Test the linear LR/batch Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`. | Benchmark this linear LR/batch row and keep it only if it improves the corrected medium loss/time Pareto frontier. |
+| 12 | `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1` | classification_scaling_law | no | ready | none | Test the momentum-timescale Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`. | Benchmark this momentum-timescale row and keep it only if it improves the corrected medium loss/time Pareto frontier versus the simpler high-batch rows. |
+
+## Detailed Rows
+
+### 1. `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`) as the selector floor.
+- Rationale: Compact Muon training-dynamics selector row for `128x2` using the carried low-batch baseline at a fixed 5000-step horizon.
+- Hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step endpoint gives the compact time-efficient selector baseline.
+- Upstream delta: This is the compact endpoint selector baseline that follows corrected Muon Phase 2 and the cleanup-first navigation lane; it keeps the corrected multiclass benchmark contract and the `v6` training corpus fixed while measuring the carried low-batch dynamics point directly.
+- Anchor delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as the selector baseline.
+- Expected effect: If the carried low-batch Muon surface is still on the quality/time frontier after the corrected Phase-2 closeout, this row should remain the compact selector floor that later higher-batch prescriptions must beat.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `63f4e190b563f9ecc902d6baa68d10a621f95685f210fff34ad80e76e3a29f94`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'grad_accum_steps': 4, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `128x2` with carried low-batch baseline.
+  - Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64` (`task_batch_size=16`, `grad_accum_steps=4`).
+  - This row exists to quantify the quality/time floor before any higher-batch or literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 2. `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`) and the original Muon LR/beta surface unchanged.
+- Rationale: Compact Muon training-dynamics selector row for `128x2` using the carried high-batch empirical reference at a fixed 5000-step horizon.
+- Hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff` to 256 should test whether the Phase-2 batch-side gain transfers across the compact geometry set.
+- Upstream delta: Corrected Muon Phase 2 showed that batch-side movement dominated geometry-only movement; this row tests whether the measured high-batch gain transfers to the compact `128x2` selector geometry without opening the optimizer prescription yet.
+- Anchor delta: Raise effective batch to `B_eff=256` without changing the carried Muon LR or beta surface.
+- Expected effect: If the Phase-2 batch-side gain transfers cleanly, this row should beat or match the low-batch `128x2` floor at acceptable extra training time and justify keeping high-batch dynamics in the next law-conditioning lane.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `10a9234a87808903bf9a2ccaabe0073e5dc4af95b5c9857f2b9d90a1b04cc29e`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'grad_accum_steps': 16, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - high-batch empirical reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `128x2` with carried high-batch empirical reference.
+  - Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and only raise `B_eff` to 256.
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 3. `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the literature-backed linear LR/batch prescription on `128x2` at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping `betas=(0.9, 0.95)` and `weight_decay=0.01`.
+- Rationale: Compact Muon training-dynamics selector row for `128x2` using the linear LR/batch prescription at a fixed 5000-step horizon.
+- Hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription may outperform the carried high-batch reference without reopening geometry.
+- Upstream delta: This row encodes the first defended optimizer-timescale variant for the compact selector after corrected Muon Phase 2, testing the simplest `eta proportional to batch` prescription under the fixed corpus, benchmark, and horizon contract.
+- Anchor delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription `eta ∝ B`.
+- Expected effect: If the corrected Muon surface follows the linear LR/batch invariant closely enough, this row should improve quality at the high-batch endpoint without requiring a separate geometry change.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `06b20c3067b9dac0deb69aaec88af3cfd1f6e44736f5971b398a40c0cb91b0ea`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'grad_accum_steps': 16, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - `weight_decay=0.01` stays frozen while batch and LR move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `128x2` with linear LR/batch prescription.
+  - Literature-backed selector row: test the first defended invariant `eta ∝ B` under fixed corpus and fixed weight decay.
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 4. `delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the momentum-timescale Muon selector prescription on `128x2` at `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising `beta1` to `0.975`.
+- Rationale: Compact Muon training-dynamics selector row for `128x2` using the momentum-timescale prescription at a fixed 5000-step horizon.
+- Hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping `B(1-beta1)` approximately constant at high batch may outperform the plain linear LR/batch row.
+- Upstream delta: Corrected Muon Phase 2 justified training-dynamics-first work; this row is the second defended invariant-backed probe, testing whether a larger effective momentum timescale transfers better than simple linear LR scaling on the compact selector geometry.
+- Anchor delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale variant with `beta1=0.975`.
+- Expected effect: If momentum-timescale coupling matters on the corrected Muon surface, this row should outperform the linear LR/batch prescription at comparable wall time on `128x2`.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `06b20c3067b9dac0deb69aaec88af3cfd1f6e44736f5971b398a40c0cb91b0ea`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.975, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'grad_accum_steps': 16, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - `weight_decay=0.01` stays frozen while LR and momentum move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `128x2` with momentum-timescale prescription.
+  - Literature-backed selector row: test a timescale-style invariant by pairing high batch with `beta1=0.975` while keeping `beta2=0.95`.
+  - This row is still selector evidence only; do not promote it into a larger-family law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 5. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run the corrected Muon NS winner geometry `144x4` at the fixed 5000-step endpoint with the carried low-batch `B_eff=64` contract.
+- Rationale: Compact Muon training-dynamics selector row for `144x4` using the carried low-batch baseline at a fixed 5000-step horizon.
+- Hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step endpoint gives the compact time-efficient selector baseline.
+- Upstream delta: Corrected Muon Phase 2 showed that `144x4` is the best NS geometry while `264x6` only wins after batch tuning; this row carries the NS winner into the compact training-dynamics selector without changing the geometry.
+- Anchor delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as the selector baseline.
+- Expected effect: If `144x4` remains the best compact geometry under the selector contract, this low-batch row should establish the geometry’s time-efficient frontier point before any higher-batch or literature-backed prescription is kept.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `144x4` with carried low-batch baseline.
+  - Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64` (`task_batch_size=16`, `grad_accum_steps=4`).
+  - This row exists to quantify the quality/time floor before any higher-batch or literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 6. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Compact Muon training-dynamics selector row for `144x4` using the carried high-batch empirical reference at a fixed 5000-step horizon.
+- Hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff` to 256 should test whether the Phase-2 batch-side gain transfers across the compact geometry set.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Raise effective batch to `B_eff=256` without changing the carried Muon LR or beta surface.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `d788d8328141bedffd258acd3393ef7087e3c906ed36df06bd0f618fd56f7baa`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `144x4` with carried high-batch empirical reference.
+  - Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and only raise `B_eff` to 256.
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 7. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the linear LR/batch Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+- Rationale: Compact Muon training-dynamics selector row for `144x4` using the linear LR/batch prescription at a fixed 5000-step horizon.
+- Hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription may outperform the carried high-batch reference without reopening geometry.
+- Upstream delta: This row applies the simplest defended high-batch optimizer invariant to the corrected NS-winner geometry so the selector can decide whether `144x4` wants a new dynamics contract before any later Phase-2B rerun.
+- Anchor delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription `eta ∝ B`.
+- Expected effect: If `eta proportional to batch` is a better organizing invariant than pure carry-forward at `144x4`, this row should improve corrected benchmark quality enough to stay on the Pareto frontier.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `31d415ca121d3bd94a067bd33fb7d11a278f3492933bd46bd6fa5872d22049af`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - `weight_decay=0.01` stays frozen while batch and LR move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `144x4` with linear LR/batch prescription.
+  - Literature-backed selector row: test the first defended invariant `eta ∝ B` under fixed corpus and fixed weight decay.
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 8. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the momentum-timescale Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
+- Rationale: Compact Muon training-dynamics selector row for `144x4` using the momentum-timescale prescription at a fixed 5000-step horizon.
+- Hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping `B(1-beta1)` approximately constant at high batch may outperform the plain linear LR/batch row.
+- Upstream delta: This row is the second invariant-backed training-dynamics probe for the corrected NS-winner geometry, testing whether a longer effective momentum timescale gives a cleaner high-batch transfer than the linear LR/batch rule.
+- Anchor delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale variant with `beta1=0.975`.
+- Expected effect: If momentum-timescale coupling is the better invariant on `144x4`, this row should outperform the linear LR/batch `144x4` prescription at comparable high-batch wall time.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `31d415ca121d3bd94a067bd33fb7d11a278f3492933bd46bd6fa5872d22049af`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.975, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - `weight_decay=0.01` stays frozen while LR and momentum move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `144x4` with momentum-timescale prescription.
+  - Literature-backed selector row: test a timescale-style invariant by pairing high batch with `beta1=0.975` while keeping `beta2=0.95`.
+  - This row is still selector evidence only; do not promote it into a larger-family law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 9. `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run the corrected overall Muon Phase-2 winner geometry `264x6` at the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward contract.
+- Rationale: Compact Muon training-dynamics selector row for `264x6` using the carried low-batch baseline at a fixed 5000-step horizon.
+- Hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step endpoint gives the compact time-efficient selector baseline.
+- Upstream delta: Corrected Muon Phase 2 showed that `264x6` only wins once effective batch is pushed up; this row measures the larger geometry’s low-batch floor inside the compact selector so the later high-batch gain can be interpreted cleanly.
+- Anchor delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as the selector baseline.
+- Expected effect: If `264x6` is genuinely under-optimized at low batch, this row should underperform the high-batch `264x6` rows and justify training-dynamics-first sequencing over immediate larger-family reopen.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `f827b6780fc6bf418ddc836c458638901244403df61fcd6c23148eba212584f0`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `264x6` with carried low-batch baseline.
+  - Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64` (`task_batch_size=16`, `grad_accum_steps=4`).
+  - This row exists to quantify the quality/time floor before any higher-batch or literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 10. `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `264x6` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Compact Muon training-dynamics selector row for `264x6` using the carried high-batch empirical reference at a fixed 5000-step horizon.
+- Hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff` to 256 should test whether the Phase-2 batch-side gain transfers across the compact geometry set.
+- Upstream delta: This row carries forward the corrected Phase-2 result that made `264x6` the best overall row, but now inside the compact selector where quality is judged jointly with training time.
+- Anchor delta: Raise effective batch to `B_eff=256` without changing the carried Muon LR or beta surface.
+- Expected effect: If the corrected Phase-2 high-batch gain is robust enough to survive the selector replay, this row should stay on the corrected quality/time Pareto frontier and justify keeping `264x6` in later Phase-2B planning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `2600b55293a704b039f05de7486db9377acc90231d0ad52433d0b5a231bab53f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `264x6` with carried high-batch empirical reference.
+  - Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and only raise `B_eff` to 256.
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 11. `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the linear LR/batch Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+- Rationale: Compact Muon training-dynamics selector row for `264x6` using the linear LR/batch prescription at a fixed 5000-step horizon.
+- Hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription may outperform the carried high-batch reference without reopening geometry.
+- Upstream delta: This row asks whether the larger corrected winner geometry wants the simple `eta proportional to batch` prescription strongly enough to beat the empirical carry-forward contract once quality and time are judged together.
+- Anchor delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription `eta ∝ B`.
+- Expected effect: If linear LR scaling is the better invariant for the larger geometry, this row should improve corrected benchmark quality enough to remain Pareto-admissible despite the geometry’s higher training cost.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `d0291fe363bc08a66ae43f4aebfa1ce01f75a221b3f3b1c6438c9aae4c5aff31`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - `weight_decay=0.01` stays frozen while batch and LR move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `264x6` with linear LR/batch prescription.
+  - Literature-backed selector row: test the first defended invariant `eta ∝ B` under fixed corpus and fixed weight decay.
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 12. `delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Test the momentum-timescale Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
+- Rationale: Compact Muon training-dynamics selector row for `264x6` using the momentum-timescale prescription at a fixed 5000-step horizon.
+- Hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping `B(1-beta1)` approximately constant at high batch may outperform the plain linear LR/batch row.
+- Upstream delta: This row is the second invariant-backed high-batch probe for the larger corrected winner geometry, testing whether a longer momentum timescale produces a better kept dynamics contract than simple linear LR scaling.
+- Anchor delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale variant with `beta1=0.975`.
+- Expected effect: If momentum-timescale coupling is the better organizing invariant for the larger geometry, this row should beat the linear LR/batch `264x6` prescription on corrected benchmark quality at comparable wall time.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `d0291fe363bc08a66ae43f4aebfa1ce01f75a221b3f3b1c6438c9aae4c5aff31`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.975, 0.95], 'min_lr': 4e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.004, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Parameter adequacy plan:
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - `weight_decay=0.01` stays frozen while LR and momentum move together
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Selector geometry `264x6` with momentum-timescale prescription.
+  - Literature-backed selector row: test a timescale-style invariant by pairing high batch with `beta1=0.975` while keeping `beta2=0.95`.
+  - This row is still selector evidence only; do not promote it into a larger-family law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`; historical schedulefree TF-RD-009 remains preserved context only.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/queue.yaml
@@ -1,0 +1,1377 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
+rows:
+- order: 1
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 4
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `128x2` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 2
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `128x2` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 3
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription
+    may outperform the carried high-batch reference without reopening geometry.
+  anchor_delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription
+    `eta ∝ B`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `128x2` with linear LR/batch prescription.
+  - 'Literature-backed selector row: test the first defended invariant `eta ∝ B` under
+    fixed corpus and fixed weight decay.'
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 4
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `128x2` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 5
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `144x4` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 6
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `144x4` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 7
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription
+    may outperform the carried high-batch reference without reopening geometry.
+  anchor_delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription
+    `eta ∝ B`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `144x4` with linear LR/batch prescription.
+  - 'Literature-backed selector row: test the first defended invariant `eta ∝ B` under
+    fixed corpus and fixed weight decay.'
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 8
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `144x4` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 9
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `264x6` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 10
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `264x6` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 11
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: Under fixed corpus and fixed weight decay, a first-pass `eta ∝ B` prescription
+    may outperform the carried high-batch reference without reopening geometry.
+  anchor_delta: Keep `B_eff=256` and test the literature-backed linear LR/batch prescription
+    `eta ∝ B`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `264x6` with linear LR/batch prescription.
+  - 'Literature-backed selector row: test the first defended invariant `eta ∝ B` under
+    fixed corpus and fixed weight decay.'
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+- order: 12
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `264x6` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml
@@ -275,7 +275,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -650,7 +650,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -1024,7 +1024,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -1399,7 +1399,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -1772,7 +1772,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2144,7 +2144,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2516,7 +2516,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2890,7 +2890,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -3264,7 +3264,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -3637,7 +3637,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -4009,7 +4009,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -4383,7 +4383,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml
@@ -1,0 +1,4535 @@
+schema: tab-foundry-system-delta-resolved-queue-v1
+generated_from_sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
+catalog_path: reference/system_delta_catalog.yaml
+canonical_sweep_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/sweep.yaml
+canonical_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/queue.yaml
+canonical_matrix_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/matrix.md
+sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
+parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+sweep_status: draft
+complexity_level: classification_md
+anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+surface_role: classification_training_dynamics_selector
+comparison_policy: anchor_only
+upstream_reference:
+  name: PerceiverIO
+  model_source: https://openreview.net/forum?id=fILj7WpI-g
+anchor_surface:
+  notes:
+  - 'PR #280 closed the corrected Muon Phase-2 study as a directional `L(N,S)` result,
+    not a stable compute-optimal law surface.'
+  - 'The next defended TF-RD-009 move is cleanup-first navigation and contract hardening
+    under #283, then the compact training-dynamics selector under #284.'
+  - Keep `60x2` as the formal external Muon anchor from `tf_rd_009_muon_width_screen_medium_v1`,
+    but carry `128x2` as the in-family baseline into this selector.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed; historical schedulefree TF-RD-009 remains preserved context only.
+  - Rank selector rows on the quality/time Pareto frontier before any Muon Phase-2B
+    rerun or upper-family reopening.
+  dimension_table: []
+anchor_context:
+  run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup
+rows:
+- order: 1
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 4
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `128x2` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step
+    endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`)
+    as the selector floor.
+  upstream_delta: This is the compact endpoint selector baseline that follows corrected
+    Muon Phase 2 and the cleanup-first navigation lane; it keeps the corrected multiclass
+    benchmark contract and the `v6` training corpus fixed while measuring the carried
+    low-batch dynamics point directly.
+  entangled_legacy_stage: none
+  expected_effect: If the carried low-batch Muon surface is still on the quality/time
+    frontier after the corrected Phase-2 closeout, this row should remain the compact
+    selector floor that later higher-batch prescriptions must beat.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the `128x2` low-batch selector floor after the active Muon lineage
+      cleanup is landed.
+    - Compare directly against the high-batch and literature-backed `128x2` prescriptions
+      on corrected benchmark loss and end-to-end train wall time.
+    - Carry forward only if the corrected Pareto frontier still prefers the low-batch
+      contract once the selector is complete.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 128
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 2
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 2
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 63f4e190b563f9ecc902d6baa68d10a621f95685f210fff34ad80e76e3a29f94
+- order: 2
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `128x2` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint
+    with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`)
+    and the original Muon LR/beta surface unchanged.
+  upstream_delta: Corrected Muon Phase 2 showed that batch-side movement dominated
+    geometry-only movement; this row tests whether the measured high-batch gain transfers
+    to the compact `128x2` selector geometry without opening the optimizer prescription
+    yet.
+  entangled_legacy_stage: none
+  expected_effect: If the Phase-2 batch-side gain transfers cleanly, this row should
+    beat or match the low-batch `128x2` floor at acceptable extra training time and
+    justify keeping high-batch dynamics in the next law-conditioning lane.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - high-batch empirical reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `128x2`.
+    - Compare directly against the low-batch `128x2` row on corrected benchmark loss,
+      throughput, and wall time.
+    - Keep this contract only if the measured gain justifies the time cost before
+      any later Phase-2B rerun.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 128
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 2
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 2
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 10a9234a87808903bf9a2ccaabe0073e5dc4af95b5c9857f2b9d90a1b04cc29e
+- order: 3
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: "Under fixed corpus and fixed weight decay, a first-pass `eta \u221D\
+    \ B` prescription may outperform the carried high-batch reference without reopening\
+    \ geometry."
+  anchor_delta: "Keep `B_eff=256` and test the literature-backed linear LR/batch prescription\
+    \ `eta \u221D B`."
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `128x2` with linear LR/batch prescription.
+  - "Literature-backed selector row: test the first defended invariant `eta \u221D\
+    \ B` under fixed corpus and fixed weight decay."
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the literature-backed linear LR/batch prescription on `128x2`
+    at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping
+    `betas=(0.9, 0.95)` and `weight_decay=0.01`.
+  upstream_delta: This row encodes the first defended optimizer-timescale variant
+    for the compact selector after corrected Muon Phase 2, testing the simplest `eta
+    proportional to batch` prescription under the fixed corpus, benchmark, and horizon
+    contract.
+  entangled_legacy_stage: none
+  expected_effect: If the corrected Muon surface follows the linear LR/batch invariant
+    closely enough, this row should improve quality at the high-batch endpoint without
+    requiring a separate geometry change.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - '`weight_decay=0.01` stays frozen while batch and LR move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the first literature-backed high-batch prescription for `128x2`.
+    - Compare directly against both carried `128x2` rows to test whether linear LR
+      scaling is a better kept invariant than the pure carry-forward contract.
+    - Promote only if it lands on the corrected quality/time Pareto frontier.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 128
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 2
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 2
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 06b20c3067b9dac0deb69aaec88af3cfd1f6e44736f5971b398a40c0cb91b0ea
+- order: 4
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `128x2` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    d_icl: 128
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_layers: 2
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        grad_accum_steps: 16
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        max_steps: 5000
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `128x2` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the momentum-timescale Muon selector prescription on `128x2` at
+    `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising `beta1`
+    to `0.975`.
+  upstream_delta: Corrected Muon Phase 2 justified training-dynamics-first work; this
+    row is the second defended invariant-backed probe, testing whether a larger effective
+    momentum timescale transfers better than simple linear LR scaling on the compact
+    selector geometry.
+  entangled_legacy_stage: none
+  expected_effect: If momentum-timescale coupling matters on the corrected Muon surface,
+    this row should outperform the linear LR/batch prescription at comparable wall
+    time on `128x2`.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - '`weight_decay=0.01` stays frozen while LR and momentum move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the momentum-timescale comparator for the `128x2` selector geometry.
+    - Compare directly against the carried high-batch and linear LR/batch `128x2`
+      rows.
+    - Promote only if the corrected benchmark gain is real enough to justify the additional
+      training-time cost.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 128
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 2
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 2
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 06b20c3067b9dac0deb69aaec88af3cfd1f6e44736f5971b398a40c0cb91b0ea
+- order: 5
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `144x4` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run the corrected Muon NS winner geometry `144x4` at the fixed 5000-step
+    endpoint with the carried low-batch `B_eff=64` contract.
+  upstream_delta: Corrected Muon Phase 2 showed that `144x4` is the best NS geometry
+    while `264x6` only wins after batch tuning; this row carries the NS winner into
+    the compact training-dynamics selector without changing the geometry.
+  entangled_legacy_stage: none
+  expected_effect: "If `144x4` remains the best compact geometry under the selector\
+    \ contract, this low-batch row should establish the geometry\u2019s time-efficient\
+    \ frontier point before any higher-batch or literature-backed prescription is\
+    \ kept."
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the `144x4` low-batch selector floor.
+    - Compare against the corresponding high-batch and literature-backed `144x4` rows
+      plus the carried `128x2` floor.
+    - Keep the geometry only if at least one `144x4` dynamics contract stays on the
+      corrected Pareto frontier.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d
+- order: 6
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `144x4` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch
+    `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+  upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side
+    gain also improves the `144x4` NS winner when geometry is held fixed.
+  entangled_legacy_stage: none
+  expected_effect: If batch-side movement generalizes across the compact frontier,
+    this row should improve `144x4` materially enough to challenge the carried low-batch
+    point on the corrected quality/time frontier.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `144x4`.
+    - Compare directly against the `144x4` low-batch floor and the two literature-backed
+      `144x4` prescriptions.
+    - Keep this contract only if the corrected gain is large enough to offset the
+      extra train time.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: d788d8328141bedffd258acd3393ef7087e3c906ed36df06bd0f618fd56f7baa
+- order: 7
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: "Under fixed corpus and fixed weight decay, a first-pass `eta \u221D\
+    \ B` prescription may outperform the carried high-batch reference without reopening\
+    \ geometry."
+  anchor_delta: "Keep `B_eff=256` and test the literature-backed linear LR/batch prescription\
+    \ `eta \u221D B`."
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `144x4` with linear LR/batch prescription.
+  - "Literature-backed selector row: test the first defended invariant `eta \u221D\
+    \ B` under fixed corpus and fixed weight decay."
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the linear LR/batch Muon selector prescription on `144x4` at `B_eff=256`
+    with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+  upstream_delta: This row applies the simplest defended high-batch optimizer invariant
+    to the corrected NS-winner geometry so the selector can decide whether `144x4`
+    wants a new dynamics contract before any later Phase-2B rerun.
+  entangled_legacy_stage: none
+  expected_effect: If `eta proportional to batch` is a better organizing invariant
+    than pure carry-forward at `144x4`, this row should improve corrected benchmark
+    quality enough to stay on the Pareto frontier.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - '`weight_decay=0.01` stays frozen while batch and LR move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the first literature-backed high-batch prescription for `144x4`.
+    - Compare directly against both carried `144x4` rows and the momentum-timescale
+      `144x4` variant.
+    - Promote only if it lands on the corrected quality/time Pareto frontier.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 31d415ca121d3bd94a067bd33fb7d11a278f3492933bd46bd6fa5872d22049af
+- order: 8
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `144x4` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `144x4` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the momentum-timescale Muon selector prescription on `144x4` at
+    `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and
+    `weight_decay=0.01`.
+  upstream_delta: This row is the second invariant-backed training-dynamics probe
+    for the corrected NS-winner geometry, testing whether a longer effective momentum
+    timescale gives a cleaner high-batch transfer than the linear LR/batch rule.
+  entangled_legacy_stage: none
+  expected_effect: If momentum-timescale coupling is the better invariant on `144x4`,
+    this row should outperform the linear LR/batch `144x4` prescription at comparable
+    high-batch wall time.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - '`weight_decay=0.01` stays frozen while LR and momentum move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the momentum-timescale comparator for `144x4`.
+    - Compare directly against the carried high-batch and linear LR/batch `144x4`
+      rows.
+    - Promote only if the corrected gain is large enough to justify the same or higher
+      wall time.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 31d415ca121d3bd94a067bd33fb7d11a278f3492933bd46bd6fa5872d22049af
+- order: 9
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the carried
+    low-batch baseline at a fixed 5000-step horizon.
+  hypothesis: Re-running the carried low-batch Muon surface at the fixed 5000-step
+    endpoint gives the compact time-efficient selector baseline.
+  anchor_delta: Keep the carried Muon optimizer/runtime surface and `B_eff=64` as
+    the selector baseline.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this low-batch endpoint row and rank it on the corrected
+    medium loss/time Pareto frontier before any larger-family work.
+  notes:
+  - Selector geometry `264x6` with carried low-batch baseline.
+  - 'Selector baseline row: keep the carried Muon optimizer surface and `B_eff=64`
+    (`task_batch_size=16`, `grad_accum_steps=4`).'
+  - This row exists to quantify the quality/time floor before any higher-batch or
+    literature-backed prescription is admitted.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run the corrected overall Muon Phase-2 winner geometry `264x6` at
+    the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward contract.
+  upstream_delta: "Corrected Muon Phase 2 showed that `264x6` only wins once effective\
+    \ batch is pushed up; this row measures the larger geometry\u2019s low-batch floor\
+    \ inside the compact selector so the later high-batch gain can be interpreted\
+    \ cleanly."
+  entangled_legacy_stage: none
+  expected_effect: If `264x6` is genuinely under-optimized at low batch, this row
+    should underperform the high-batch `264x6` rows and justify training-dynamics-first
+    sequencing over immediate larger-family reopen.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+  - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the `264x6` low-batch floor so the selector can separate geometry
+      size from optimization effects.
+    - Compare directly against the corresponding high-batch and literature-backed
+      `264x6` rows plus the compact `128x2` and `144x4` candidates.
+    - Keep the larger geometry only if at least one `264x6` dynamics contract justifies
+      its time cost on the corrected Pareto frontier.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 264
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 6
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 6
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: f827b6780fc6bf418ddc836c458638901244403df61fcd6c23148eba212584f0
+- order: 10
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the carried
+    high-batch empirical reference at a fixed 5000-step horizon.
+  hypothesis: Holding the carried Muon optimizer surface fixed while raising `B_eff`
+    to 256 should test whether the Phase-2 batch-side gain transfers across the compact
+    geometry set.
+  anchor_delta: Raise effective batch to `B_eff=256` without changing the carried
+    Muon LR or beta surface.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this high-batch carried reference and compare it against
+    the low-batch row on the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `264x6` with carried high-batch empirical reference.
+  - 'Empirical carry-forward row: keep the measured Muon LR/beta surface fixed and
+    only raise `B_eff` to 256.'
+  - This row tests whether the corrected Phase-2 batch-side gain transfers cleanly
+    across the compact geometry set.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run `264x6` at the fixed 5000-step endpoint with the empirical high-batch
+    `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+  upstream_delta: This row carries forward the corrected Phase-2 result that made
+    `264x6` the best overall row, but now inside the compact selector where quality
+    is judged jointly with training time.
+  entangled_legacy_stage: none
+  expected_effect: If the corrected Phase-2 high-batch gain is robust enough to survive
+    the selector replay, this row should stay on the corrected quality/time Pareto
+    frontier and justify keeping `264x6` in later Phase-2B planning.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `264x6`.
+    - Compare directly against the `264x6` low-batch floor and both literature-backed
+      `264x6` prescriptions.
+    - Keep this contract only if the corrected gain remains large enough to justify
+      its wall-time cost.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 264
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 6
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 6
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 2600b55293a704b039f05de7486db9377acc90231d0ad52433d0b5a231bab53f
+- order: 11
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the linear
+    LR/batch prescription at a fixed 5000-step horizon.
+  hypothesis: "Under fixed corpus and fixed weight decay, a first-pass `eta \u221D\
+    \ B` prescription may outperform the carried high-batch reference without reopening\
+    \ geometry."
+  anchor_delta: "Keep `B_eff=256` and test the literature-backed linear LR/batch prescription\
+    \ `eta \u221D B`."
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this linear LR/batch row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier.
+  notes:
+  - Selector geometry `264x6` with linear LR/batch prescription.
+  - "Literature-backed selector row: test the first defended invariant `eta \u221D\
+    \ B` under fixed corpus and fixed weight decay."
+  - Do not reinterpret this row as an optimizer scaling law claim; it is a compact
+    selector candidate for the next Muon contract.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the linear LR/batch Muon selector prescription on `264x6` at `B_eff=256`
+    with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+  upstream_delta: This row asks whether the larger corrected winner geometry wants
+    the simple `eta proportional to batch` prescription strongly enough to beat the
+    empirical carry-forward contract once quality and time are judged together.
+  entangled_legacy_stage: none
+  expected_effect: "If linear LR scaling is the better invariant for the larger geometry,\
+    \ this row should improve corrected benchmark quality enough to remain Pareto-admissible\
+    \ despite the geometry\u2019s higher training cost."
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with linear LR scaling
+  - '`weight_decay=0.01` stays frozen while batch and LR move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the first literature-backed high-batch prescription for `264x6`.
+    - Compare directly against both carried `264x6` rows and the momentum-timescale
+      `264x6` variant.
+    - Promote only if it stays on the corrected quality/time Pareto frontier.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 264
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 6
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 6
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: d0291fe363bc08a66ae43f4aebfa1ce01f75a221b3f3b1c6438c9aae4c5aff31
+- order: 12
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1
+  status: ready
+  rationale: Compact Muon training-dynamics selector row for `264x6` using the momentum-timescale
+    prescription at a fixed 5000-step horizon.
+  hypothesis: If the batch-side Phase-2 gain reflects a timescale effect, keeping
+    `B(1-beta1)` approximately constant at high batch may outperform the plain linear
+    LR/batch row.
+  anchor_delta: Keep `B_eff=256`, raise LR with batch, and test a momentum-timescale
+    variant with `beta1=0.975`.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 264
+    sandwich_layers: 6
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.975
+        - 0.95
+        min_lr: 4.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.004
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 1280000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan: []
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this momentum-timescale row and keep it only if it improves
+    the corrected medium loss/time Pareto frontier versus the simpler high-batch rows.
+  notes:
+  - Selector geometry `264x6` with momentum-timescale prescription.
+  - 'Literature-backed selector row: test a timescale-style invariant by pairing high
+    batch with `beta1=0.975` while keeping `beta2=0.95`.'
+  - This row is still selector evidence only; do not promote it into a larger-family
+    law claim without the later Phase-2B rerun.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed across the selector lane.
+  - This selector is downstream of cleanup issue `#283` and execution issue `#284`;
+    historical schedulefree TF-RD-009 remains preserved context only.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Test the momentum-timescale Muon selector prescription on `264x6` at
+    `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and
+    `weight_decay=0.01`.
+  upstream_delta: This row is the second invariant-backed high-batch probe for the
+    larger corrected winner geometry, testing whether a longer momentum timescale
+    produces a better kept dynamics contract than simple linear LR scaling.
+  entangled_legacy_stage: none
+  expected_effect: If momentum-timescale coupling is the better organizing invariant
+    for the larger geometry, this row should beat the linear LR/batch `264x6` prescription
+    on corrected benchmark quality at comparable wall time.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - high-batch `B_eff=256` endpoint with `beta1=0.975`
+  - '`weight_decay=0.01` stays frozen while LR and momentum move together'
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the momentum-timescale comparator for `264x6`.
+    - Compare directly against the carried high-batch and linear LR/batch `264x6`
+      rows.
+    - "Promote only if the corrected gain is real enough to justify the larger geometry\u2019\
+      s time cost."
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 264
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 6
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 6
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.004
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: d0291fe363bc08a66ae43f4aebfa1ce01f75a221b3f3b1c6438c9aae4c5aff31
+canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/resolved_queue.yaml
+inputs_fingerprint: de30d58f0cbf8ffb299d5f2670f2152987dfc7017dc6cd16289ab2b63d891b6e

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_endpoint_medium_v1/sweep.yaml
@@ -1,0 +1,44 @@
+schema: tab-foundry-system-delta-sweep-v1
+sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
+parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+status: draft
+complexity_level: classification_md
+anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+surface_role: classification_training_dynamics_selector
+comparison_policy: anchor_only
+upstream_reference:
+  name: PerceiverIO
+  model_source: https://openreview.net/forum?id=fILj7WpI-g
+anchor_surface:
+  notes:
+  - 'PR #280 closed the corrected Muon Phase-2 study as a directional `L(N,S)` result,
+    not a stable compute-optimal law surface.'
+  - 'The next defended TF-RD-009 move is cleanup-first navigation and contract hardening
+    under #283, then the compact training-dynamics selector under #284.'
+  - Keep `60x2` as the formal external Muon anchor from `tf_rd_009_muon_width_screen_medium_v1`,
+    but carry `128x2` as the in-family baseline into this selector.
+  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
+    corpus fixed; historical schedulefree TF-RD-009 remains preserved context only.
+  - Rank selector rows on the quality/time Pareto frontier before any Muon Phase-2B
+    rerun or upper-family reopening.
+  dimension_table: []
+anchor_context:
+  run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup

--- a/src/tab_foundry/cli/research_sweep_core.py
+++ b/src/tab_foundry/cli/research_sweep_core.py
@@ -24,9 +24,13 @@ from tab_foundry.research.sweep import matrix as sweep_matrix
 
 def _run_list_sweeps(*, index_path: Path) -> int:
     for sweep_info in sweep_manage.list_sweeps(index_path=index_path):
+        depth = int(sweep_info.get("depth", 0))
+        tree_prefix = f"{'  ' * depth}{'└─ ' if depth else ''}"
         print(
-            f"{sweep_info['sweep_id']}  {sweep_info['status']:<8}  "
-            f"{sweep_info['complexity_level']:<16}  anchor={sweep_info['anchor_run_id']}"
+            f"{tree_prefix}{sweep_info['sweep_id']}  {sweep_info['status']:<8}  "
+            f"{sweep_info['complexity_level']:<16}  "
+            f"anchor={sweep_info['anchor_run_id']}  "
+            f"baseline={sweep_info['control_baseline_id']}"
         )
     return 0
 

--- a/src/tab_foundry/research/navigation.py
+++ b/src/tab_foundry/research/navigation.py
@@ -1,0 +1,428 @@
+"""Shared sweep/scaling navigation and contract summaries."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+from tab_foundry.research.scaling.study import ScalingStudyConfig, default_scaling_studies_root, load_scaling_study_config
+from tab_foundry.research.sweep.catalog import load_system_delta_index_payload
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+
+
+def _optional_string(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return str(value).strip()
+
+
+def _row_corpus_ref(row: Mapping[str, Any]) -> str | None:
+    data = row.get("data")
+    if not isinstance(data, Mapping):
+        return None
+    corpus_ref = _optional_string(data.get("corpus_ref"))
+    if corpus_ref is not None:
+        return corpus_ref
+    surface_overrides = data.get("surface_overrides")
+    if not isinstance(surface_overrides, Mapping):
+        return None
+    return _optional_string(surface_overrides.get("corpus_ref"))
+
+
+def _unique_corpus_refs(rows: Sequence[Any]) -> list[str]:
+    return sorted(
+        {
+            corpus_ref
+            for row in rows
+            if isinstance(row, Mapping)
+            for corpus_ref in [_row_corpus_ref(row)]
+            if corpus_ref is not None
+        }
+    )
+
+
+def _winner_from_rows(rows: Sequence[Any]) -> dict[str, Any] | None:
+    candidates: list[Mapping[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("status", "")).strip() != "completed":
+            continue
+        metrics = row.get("benchmark_metrics")
+        if not isinstance(metrics, Mapping):
+            continue
+        if metrics.get("final_log_loss") is None:
+            continue
+        candidates.append(row)
+    if not candidates:
+        return None
+    best = min(candidates, key=lambda row: float(cast(Mapping[str, Any], row["benchmark_metrics"])["final_log_loss"]))
+    best_metrics = cast(Mapping[str, Any], best["benchmark_metrics"])
+    model = cast(Mapping[str, Any], best.get("model", {}))
+    geometry_label = None
+    if model.get("d_icl") is not None and model.get("sandwich_layers") is not None:
+        geometry_label = f"{int(model['d_icl'])}x{int(model['sandwich_layers'])}"
+    return {
+        "order": int(best["order"]),
+        "delta_ref": str(best.get("delta_ref", best.get("delta_id", ""))),
+        "run_id": _optional_string(best.get("run_id")),
+        "geometry_label": geometry_label,
+        "benchmark_log_loss": float(best_metrics["final_log_loss"]),
+        "throughput_tokens_per_second": (
+            None
+            if best_metrics.get("throughput_tokens_per_second") is None
+            else float(best_metrics["throughput_tokens_per_second"])
+        ),
+        "end_to_end_wall_seconds": (
+            None
+            if best_metrics.get("end_to_end_wall_seconds") is None
+            else float(best_metrics["end_to_end_wall_seconds"])
+        ),
+        "tokens_per_step": (
+            None if best_metrics.get("tokens_per_step") is None else float(best_metrics["tokens_per_step"])
+        ),
+        "steps": None if best_metrics.get("best_step") is None else int(best_metrics["best_step"]),
+    }
+
+
+def _winner_from_points(points: Sequence[Any]) -> dict[str, Any] | None:
+    if not points:
+        return None
+    best = min(points, key=lambda point: float(point.benchmark_log_loss))
+    return {
+        "family": str(best.family),
+        "sweep_id": str(best.sweep_id),
+        "row_order": int(best.row_order),
+        "row_label": str(best.row_label),
+        "run_id": str(best.run_id),
+        "geometry_label": f"{int(best.d_icl)}x{int(best.layers)}",
+        "benchmark_log_loss": float(best.benchmark_log_loss),
+        "validation_loss": None if best.validation_loss is None else float(best.validation_loss),
+        "throughput_tokens_per_second": (
+            None
+            if getattr(best, "throughput_tokens_per_second", None) is None
+            else float(best.throughput_tokens_per_second)
+        ),
+        "end_to_end_wall_seconds": (
+            None
+            if getattr(best, "end_to_end_wall_seconds", None) is None
+            else float(best.end_to_end_wall_seconds)
+        ),
+        "tokens_per_step": float(best.tokens_per_step),
+        "steps": int(best.steps),
+    }
+
+
+def sweep_lineage_entries(*, sweep_id: str, index_path: Path | None = None) -> list[dict[str, Any]]:
+    index = load_system_delta_index_payload(index_path)
+    lineage_reversed: list[dict[str, Any]] = []
+    current_id = str(sweep_id)
+    seen: set[str] = set()
+    while current_id:
+        if current_id in seen:
+            raise RuntimeError(f"cycle detected in sweep lineage for {sweep_id!r}")
+        seen.add(current_id)
+        sweep_info = index.sweeps.get(current_id)
+        if sweep_info is None:
+            raise RuntimeError(f"unknown sweep in lineage: {current_id!r}")
+        lineage_reversed.append(
+            {
+                "sweep_id": current_id,
+                "parent_sweep_id": _optional_string(sweep_info.parent_sweep_id),
+                "status": str(sweep_info.status),
+                "complexity_level": str(sweep_info.complexity_level),
+                "anchor_run_id": _optional_string(sweep_info.anchor_run_id),
+            }
+        )
+        parent_id = _optional_string(sweep_info.parent_sweep_id)
+        if parent_id is None:
+            break
+        current_id = parent_id
+    lineage = list(reversed(lineage_reversed))
+    for depth, entry in enumerate(lineage):
+        entry["depth"] = depth
+    return lineage
+
+
+def list_sweep_tree_entries(*, index_path: Path | None = None) -> list[dict[str, Any]]:
+    index = load_system_delta_index_payload(index_path)
+    children: dict[str | None, list[str]] = defaultdict(list)
+    for sweep_id, sweep_info in index.sweeps.items():
+        children[_optional_string(sweep_info.parent_sweep_id)].append(str(sweep_id))
+    for child_ids in children.values():
+        child_ids.sort()
+    ordered: list[dict[str, Any]] = []
+
+    def _visit(sweep_id: str, *, depth: int) -> None:
+        sweep_info = index.sweeps[sweep_id]
+        lineage = sweep_lineage_entries(sweep_id=sweep_id, index_path=index_path)
+        ordered.append(
+            {
+                "sweep_id": sweep_id,
+                "parent_sweep_id": _optional_string(sweep_info.parent_sweep_id),
+                "status": str(sweep_info.status),
+                "complexity_level": str(sweep_info.complexity_level),
+                "anchor_run_id": _optional_string(sweep_info.anchor_run_id),
+                "benchmark_manifest_path": str(sweep_info.benchmark_manifest_path),
+                "control_baseline_id": str(sweep_info.control_baseline_id),
+                "depth": depth,
+                "lineage": lineage,
+                "child_sweep_ids": list(children.get(sweep_id, [])),
+            }
+        )
+        for child_sweep_id in children.get(sweep_id, []):
+            _visit(child_sweep_id, depth=depth + 1)
+
+    for root_sweep_id in children.get(None, []):
+        _visit(root_sweep_id, depth=0)
+    return ordered
+
+
+def _scan_linked_scaling_studies(*, sweep_id: str, studies_root: Path | None = None) -> list[str]:
+    root = (
+        studies_root.expanduser().resolve()
+        if studies_root is not None
+        else default_scaling_studies_root()
+    )
+    if not root.exists():
+        return []
+    linked: list[str] = []
+    for study_path in sorted(root.glob("*.yaml")):
+        try:
+            config = load_scaling_study_config(study_path=study_path)
+        except RuntimeError:
+            continue
+        if any(ref.sweep_id == sweep_id for ref in config.sweeps):
+            linked.append(config.study_id)
+            continue
+        if config.phase1_reference_sweep_id == sweep_id:
+            linked.append(config.study_id)
+    return linked
+
+
+def validate_sweep_contract(
+    *,
+    queue: Mapping[str, Any],
+    index_path: Path | None = None,
+) -> list[str]:
+    issues: list[str] = []
+    index = load_system_delta_index_payload(index_path)
+    sweep_id = str(queue["sweep_id"])
+    index_entry = index.sweeps.get(sweep_id)
+    if index_entry is None:
+        issues.append(f"sweep {sweep_id!r} is missing from the sweep index")
+        return issues
+    for key in (
+        "anchor_run_id",
+        "complexity_level",
+        "benchmark_manifest_path",
+        "control_baseline_id",
+    ):
+        queue_value = _optional_string(queue.get(key))
+        index_value = _optional_string(getattr(index_entry, key))
+        if queue_value != index_value:
+            issues.append(
+                f"{sweep_id}: {key} mismatch between queue metadata ({queue_value!r}) "
+                f"and index ({index_value!r})"
+            )
+    anchor_context = queue.get("anchor_context")
+    if isinstance(anchor_context, Mapping):
+        anchor_context_run_id = _optional_string(anchor_context.get("run_id"))
+        queue_anchor_run_id = _optional_string(queue.get("anchor_run_id"))
+        if anchor_context_run_id != queue_anchor_run_id:
+            issues.append(
+                f"{sweep_id}: anchor_context.run_id {anchor_context_run_id!r} does not match "
+                f"anchor_run_id {queue_anchor_run_id!r}"
+            )
+    return issues
+
+
+def build_sweep_navigation_payload(
+    *,
+    queue: Mapping[str, Any],
+    index_path: Path | None = None,
+    studies_root: Path | None = None,
+) -> dict[str, Any]:
+    rows = cast(Sequence[Any], queue.get("rows", []))
+    corpus_refs = _unique_corpus_refs(rows)
+    return {
+        "lineage": sweep_lineage_entries(sweep_id=str(queue["sweep_id"]), index_path=index_path),
+        "linked_scaling_study_ids": _scan_linked_scaling_studies(
+            sweep_id=str(queue["sweep_id"]),
+            studies_root=studies_root,
+        ),
+        "contract": {
+            "benchmark_manifest_path": str(queue["benchmark_manifest_path"]),
+            "control_baseline_id": str(queue["control_baseline_id"]),
+            "external_benchmarks": list(cast(Sequence[Any], queue.get("external_benchmarks", []))),
+            "training_experiment": str(queue["training_experiment"]),
+            "training_config_profile": str(queue["training_config_profile"]),
+            "surface_role": str(queue["surface_role"]),
+            "comparison_policy": str(queue["comparison_policy"]),
+            "formal_external_reference": (
+                dict(cast(Mapping[str, Any], queue["upstream_reference"]))
+                if isinstance(queue.get("upstream_reference"), Mapping)
+                else None
+            ),
+            "carried_in_family_baseline_run_id": _optional_string(queue.get("anchor_run_id")),
+            "anchor_context_surface_labels": (
+                dict(cast(Mapping[str, Any], cast(Mapping[str, Any], queue["anchor_context"])["surface_labels"]))
+                if isinstance(queue.get("anchor_context"), Mapping)
+                and isinstance(cast(Mapping[str, Any], queue["anchor_context"]).get("surface_labels"), Mapping)
+                else None
+            ),
+            "corpus_ref": corpus_refs[0] if len(corpus_refs) == 1 else None,
+            "corpus_refs": corpus_refs,
+        },
+        "winner": _winner_from_rows(rows),
+        "contract_issues": validate_sweep_contract(queue=queue, index_path=index_path),
+    }
+
+
+def _expected_family_counts(config: ScalingStudyConfig) -> dict[str, int | None]:
+    counts: dict[str, int | None] = {}
+    for sweep_ref in config.sweeps:
+        if sweep_ref.family == "ns_core":
+            counts[sweep_ref.family] = len(config.geometry_row_labels) * len(config.step_ladder)
+        elif sweep_ref.family == "batch_critical":
+            counts[sweep_ref.family] = len(config.batch_grad_accum_ladder) * len(config.step_ladder)
+        else:
+            counts[sweep_ref.family] = None
+    return counts
+
+
+def build_scaling_navigation_payload(
+    *,
+    config: ScalingStudyConfig,
+    points: Sequence[Any],
+    index_path: Path,
+    catalog_path: Path,
+    sweeps_root: Path,
+) -> dict[str, Any]:
+    queues: dict[str, Mapping[str, Any]] = {}
+    for sweep_ref in config.sweeps:
+        queues[sweep_ref.sweep_id] = load_system_delta_queue(
+            sweep_id=sweep_ref.sweep_id,
+            index_path=index_path,
+            catalog_path=catalog_path,
+            sweeps_root=sweeps_root,
+        )
+    benchmark_paths = {str(queue["benchmark_manifest_path"]) for queue in queues.values()}
+    control_baselines = {str(queue["control_baseline_id"]) for queue in queues.values()}
+    anchor_run_ids = {
+        anchor_run_id
+        for queue in queues.values()
+        for anchor_run_id in [_optional_string(queue.get("anchor_run_id"))]
+        if anchor_run_id is not None
+    }
+    training_experiments = {str(queue["training_experiment"]) for queue in queues.values()}
+    training_profiles = {str(queue["training_config_profile"]) for queue in queues.values()}
+    corpus_refs = {
+        corpus_ref
+        for queue in queues.values()
+        for corpus_ref in [build_sweep_navigation_payload(queue=queue, index_path=index_path)["contract"]["corpus_ref"]]
+        if corpus_ref is not None
+    }
+    issues: list[str] = []
+    if len(benchmark_paths) != 1:
+        issues.append(f"scaling study {config.study_id}: benchmark manifest mismatch across sweeps {sorted(benchmark_paths)!r}")
+    if len(control_baselines) != 1:
+        issues.append(f"scaling study {config.study_id}: control baseline mismatch across sweeps {sorted(control_baselines)!r}")
+    if len(training_experiments) != 1:
+        issues.append(
+            f"scaling study {config.study_id}: training_experiment mismatch across sweeps {sorted(training_experiments)!r}"
+        )
+    if len(training_profiles) != 1:
+        issues.append(
+            f"scaling study {config.study_id}: training_config_profile mismatch across sweeps {sorted(training_profiles)!r}"
+        )
+    if len(anchor_run_ids) > 1:
+        issues.append(
+            f"scaling study {config.study_id}: carried baseline / anchor mismatch across sweeps {sorted(anchor_run_ids)!r}"
+        )
+    if len(corpus_refs) > 1:
+        issues.append(
+            f"scaling study {config.study_id}: corpus_ref mismatch across sweeps {sorted(corpus_refs)!r}"
+        )
+    if config.phase1_reference_sweep_id is not None:
+        for sweep_ref in config.sweeps:
+            lineage_ids = {
+                entry["sweep_id"]
+                for entry in sweep_lineage_entries(sweep_id=sweep_ref.sweep_id, index_path=index_path)
+            }
+            if config.phase1_reference_sweep_id not in lineage_ids:
+                issues.append(
+                    f"scaling study {config.study_id}: phase1_reference_sweep_id "
+                    f"{config.phase1_reference_sweep_id!r} is not in lineage for {sweep_ref.sweep_id!r}"
+                )
+    actual_counts = Counter(str(point.family) for point in points)
+    expected_counts = _expected_family_counts(config)
+    completeness: dict[str, Any] = {
+        "expected_counts_by_family": dict(expected_counts),
+        "actual_counts_by_family": dict(actual_counts),
+        "missing_counts_by_family": {
+            family: None if expected is None else max(int(expected) - int(actual_counts.get(family, 0)), 0)
+            for family, expected in expected_counts.items()
+        },
+    }
+    completeness["all_expected_points_present"] = all(
+        expected is None or int(actual_counts.get(family, 0)) == int(expected)
+        for family, expected in expected_counts.items()
+    )
+    completeness["ns_core_expected_points_present"] = all(
+        family != "ns_core" or expected is None or int(actual_counts.get(family, 0)) == int(expected)
+        for family, expected in expected_counts.items()
+    )
+    output_root = config.output_root_path()
+    fit_summary_path = output_root / "fit_summary.json"
+    audit_summary_path = output_root / "audit" / "audit_summary.json"
+    validation_overlay_path = config.validation_overlay_resolved_path()
+    linked_sweeps: list[dict[str, Any]] = []
+    for sweep_ref in config.sweeps:
+        queue = queues[sweep_ref.sweep_id]
+        linked_sweeps.append(
+            {
+                "name": sweep_ref.name,
+                "family": sweep_ref.family,
+                "sweep_id": sweep_ref.sweep_id,
+                "status": str(queue.get("status", "unknown")),
+                "lineage": sweep_lineage_entries(sweep_id=sweep_ref.sweep_id, index_path=index_path),
+                "winner": _winner_from_rows(cast(Sequence[Any], queue.get("rows", []))),
+            }
+        )
+    first_queue = next(iter(queues.values()))
+    return {
+        "linked_sweeps": linked_sweeps,
+        "contract": {
+            "benchmark_manifest_path": next(iter(benchmark_paths)) if len(benchmark_paths) == 1 else None,
+            "control_baseline_id": next(iter(control_baselines)) if len(control_baselines) == 1 else None,
+            "training_experiment": next(iter(training_experiments)) if len(training_experiments) == 1 else None,
+            "training_config_profile": next(iter(training_profiles)) if len(training_profiles) == 1 else None,
+            "corpus_ref": next(iter(corpus_refs)) if len(corpus_refs) == 1 else None,
+            "carried_in_family_baseline_run_id": next(iter(anchor_run_ids)) if len(anchor_run_ids) == 1 else None,
+            "formal_external_reference": (
+                dict(cast(Mapping[str, Any], first_queue["upstream_reference"]))
+                if isinstance(first_queue.get("upstream_reference"), Mapping)
+                else None
+            ),
+            "phase1_reference_sweep_id": config.phase1_reference_sweep_id,
+            "historical_context_studies": list(config.historical_context_studies),
+            "primary_fit": None if config.primary_fit is None else dict(config.primary_fit),
+            "frozen_contract": None if config.frozen_contract is None else dict(config.frozen_contract),
+        },
+        "winner": _winner_from_points(points),
+        "fit_audit_state": {
+            "validation_overlay_exists": bool(
+                validation_overlay_path is not None and validation_overlay_path.exists()
+            ),
+            "fit_summary_exists": fit_summary_path.exists(),
+            "audit_summary_exists": audit_summary_path.exists(),
+            "full_scope_ready": bool(completeness["all_expected_points_present"]),
+            "ns_core_ready": bool(completeness["ns_core_expected_points_present"]),
+            "fit_summary_path": str(fit_summary_path),
+            "audit_summary_path": str(audit_summary_path),
+        },
+        "completeness": completeness,
+        "contract_issues": issues,
+    }

--- a/src/tab_foundry/research/scaling/__init__.py
+++ b/src/tab_foundry/research/scaling/__init__.py
@@ -1,7 +1,5 @@
 """Scaling-study helpers."""
 
-from .audit import SCALING_AUDIT_SCHEMA, audit_scaling_study
-from .fit import collect_completed_scaling_points, fit_scaling_study, inspect_scaling_study
 from .study import (
     SCALING_STUDY_SCHEMA,
     ScalingStudyConfig,
@@ -12,15 +10,10 @@ from .study import (
 )
 
 __all__ = [
-    "SCALING_AUDIT_SCHEMA",
     "SCALING_STUDY_SCHEMA",
     "ScalingStudyConfig",
     "ScalingStudySweepRef",
-    "audit_scaling_study",
-    "collect_completed_scaling_points",
     "default_scaling_studies_root",
     "default_scaling_study_path",
-    "fit_scaling_study",
-    "inspect_scaling_study",
     "load_scaling_study_config",
 ]

--- a/src/tab_foundry/research/scaling/audit.py
+++ b/src/tab_foundry/research/scaling/audit.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Any, Callable, Literal, Mapping, Sequence
+from typing import Any, Callable, Literal, Mapping, Sequence, cast
 
 import numpy as np
 
 from tab_foundry.bench.artifacts import write_json
+from tab_foundry.research.navigation import build_scaling_navigation_payload
 from tab_foundry.repo_paths import normalize_repo_relative_path, repo_root
 from tab_foundry.research.scaling.fit import (
     FIT_SCOPE_ALL,
@@ -1001,6 +1002,19 @@ def audit_scaling_study(
         catalog_path=catalog_path,
         sweeps_root=sweeps_root,
     )
+    navigation = build_scaling_navigation_payload(
+        config=config,
+        points=all_points,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+    )
+    contract_issues = navigation.get("contract_issues")
+    if isinstance(contract_issues, list) and contract_issues:
+        raise RuntimeError(
+            "scaling study contract validation failed:\n- "
+            + "\n- ".join(str(issue) for issue in contract_issues)
+        )
     points = _ns_points(all_points) if normalized_scope == FIT_SCOPE_NS_ONLY else all_points
     artifact_root = (
         out_root.expanduser().resolve()
@@ -1010,10 +1024,18 @@ def audit_scaling_study(
     artifact_root.mkdir(parents=True, exist_ok=True)
     ns_points = _ns_points(points)
     batch_points = _batch_points(points)
+    completeness = cast(Mapping[str, Any], navigation.get("completeness", {}))
+    if normalized_scope == FIT_SCOPE_ALL and batch_points and not bool(completeness.get("all_expected_points_present")):
+        raise RuntimeError(
+            "fit_scope='all' requires the full expected study surface before auditing; "
+            f"expected={completeness.get('expected_counts_by_family')} "
+            f"actual={completeness.get('actual_counts_by_family')}"
+        )
     payload: dict[str, Any] = {
         "schema": SCALING_AUDIT_SCHEMA,
         "study": config.as_dict(),
         "fit_scope": normalized_scope,
+        "navigation": navigation,
         "counts": {
             "total_completed_points": len(points),
             "all_completed_points": len(all_points),

--- a/src/tab_foundry/research/scaling/fit.py
+++ b/src/tab_foundry/research/scaling/fit.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 import json
 import math
 from pathlib import Path
-from typing import Any, Callable, Literal, Mapping, Sequence
+from typing import Any, Callable, Literal, Mapping, Sequence, cast
 
 import numpy as np
 
@@ -16,6 +16,7 @@ from tab_foundry.benchmark_registry import (
     load_benchmark_run_entry,
     resolve_registry_path_value,
 )
+from tab_foundry.research.navigation import build_scaling_navigation_payload
 from tab_foundry.research.scaling.study import ScalingStudyConfig, load_scaling_study_config
 from tab_foundry.research.scaling.validation_backfill_schema import (
     VALIDATION_BACKFILL_FILENAME,
@@ -75,6 +76,8 @@ class ScalingStudyRunPoint:
     run_dir: str
     history_path: str
     telemetry_path: str
+    throughput_tokens_per_second: float | None = None
+    end_to_end_wall_seconds: float | None = None
     compute_training_shape_summary_present: bool = True
     compute_training_shape_signature_count: int = 1
     uses_reuse_train_artifact: bool = False
@@ -551,6 +554,16 @@ def _collect_run_point(
         steps=steps,
         tokens_seen=tokens_seen,
         tokens_per_step=tokens_per_step,
+        throughput_tokens_per_second=(
+            None
+            if metrics.get("throughput_tokens_per_second") is None
+            else float(metrics["throughput_tokens_per_second"])
+        ),
+        end_to_end_wall_seconds=(
+            None
+            if metrics.get("end_to_end_wall_seconds") is None
+            else float(metrics["end_to_end_wall_seconds"])
+        ),
         train_flops_per_token=_required_float(
             compute_accounting,
             "train_flops_per_token",
@@ -813,6 +826,19 @@ def inspect_scaling_study(
         sweeps_root=sweeps_root,
     )
     validation_points = _validation_backed_points(points)
+    navigation = build_scaling_navigation_payload(
+        config=config,
+        points=points,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+    )
+    contract_issues = navigation.get("contract_issues")
+    if isinstance(contract_issues, list) and contract_issues:
+        raise RuntimeError(
+            "scaling study contract validation failed:\n- "
+            + "\n- ".join(str(issue) for issue in contract_issues)
+        )
     return {
         "study": config.as_dict(),
         "available_points": [point.as_dict() for point in points],
@@ -833,6 +859,7 @@ def inspect_scaling_study(
             "bcrit_points": len(_batch_envelope(_batch_points(points))),
         },
         "validation_coverage": _validation_coverage_payload(points),
+        "navigation": navigation,
     }
 
 
@@ -841,6 +868,7 @@ def render_scaling_study_text(payload: Mapping[str, Any]) -> str:
 
     study = payload.get("study", {})
     counts = payload.get("counts", {})
+    navigation = payload.get("navigation", {})
     lines = [
         f"Study: {study.get('study_id', 'unknown')}",
         f"Phase: {study.get('phase', 'unknown')}",
@@ -850,6 +878,49 @@ def render_scaling_study_text(payload: Mapping[str, Any]) -> str:
         f"Validation-backed points: {counts.get('validation_backed_points', 0)}",
         f"Missing validation points: {counts.get('missing_validation_points', 0)}",
     ]
+    if isinstance(navigation, Mapping):
+        contract = navigation.get("contract")
+        if isinstance(contract, Mapping):
+            lines.append(
+                f"Benchmark manifest: {contract.get('benchmark_manifest_path', 'unknown')}"
+            )
+            lines.append(
+                f"Control baseline: {contract.get('control_baseline_id', 'unknown')}"
+            )
+            if contract.get("corpus_ref") is not None:
+                lines.append(f"Corpus ref: {contract.get('corpus_ref')}")
+            if contract.get("carried_in_family_baseline_run_id") is not None:
+                lines.append(
+                    "Carried baseline run: "
+                    f"{contract.get('carried_in_family_baseline_run_id')}"
+                )
+        winner = navigation.get("winner")
+        if isinstance(winner, Mapping):
+            winner_bits = [
+                f"{winner.get('geometry_label', 'unknown')}",
+                f"log_loss={float(winner['benchmark_log_loss']):.6f}",
+            ]
+            if winner.get("throughput_tokens_per_second") is not None:
+                winner_bits.append(
+                    f"throughput={float(winner['throughput_tokens_per_second']):.1f} tok/s"
+                )
+            if winner.get("end_to_end_wall_seconds") is not None:
+                winner_bits.append(f"wall={float(winner['end_to_end_wall_seconds']):.1f}s")
+            lines.append("Winner: " + ", ".join(winner_bits))
+        fit_audit_state = navigation.get("fit_audit_state")
+        if isinstance(fit_audit_state, Mapping):
+            lines.append(
+                "Fit/audit state: "
+                f"overlay={bool(fit_audit_state.get('validation_overlay_exists'))} "
+                f"fit={bool(fit_audit_state.get('fit_summary_exists'))} "
+                f"audit={bool(fit_audit_state.get('audit_summary_exists'))}"
+            )
+        completeness = navigation.get("completeness")
+        if isinstance(completeness, Mapping):
+            lines.append(
+                "Full-scope completeness: "
+                f"{bool(completeness.get('all_expected_points_present'))}"
+            )
     fit_summary = payload.get("fit_summary")
     if isinstance(fit_summary, Mapping):
         lines.append("Fits:")
@@ -1592,6 +1663,19 @@ def fit_scaling_study(
         catalog_path=catalog_path,
         sweeps_root=sweeps_root,
     )
+    navigation = build_scaling_navigation_payload(
+        config=config,
+        points=all_points,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+    )
+    contract_issues = navigation.get("contract_issues")
+    if isinstance(contract_issues, list) and contract_issues:
+        raise RuntimeError(
+            "scaling study contract validation failed:\n- "
+            + "\n- ".join(str(issue) for issue in contract_issues)
+        )
     points = _ns_points(all_points) if normalized_fit_scope == FIT_SCOPE_NS_ONLY else all_points
     artifact_root = (
         out_root.expanduser().resolve()
@@ -1613,6 +1697,17 @@ def fit_scaling_study(
     l_nd_points = _ns_points(points)
     l_ns_points = _require_validation_points(_ns_points(points), fit_name="L(N,S)")
     batch_points = _batch_points(points)
+    completeness = cast(Mapping[str, Any], navigation.get("completeness", {}))
+    if (
+        normalized_fit_scope == FIT_SCOPE_ALL
+        and batch_points
+        and not bool(completeness.get("all_expected_points_present"))
+    ):
+        raise RuntimeError(
+            "fit_scope='all' requires the full expected study surface before fitting; "
+            f"expected={completeness.get('expected_counts_by_family')} "
+            f"actual={completeness.get('actual_counts_by_family')}"
+        )
     cmin_points: tuple[dict[str, Any], ...] = ()
     fit_summary: dict[str, Any] = {}
     fit_summary["L(N)"] = {
@@ -1849,6 +1944,7 @@ def fit_scaling_study(
     fit_payload = {
         "study": config.as_dict(),
         "fit_scope": normalized_fit_scope,
+        "navigation": navigation,
         "counts": {
             "total_completed_points": len(points),
             "all_completed_points": len(all_points),

--- a/src/tab_foundry/research/scaling/study.py
+++ b/src/tab_foundry/research/scaling/study.py
@@ -40,6 +40,9 @@ class ScalingStudyConfig:
     canonical_loss_axes: dict[str, str]
     canonical_variables: dict[str, str]
     slice_selection: dict[str, str]
+    primary_fit: dict[str, Any] | None
+    historical_context_studies: tuple[str, ...]
+    frozen_contract: dict[str, Any] | None
 
     def output_root_path(self, *, root: Path | None = None) -> Path:
         return resolve_repo_relative_path(self.output_root, root=root or repo_root())
@@ -178,4 +181,19 @@ def load_scaling_study_config(
         canonical_loss_axes=_required_mapping(payload, "canonical_loss_axes"),
         canonical_variables=_required_mapping(payload, "canonical_variables"),
         slice_selection=_required_mapping(payload, "slice_selection"),
+        primary_fit=(
+            _required_mapping(payload, "primary_fit")
+            if isinstance(payload.get("primary_fit"), Mapping)
+            else None
+        ),
+        historical_context_studies=tuple(
+            str(value) for value in payload.get("historical_context_studies", [])
+        )
+        if isinstance(payload.get("historical_context_studies"), list)
+        else (),
+        frozen_contract=(
+            _required_mapping(payload, "frozen_contract")
+            if isinstance(payload.get("frozen_contract"), Mapping)
+            else None
+        ),
     )

--- a/src/tab_foundry/research/sweep/inspection_render.py
+++ b/src/tab_foundry/research/sweep/inspection_render.py
@@ -10,6 +10,7 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
     queue = cast(Mapping[str, Any], payload["queue"])
     row = cast(Mapping[str, Any], payload["row"])
     target = cast(Mapping[str, Any], payload["target"])
+    navigation = cast(Mapping[str, Any] | None, payload.get("navigation"))
     resolved = cast(Mapping[str, Any], target["resolved"])
     model = cast(Mapping[str, Any], resolved["model"])
     data = cast(Mapping[str, Any] | None, resolved.get("data"))
@@ -34,6 +35,46 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
         f"model.parameters.total={parameter_counts['total_params']}",
         f"model.parameters.trainable={parameter_counts['trainable_params']}",
     ]
+    if navigation is not None:
+        lineage = navigation.get("lineage")
+        if isinstance(lineage, list) and lineage:
+            lines.append(
+                "lineage=" + " -> ".join(str(cast(Mapping[str, Any], entry)["sweep_id"]) for entry in lineage if isinstance(entry, Mapping))
+            )
+        contract = navigation.get("contract")
+        if isinstance(contract, Mapping):
+            lines.append(f"benchmark_manifest_path={contract.get('benchmark_manifest_path')}")
+            lines.append(f"control_baseline_id={contract.get('control_baseline_id')}")
+            lines.append(f"carried_in_family_baseline_run_id={contract.get('carried_in_family_baseline_run_id')}")
+            if contract.get("corpus_ref") is not None:
+                lines.append(f"data.corpus_ref.locked={contract.get('corpus_ref')}")
+            formal_external_reference = contract.get("formal_external_reference")
+            if isinstance(formal_external_reference, Mapping):
+                lines.append(
+                    "formal_external_reference="
+                    + json.dumps(dict(formal_external_reference), sort_keys=True)
+                )
+        winner = navigation.get("winner")
+        if isinstance(winner, Mapping):
+            winner_parts = [f"order {int(winner['order']):02d}"]
+            if winner.get("geometry_label") is not None:
+                winner_parts.append(str(winner["geometry_label"]))
+            winner_parts.append(f"log_loss={float(winner['benchmark_log_loss']):.6f}")
+            if winner.get("throughput_tokens_per_second") is not None:
+                winner_parts.append(
+                    f"throughput={float(winner['throughput_tokens_per_second']):.1f} tok/s"
+                )
+            if winner.get("end_to_end_wall_seconds") is not None:
+                winner_parts.append(
+                    f"wall={float(winner['end_to_end_wall_seconds']):.1f}s"
+                )
+            lines.append("sweep_winner=" + ", ".join(winner_parts))
+        linked_scaling_studies = navigation.get("linked_scaling_study_ids")
+        if isinstance(linked_scaling_studies, list) and linked_scaling_studies:
+            lines.append(
+                "linked_scaling_studies="
+                + ", ".join(str(value) for value in linked_scaling_studies)
+            )
     if data is not None:
         lines.append(f"data.surface_label={data.get('surface_label')}")
         if data.get("corpus_ref") is not None:

--- a/src/tab_foundry/research/sweep/inspection_targets.py
+++ b/src/tab_foundry/research/sweep/inspection_targets.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping, cast
 
+from tab_foundry.research.navigation import build_sweep_navigation_payload
+
 from .inspection_artifacts import (
     anchor_has_training_artifacts,
     anchor_run_artifacts,
@@ -209,8 +211,18 @@ def inspect_sweep_row(
         sweeps_root=sweeps_root,
     )
     queue_metadata = queue_metadata_payload(queue)
+    navigation = build_sweep_navigation_payload(
+        queue=queue,
+        index_path=index_path,
+    )
+    contract_issues = navigation.get("contract_issues")
+    if isinstance(contract_issues, list) and contract_issues:
+        raise RuntimeError(
+            "sweep inspection contract validation failed:\n- " + "\n- ".join(str(issue) for issue in contract_issues)
+        )
     return {
         "queue": queue_metadata,
         "row": dict(cast(dict[str, Any], _copy_jsonable(row))),
         "target": target,
+        "navigation": navigation,
     }

--- a/src/tab_foundry/research/sweep/manage.py
+++ b/src/tab_foundry/research/sweep/manage.py
@@ -11,6 +11,7 @@ from tab_foundry.research.lane_contract import (
     resolve_new_sweep_training_surface,
     resolve_sweep_semantics,
 )
+from tab_foundry.research.navigation import list_sweep_tree_entries
 
 from .anchor import anchor_context_from_registry_run, anchor_training_surface_label, build_anchor_surface
 from .catalog import (
@@ -375,12 +376,7 @@ def create_sweep(
 
 
 def list_sweeps(*, index_path: Path | None = None) -> list[dict[str, Any]]:
-    index = load_system_delta_index_payload(index_path)
-    ordered = sorted(index.sweeps.items(), key=lambda item: str(item[0]))
     return [
-        {
-            "sweep_id": sweep_id,
-            **cast(dict[str, Any], _copy_jsonable(sweep_info.to_payload_dict())),
-        }
-        for sweep_id, sweep_info in ordered
+        cast(dict[str, Any], _copy_jsonable(entry))
+        for entry in list_sweep_tree_entries(index_path=index_path)
     ]

--- a/src/tab_foundry/research/sweep/matrix.py
+++ b/src/tab_foundry/research/sweep/matrix.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, cast
 
 from tab_foundry.benchmark_registry import load_benchmark_run_registry, resolve_registry_path_value
 from tab_foundry.external_benchmarks import EXTERNAL_BENCHMARK_LABELS
+from tab_foundry.research.navigation import validate_sweep_contract
 
 from .inspection_artifacts import queue_metadata_payload
 from .queue_loading import load_system_delta_queue, ordered_rows, write_resolved_system_delta_queue
@@ -339,6 +340,8 @@ def validate_system_delta_queue(
     registry_path: Path | None = None,
 ) -> list[str]:
     issues: list[str] = []
+    if any(key in queue for key in ("canonical_queue_path", "canonical_sweep_path", "canonical_matrix_path")):
+        issues.extend(validate_sweep_contract(queue=queue))
     registry = load_benchmark_run_registry(registry_path or default_registry_path())
     runs = cast(dict[str, dict[str, Any]], registry["runs"])
     sweep_id = _require_non_empty_string(queue.get("sweep_id"), context="materialized queue sweep_id")

--- a/tests/research/test_scaling_fit.py
+++ b/tests/research/test_scaling_fit.py
@@ -308,7 +308,7 @@ def _study_workspace(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
                     "status": "draft",
                     "anchor_run_id": "anchor_run",
                     "complexity_level": "classification_md",
-                    "benchmark_manifest_path": "bundle.json",
+                    "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
                     "control_baseline_id": "baseline",
                     "external_benchmarks": [],
                 },
@@ -317,7 +317,7 @@ def _study_workspace(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
                     "status": "draft",
                     "anchor_run_id": "anchor_run",
                     "complexity_level": "classification_md",
-                    "benchmark_manifest_path": "bundle.json",
+                    "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
                     "control_baseline_id": "baseline",
                     "external_benchmarks": [],
                 },
@@ -329,7 +329,7 @@ def _study_workspace(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
         "status": "draft",
         "complexity_level": "classification_md",
         "anchor_run_id": "anchor_run",
-        "benchmark_manifest_path": "bundle.json",
+        "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
         "control_baseline_id": "baseline",
         "external_benchmarks": [],
         "training_experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_compile_eager_dynamic_v1",
@@ -426,34 +426,39 @@ def _study_workspace(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
         ("batch_4", 4, 128.0),
         ("batch_16", 16, 512.0),
     ]
-    for order, (run_id, grad_accum_steps, tokens_per_step) in enumerate(batch_specs, start=1):
-        validation_loss = math.sqrt(10.0 / tokens_per_step)
-        benchmark_loss = validation_loss + 0.08
-        registry_runs[run_id] = _registry_entry(
-            run_id=run_id,
-            d_icl=96,
-            layers=2,
-            canonical_n=2_000_000,
-            benchmark_loss=benchmark_loss,
-            validation_loss=validation_loss,
-            final_step=1250,
-            tokens_per_step=tokens_per_step,
-            tokens_seen=int(tokens_per_step * 1250.0),
-            train_flops_per_token=float(8.0e6),
-            root=root,
-        )
-        batch_rows.append(
-            _queue_row(
-                order=order,
-                delta_ref="delta_geom_96x2",
+    order = 1
+    for run_prefix, grad_accum_steps, tokens_per_step in batch_specs:
+        for steps in (625, 1250):
+            run_id = f"{run_prefix}_{steps}"
+            step_penalty = 0.02 if steps == 625 else 0.0
+            validation_loss = math.sqrt(10.0 / tokens_per_step) + step_penalty
+            benchmark_loss = validation_loss + 0.08
+            registry_runs[run_id] = _registry_entry(
+                run_id=run_id,
                 d_icl=96,
                 layers=2,
-                max_steps=1250,
-                grad_accum_steps=grad_accum_steps,
-                run_id=run_id,
+                canonical_n=2_000_000,
                 benchmark_loss=benchmark_loss,
+                validation_loss=validation_loss,
+                final_step=steps,
+                tokens_per_step=tokens_per_step,
+                tokens_seen=int(tokens_per_step * float(steps)),
+                train_flops_per_token=float(8.0e6),
+                root=root,
             )
-        )
+            batch_rows.append(
+                _queue_row(
+                    order=order,
+                    delta_ref="delta_geom_96x2",
+                    d_icl=96,
+                    layers=2,
+                    max_steps=steps,
+                    grad_accum_steps=grad_accum_steps,
+                    run_id=run_id,
+                    benchmark_loss=benchmark_loss,
+                )
+            )
+            order += 1
     _write_yaml(
         sweeps_root / "synthetic_batch" / "queue.yaml",
         {
@@ -477,7 +482,7 @@ def _study_workspace(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
             "study_id": "synthetic_phase2",
             "phase": 2,
             "output_root": "outputs/research_scaling/synthetic_phase2",
-            "phase1_reference_sweep_id": "tf_rd_009_width_depth_medium_v1",
+            "phase1_reference_sweep_id": "synthetic_ns",
             "sweeps": [
                 {"name": "ns_core", "sweep_id": "synthetic_ns", "family": "ns_core"},
                 {
@@ -783,7 +788,7 @@ def test_fit_scaling_study_ns_only_omits_batch_fits(
 
     assert payload["fit_scope"] == "ns-only"
     assert payload["counts"]["total_completed_points"] == 4
-    assert payload["counts"]["all_completed_points"] == 7
+    assert payload["counts"]["all_completed_points"] == 10
     assert payload["counts"]["batch_critical_completed_points"] == 0
     assert set(payload["fit_summary"]) == {"L(N)", "L(D)", "L(C)", "L(N,D)", "L(N,S)"}
     assert set(payload["alphas"]) == {"alpha_n", "alpha_d", "alpha_s", "alpha_c"}
@@ -944,15 +949,42 @@ def test_inspect_scaling_study_reports_missing_validation_without_crashing(tmp_p
         sweeps_root=sweeps_root,
     )
 
-    assert payload["counts"]["total_completed_points"] == 7
+    assert payload["counts"]["total_completed_points"] == 10
     assert payload["counts"]["validation_backed_points"] == 0
-    assert payload["counts"]["missing_validation_points"] == 7
+    assert payload["counts"]["missing_validation_points"] == 10
     assert payload["counts"]["l_n_points"] == 2
     assert payload["counts"]["l_ns_points"] == 0
     assert (
         payload["validation_coverage"]["missing"][0]["missing_reason"]
         == "history_missing_validation_records"
     )
+    navigation = payload["navigation"]
+    assert navigation["contract"]["phase1_reference_sweep_id"] == "synthetic_ns"
+    assert navigation["contract"]["benchmark_manifest_path"] == (
+        "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
+    )
+    assert navigation["contract"]["control_baseline_id"] == "baseline"
+    assert navigation["winner"]["geometry_label"] == "96x2"
+    assert navigation["fit_audit_state"]["full_scope_ready"] is True
+    assert navigation["completeness"]["all_expected_points_present"] is True
+
+
+def test_inspect_scaling_study_fails_fast_on_mixed_benchmark_contract(tmp_path: Path) -> None:
+    study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
+    batch_sweep_path = sweeps_root / "synthetic_batch" / "sweep.yaml"
+    batch_sweep = OmegaConf.to_container(OmegaConf.load(batch_sweep_path), resolve=True)
+    assert isinstance(batch_sweep, dict)
+    batch_sweep["benchmark_manifest_path"] = "data/manifests/bench/openml_classification_large_v1/manifest.parquet"
+    _write_yaml(batch_sweep_path, batch_sweep)
+
+    with pytest.raises(RuntimeError, match="benchmark manifest mismatch"):
+        _ = inspect_scaling_study(
+            study_path=study_path,
+            registry_path=registry_path,
+            index_path=index_path,
+            catalog_path=catalog_path,
+            sweeps_root=sweeps_root,
+        )
 
 
 def test_inspect_scaling_study_uses_validation_backfill_sidecars(tmp_path: Path) -> None:
@@ -968,8 +1000,8 @@ def test_inspect_scaling_study_uses_validation_backfill_sidecars(tmp_path: Path)
         sweeps_root=sweeps_root,
     )
 
-    assert payload["counts"]["total_completed_points"] == 7
-    assert payload["counts"]["validation_backed_points"] == 7
+    assert payload["counts"]["total_completed_points"] == 10
+    assert payload["counts"]["validation_backed_points"] == 10
     assert payload["counts"]["missing_validation_points"] == 0
     assert payload["available_points"][0]["validation_loss_source"] == "validation_backfill_v1"
 
@@ -992,6 +1024,54 @@ def test_fit_scaling_study_requires_validation_for_strict_fits(tmp_path: Path) -
         )
 
 
+def test_fit_scaling_study_rejects_incomplete_full_scope_surface(tmp_path: Path) -> None:
+    study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
+    batch_queue_path = sweeps_root / "synthetic_batch" / "queue.yaml"
+    batch_queue = OmegaConf.to_container(OmegaConf.load(batch_queue_path), resolve=True)
+    assert isinstance(batch_queue, dict)
+    rows = batch_queue["rows"]
+    assert isinstance(rows, list)
+    rows[-1]["status"] = "ready"
+    rows[-1]["run_id"] = None
+    rows[-1]["benchmark_metrics"] = None
+    _write_yaml(batch_queue_path, batch_queue)
+
+    with pytest.raises(RuntimeError, match="requires the full expected study surface"):
+        _ = fit_scaling_study(
+            study_path=study_path,
+            registry_path=registry_path,
+            index_path=index_path,
+            catalog_path=catalog_path,
+            sweeps_root=sweeps_root,
+            out_root=tmp_path / "artifacts",
+        )
+
+
+def test_audit_scaling_study_rejects_incomplete_full_scope_surface(tmp_path: Path) -> None:
+    study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
+    batch_queue_path = sweeps_root / "synthetic_batch" / "queue.yaml"
+    batch_queue = OmegaConf.to_container(OmegaConf.load(batch_queue_path), resolve=True)
+    assert isinstance(batch_queue, dict)
+    rows = batch_queue["rows"]
+    assert isinstance(rows, list)
+    rows[-1]["status"] = "ready"
+    rows[-1]["run_id"] = None
+    rows[-1]["benchmark_metrics"] = None
+    _write_yaml(batch_queue_path, batch_queue)
+
+    with pytest.raises(RuntimeError, match="requires the full expected study surface"):
+        _ = audit_scaling_study(
+            study_path=study_path,
+            registry_path=registry_path,
+            index_path=index_path,
+            catalog_path=catalog_path,
+            sweeps_root=sweeps_root,
+            out_root=tmp_path / "audit",
+            bootstrap_samples=2,
+            bootstrap_seed=7,
+        )
+
+
 def test_validation_backfill_dry_run_reports_ready_and_incomplete_rows(tmp_path: Path) -> None:
     study_path, registry_path, index_path, catalog_path, sweeps_root = _study_workspace(tmp_path)
     _remove_validation_history(tmp_path, registry_path)
@@ -1011,8 +1091,8 @@ def test_validation_backfill_dry_run_reports_ready_and_incomplete_rows(tmp_path:
         dry_run=True,
     )
 
-    assert payload["counts"]["candidate_rows"] == 7
-    assert payload["counts"]["dry_run_ready"] == 6
+    assert payload["counts"]["candidate_rows"] == 10
+    assert payload["counts"]["dry_run_ready"] == 9
     assert payload["counts"]["incomplete_artifacts"] == 1
     incomplete = [row for row in payload["rows"] if row["status"] == "incomplete_artifacts"]
     assert incomplete[0]["run_id"] == "ns_72_625"

--- a/tests/research/test_sweep_inspect.py
+++ b/tests/research/test_sweep_inspect.py
@@ -406,6 +406,14 @@ def test_inspect_sweep_row_reports_resolved_surfaces(
     assert payload["target"]["resolved"]["model"]["stage_label"] == "row_cls_pool_test"
     assert payload["target"]["resolved"]["model"]["module_selection"]["row_pool"] == "row_cls"
     assert payload["target"]["resolved"]["data"]["surface_label"] == "anchor_manifest_default"
+    assert [entry["sweep_id"] for entry in payload["navigation"]["lineage"]] == ["mini_sweep"]
+    assert payload["navigation"]["contract"]["benchmark_manifest_path"] == (
+        "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
+    )
+    assert payload["navigation"]["contract"]["control_baseline_id"] == "cls_benchmark_linear_v2"
+    assert payload["navigation"]["contract"]["carried_in_family_baseline_run_id"] == "anchor_run"
+    assert payload["navigation"]["winner"] is None
+    assert payload["navigation"]["contract_issues"] == []
 
 
 def test_inspection_artifact_helpers_share_row_and_anchor_path_resolution(
@@ -474,6 +482,31 @@ def test_inspect_sweep_row_uses_canonical_queue_metadata_payload(
     )
 
     assert payload["queue"] == sentinel_metadata
+
+
+def test_inspect_sweep_row_fails_fast_on_anchor_contract_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_path, index_path, sweeps_root, registry_path, registry_payload = _mini_sweep_workspace(tmp_path)
+    _patch_registry(monkeypatch, registry_payload=registry_payload)
+    sweep_path = sweeps_root / "mini_sweep" / "sweep.yaml"
+    sweep_payload = OmegaConf.to_container(OmegaConf.load(sweep_path), resolve=True)
+    assert isinstance(sweep_payload, dict)
+    anchor_context = sweep_payload["anchor_context"]
+    assert isinstance(anchor_context, dict)
+    anchor_context["run_id"] = "mismatched_anchor"
+    _write_yaml(sweep_path, sweep_payload)
+
+    with pytest.raises(RuntimeError, match="anchor_context.run_id"):
+        _ = inspect_module.inspect_sweep_row(
+            order=1,
+            sweep_id="mini_sweep",
+            index_path=index_path,
+            catalog_path=catalog_path,
+            sweeps_root=sweeps_root,
+            registry_path=registry_path,
+        )
 
 
 def test_inspect_sweep_row_materializes_catalog_default_effective_surface(

--- a/tests/research/test_tf_rd_009_muon_training_dynamics_selector.py
+++ b/tests/research/test_tf_rd_009_muon_training_dynamics_selector.py
@@ -1,0 +1,1 @@
+from tests.support_research.tf_rd_009_muon_training_dynamics_selector import *  # noqa: F401,F403

--- a/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
+++ b/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from tab_foundry.research.scaling.fit import inspect_scaling_study
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+from tab_foundry.research.navigation import build_sweep_navigation_payload
+from tests.support_research.helpers import assert_training_surface_semantics
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml"
+CATALOG_PATH = REPO_ROOT / "reference" / "system_delta_catalog.yaml"
+SWEEPS_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps"
+REGISTRY_PATH = REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
+
+WIDTH_SCREEN = "tf_rd_009_muon_width_screen_medium_v1"
+WIDTH_DEPTH = "tf_rd_009_muon_width_depth_medium_v1"
+NS_SWEEP = "tf_rd_009_muon_ns_one_epoch_medium_v1"
+BCRIT_SWEEP = "tf_rd_009_muon_batch_critical_one_epoch_medium_v1"
+SELECTOR_SWEEP = "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"
+PHASE2_STUDY = "tf_rd_009_muon_phase2_one_epoch_v1"
+ANCHOR_RUN_ID = "sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1"
+MUON_EXPERIMENT = "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1"
+CORPUS_V6 = "tf_rd_010_dagzoo_medium_control_curated_v6"
+BENCHMARK_MANIFEST = "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
+CONTROL_BASELINE = "cls_benchmark_linear_multiclass_medium_v1"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tf_rd_009_muon_training_dynamics_selector_is_registered() -> None:
+    index = _load_yaml(INDEX_PATH)
+
+    assert index["sweeps"][SELECTOR_SWEEP] == {
+        "parent_sweep_id": BCRIT_SWEEP,
+        "status": "draft",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "classification_md",
+        "benchmark_manifest_path": BENCHMARK_MANIFEST,
+        "control_baseline_id": CONTROL_BASELINE,
+        "external_benchmarks": [],
+    }
+
+
+def test_tf_rd_009_muon_training_dynamics_selector_tracks_the_exact_12_row_endpoint_matrix() -> None:
+    sweep_root = SWEEPS_ROOT / SELECTOR_SWEEP
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+
+    assert sweep["sweep_id"] == SELECTOR_SWEEP
+    assert sweep["parent_sweep_id"] == BCRIT_SWEEP
+    assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
+    assert_training_surface_semantics(
+        sweep,
+        training_experiment=MUON_EXPERIMENT,
+        training_config_profile=MUON_EXPERIMENT,
+        surface_role="classification_training_dynamics_selector",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+
+    rows = queue["rows"]
+    assert len(rows) == 12
+    assert {row["status"] for row in rows} == {"ready"}
+    assert {row["interpretation_status"] for row in rows} == {"pending"}
+    assert {row["benchmark_checkpoint_selection"] for row in rows} == {"best_and_final"}
+    assert {row["data"]["corpus_ref"] for row in rows} == {CORPUS_V6}
+    assert {row["training"]["task_batch_size"] for row in rows} == {16}
+    assert {row["training"]["overrides"]["runtime"]["max_steps"] for row in rows} == {5000}
+    assert Counter(f"{row['model']['d_icl']}x{row['model']['sandwich_layers']}" for row in rows) == {
+        "128x2": 4,
+        "144x4": 4,
+        "264x6": 4,
+    }
+    assert Counter(row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in rows) == {
+        4: 3,
+        16: 9,
+    }
+
+    expected_by_suffix = {
+        "carry_lowbatch_v1": {"grad_accum_steps": 4, "lr_max": 0.001, "min_lr": 1e-6, "betas": (0.9, 0.95)},
+        "carry_highbatch_v1": {"grad_accum_steps": 16, "lr_max": 0.001, "min_lr": 1e-6, "betas": (0.9, 0.95)},
+        "linear_lr_batch_v1": {"grad_accum_steps": 16, "lr_max": 0.004, "min_lr": 4e-6, "betas": (0.9, 0.95)},
+        "momentum_timescale_v1": {"grad_accum_steps": 16, "lr_max": 0.004, "min_lr": 4e-6, "betas": (0.975, 0.95)},
+    }
+    for row in rows:
+        delta_ref = str(row["delta_ref"])
+        suffix = next(key for key in expected_by_suffix if delta_ref.endswith(key))
+        expected = expected_by_suffix[suffix]
+        runtime = row["training"]["overrides"]["runtime"]
+        optimizer = row["training"]["overrides"]["optimizer"]
+        schedule = row["training"]["overrides"]["schedule"]["stages"][0]
+        assert runtime["grad_accum_steps"] == expected["grad_accum_steps"]
+        assert schedule["lr_max"] == expected["lr_max"]
+        assert optimizer["min_lr"] == expected["min_lr"]
+        assert tuple(optimizer["betas"]) == expected["betas"]
+        assert optimizer["name"] == "muon"
+        assert optimizer["weight_decay"] == 0.01
+
+
+def test_tf_rd_009_muon_training_dynamics_selector_materializes_and_exposes_the_active_lineage() -> None:
+    materialized = load_system_delta_queue(
+        sweep_id=SELECTOR_SWEEP,
+        index_path=INDEX_PATH,
+        catalog_path=CATALOG_PATH,
+        sweeps_root=SWEEPS_ROOT,
+    )
+    assert_training_surface_semantics(
+        materialized,
+        training_experiment=MUON_EXPERIMENT,
+        training_config_profile=MUON_EXPERIMENT,
+        surface_role="classification_training_dynamics_selector",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+    assert [row["delta_id"] for row in materialized["rows"]] == [
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1",
+        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1",
+    ]
+
+    navigation = build_sweep_navigation_payload(queue=materialized, index_path=INDEX_PATH)
+    assert [entry["sweep_id"] for entry in navigation["lineage"]][-5:] == [
+        WIDTH_SCREEN,
+        WIDTH_DEPTH,
+        NS_SWEEP,
+        BCRIT_SWEEP,
+        SELECTOR_SWEEP,
+    ]
+    assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
+    assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
+    assert navigation["contract"]["corpus_ref"] == CORPUS_V6
+    assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID
+    assert navigation["winner"] is None
+    assert navigation["contract_issues"] == []
+
+    resolved = _load_yaml(SWEEPS_ROOT / SELECTOR_SWEEP / "resolved_queue.yaml")
+    assert [row["delta_id"] for row in resolved["rows"]] == [row["delta_id"] for row in materialized["rows"]]
+    matrix = (SWEEPS_ROOT / SELECTOR_SWEEP / "matrix.md").read_text(encoding="utf-8")
+    assert "quality/time Pareto frontier" in matrix
+    assert "historical schedulefree TF-RD-009 remains preserved context only" in matrix
+
+
+def test_tf_rd_009_muon_phase2_inspection_exposes_the_canonical_active_contract_and_runtime_metrics() -> None:
+    payload = inspect_scaling_study(
+        study_id=PHASE2_STUDY,
+        registry_path=REGISTRY_PATH,
+        index_path=INDEX_PATH,
+        catalog_path=CATALOG_PATH,
+        sweeps_root=SWEEPS_ROOT,
+    )
+
+    navigation = payload["navigation"]
+    assert [entry["sweep_id"] for entry in navigation["linked_sweeps"]] == [NS_SWEEP, BCRIT_SWEEP]
+    assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
+    assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
+    assert navigation["contract"]["corpus_ref"] == CORPUS_V6
+    assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID
+    assert navigation["contract"]["phase1_reference_sweep_id"] == WIDTH_DEPTH
+    assert navigation["contract"]["historical_context_studies"] == ["tf_rd_009_phase2", "tf_rd_009_phase2_one_epoch_v1"]
+    assert navigation["winner"]["geometry_label"] == "264x6"
+    assert navigation["winner"]["row_order"] == 20
+    assert navigation["winner"]["benchmark_log_loss"] == 0.46464118874262356
+    assert "throughput_tokens_per_second" in navigation["winner"]
+    assert "end_to_end_wall_seconds" in navigation["winner"]
+    assert navigation["completeness"]["all_expected_points_present"] is True
+    assert navigation["fit_audit_state"]["full_scope_ready"] is True
+    assert navigation["contract_issues"] == []


### PR DESCRIPTION
## Summary
- Reworks TF-RD-009 muon navigation to use the updated sweep inspection and selection flow
- Tightens scaling fit, audit, and study helpers to support the new endpoint medium sweep shape
- Updates roadmap, workflow docs, and system delta references to match the revised sweep artifacts

## Testing
- Not run (not requested)