### PR TITLE
[codex] Close out TF-RD-009 Muon LMO transfer study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- User-facing note: TF-RD-009 issue [#284](https://github.com/bensonlee5/tab-foundry/issues/284)
+  now tracks the faithful paper-derived Muon transfer study rather than the
+  earlier heuristic endpoint selector. The repo now ships tracked screen and
+  validation sweeps for the fixed-geometry `144x4` transfer lane, exposes
+  transfer formulas and realized budget/batch diagnostics in sweep
+  inspect/summarize/result-card output, and preserves the old endpoint study as
+  superseded context only.
+- User-facing note: Muon configs now accept an explicit
+  `optimizer.momentum` field for the core Muon momentum parameter. The repo
+  defaults that field to `0.95` for Muon surfaces, keeps `optimizer.betas` as
+  the Adam-style beta tuple, and rejects `optimizer.momentum` on optimizers
+  that do not support it.
+- User-facing note: the repo-wide default anchor benchmark contract is now
+  hardened around `openml_classification_medium_v1`. Default-anchor validation
+  and inspection fail fast if a sweep drifts to the wrong manifest hash or to a
+  binary benchmark surface.
+
 ## [0.17.2] - 2026-04-15
 
 ### Changed

--- a/configs/optimizer/muon_default.yaml
+++ b/configs/optimizer/muon_default.yaml
@@ -2,6 +2,7 @@ name: muon
 require_requested: true
 weight_decay: 0.01
 betas: [0.9, 0.95]
+momentum: 0.95
 min_lr: 1.0e-6
 muon_per_parameter_lr: true
 muon_lr_scale_base: 0.2

--- a/docs/development/model-architecture.md
+++ b/docs/development/model-architecture.md
@@ -41,6 +41,37 @@ Key code paths:
 - `tabfoundry_staged` is still useful as a historical comparison surface, but
   it is no longer the center of the roadmap or architecture docs.
 
+## Active TF-RD-009 Carried Surface
+
+The generic sandwich defaults below are not the current TF-RD-009 study
+surface. The active Muon training-dynamics study under
+`tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1` carries one fixed
+`tabfoundry_sandwich` geometry while testing optimizer and batch transfer laws:
+
+- geometry: `144x4` (`d_icl=144`, `sandwich_layers=4`)
+- architecture knobs held fixed:
+  - `sandwich_latents=24`
+  - `sandwich_heads=1`
+  - `sandwich_ff_expansion=2`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `sandwich_self_attention_per_cross=4`
+  - `sandwich_pre_row_attention_layers=1`
+  - `sandwich_pre_column_attention_layers=1`
+  - `sandwich_pre_column_inducing_tokens=16`
+- non-geometry surface held fixed:
+  - `input_normalization=train_zscore_clip`
+  - `feature_type_conditioning=film`
+  - `floating_likelihood=single_gaussian`
+  - `integer_likelihood=hybrid_mixture`
+  - corrected anchor benchmark `openml_classification_medium_v1`
+  - corpus `tf_rd_010_dagzoo_medium_control_curated_v6`
+
+Interpret this as the current carried architecture contract for TF-RD-009:
+`128x2` remains the formal in-family baseline lineage, `264x6` remains later
+planning context, but the active optimizer-transfer question is being tested at
+fixed `144x4` in the strict shared-anchor LMO transfer sweep. The earlier
+screen-based transfer sweeps remain preserved superseded context only.
+
 ## Intent Map
 
 This diagram summarizes the design intent behind the current sandwich architecture.

--- a/docs/development/module-dependency-map.md
+++ b/docs/development/module-dependency-map.md
@@ -19,7 +19,7 @@ section factual and keep design intent in the policy section below it.
   `tab_foundry.benchmark_registry`,
   `tab_foundry.hardware_architecture_registry`,
   `tab_foundry.hardware_profiles`,
-  `tab_foundry.checkpoint_state`,
+  `tab_foundry.checkpoint_state`, `tab_foundry.hashing`,
   `tab_foundry.input_normalization`, `tab_foundry.model`,
   `tab_foundry.preprocessing`, `tab_foundry.registry`,
   `tab_foundry.repo_paths`, `tab_foundry.task_batching`,
@@ -124,7 +124,7 @@ Observed cycle status:
   `tab_foundry.benchmark_registry`, `tab_foundry.device`,
   `tab_foundry.external_benchmarks`,
   `tab_foundry.hardware_architecture_registry`,
-  `tab_foundry.hardware_profiles`, and
+  `tab_foundry.hardware_profiles`, `tab_foundry.hashing`, and
   `tab_foundry.control_baseline_registry`, but lower layers should not depend
   on it.
 - `tab_foundry.research` is the sweep-management layer. It may depend on

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1170,7 +1170,7 @@ Legacy wording note:
     [#256](https://github.com/bensonlee5/tab-foundry/issues/256), and
     [#257](https://github.com/bensonlee5/tab-foundry/issues/257) remains
     preserved context only
-  - the active `#284` execution surface is now the strict shared-anchor LMO
+  - the completed `#284` execution surface is the strict shared-anchor LMO
     transfer sweep:
     `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
   - the earlier screen-based transfer sweeps
@@ -1181,7 +1181,7 @@ Legacy wording note:
     `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` remains tracked
     superseded context only; it is no longer the canonical training-dynamics
     decision surface
-- Required work:
+- Closeout state:
   - keep [#253](https://github.com/bensonlee5/tab-foundry/issues/253) as the
     authoritative umbrella for TF-RD-009, but treat the historical
     schedulefree family under [#254](https://github.com/bensonlee5/tab-foundry/issues/254),
@@ -1199,54 +1199,40 @@ Legacy wording note:
     corrected Muon Phase-2 closeout: keep `L(N,S)` on validation loss as the
     primary directional law, keep benchmark loss as external ranking evidence,
     and keep `Bcrit` / `Cmin` diagnostic-only with `ready_for_cmin=false`
-  - land [#283](https://github.com/bensonlee5/tab-foundry/issues/283) next so
-    one sweep/scaling inspection path can show the active benchmark, corpus,
-    formal external anchor, carried in-family baseline, linked study lineage,
-    kept winner, and fit/audit readiness, while failing fast on benchmark,
-    baseline, corpus, anchor, and replay-completeness contract drift
-  - after the cleanup child lands, execute
-    [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the
-    strict shared-anchor Muon transfer study at fixed `144x4`: keep the
-    corrected `openml_classification_medium_v1` default anchor benchmark and
-    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, reuse one
-    carried low-batch `144x4` Muon `T0` artifact as the shared source of truth,
-    and derive Regime `B` and Regime `D` deterministically inside
-    `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
-  - for that transfer study, carry one exact sandwich architecture surface
-    rather than a generic family label: `d_icl=144`, `sandwich_layers=4`,
-    `sandwich_latents=24`, `sandwich_heads=1`,
+  - [#283](https://github.com/bensonlee5/tab-foundry/issues/283) is now
+    satisfied on this branch: `research sweep list-sweeps` renders the lineage
+    tree, `research sweep inspect` exposes the active benchmark/corpus/carried
+    baseline/shared-anchor winner surface, `research scaling inspect` exposes
+    linked sweeps plus winner and fit/audit readiness, and the default-anchor
+    contract guards now fail fast on benchmark, baseline, corpus, anchor, and
+    replay-completeness drift
+  - [#284](https://github.com/bensonlee5/tab-foundry/issues/284) is complete
+    on the fixed `144x4` sandwich surface (`d_icl=144`,
+    `sandwich_layers=4`, `sandwich_latents=24`, `sandwich_heads=1`,
     `sandwich_summary_tokens_per_axis=3`, `sandwich_ff_expansion=2`,
     `sandwich_self_attention_per_cross=4`,
     `sandwich_pre_row_attention_layers=1`,
     `sandwich_pre_column_attention_layers=1`, and
-    `sandwich_pre_column_inducing_tokens=16`; treat optimizer and batch laws as
-    the only active variable
-  - derive the transfer rows directly from
-    [arXiv:2603.15958](https://arxiv.org/abs/2603.15958):
-    Regime `B` uses `B(T)=64`, `alpha(T)=alpha0*(T/T0)^(-1/2)`, and
-    `lr_max(T)=lr0*(T/T0)^(-3/4)`; Regime `D` uses
-    `B(T)=B0*(T/T0)^(1/6)`, `alpha(T)=alpha0*(T/T0)^(-1/3)`, and
-    `lr_max(T)=lr0*(T/T0)^(-7/12)` with `momentum(T)=1-alpha(T)` and
-    `min_lr=lr_max*1e-3`
-  - realize budgets deterministically on the existing rung ladder
-    `T0/T1/T2 = {625×64, 2500×64, 5000×64}` with `task_batch_size=16`,
-    nearest-realizable effective batch rounding, `max_steps=round_half_up(T/B)`,
-    and a default `2%` drift guard on realized batch and effective-budget
-    mismatch
-  - keep the active `#284` surface law-driven rather than screened: the
-    canonical sweep is a `10`-row validation surface with imported carried
-    low-batch baselines at `T0/T1/T2`, carried high-batch baselines at
-    `T0/T1/T2`, and Regime `B` / Regime `D` rows only at `T1/T2`; there is no
-    regime-specific `T0` search in the active path
-  - choose the kept law-derived regime by corrected benchmark log loss with a
-    `T2`-first, `T1` tie-break rule, then compare that winning regime against
-    the carried high-batch baseline at `T2` before opening any later Phase-2B
-    rerun issue
-  - only after the cleanup child and faithful transfer study land should
+    `sandwich_pre_column_inducing_tokens=16`) against the corrected
+    `openml_classification_medium_v1` benchmark and
+    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - the completed strict shared-anchor LMO sweep kept Regime `B` over Regime
+    `D` by the tracked `T2`-then-`T1` rule:
+    `B@T1=0.5239001271`, `B@T2=0.5143437440`,
+    `D@T1=0.5268794041`, `D@T2=0.5169818590`
+  - the best overall row in the completed study remains the imported carried
+    low-batch baseline `T2` row `3` at `0.4914031270`; the carried high-batch
+    `T2` row `6` landed at `0.5135392585`
+  - final transfer-study verdict: the kept law-derived regime `B` did **not**
+    beat carried high-batch at `T2`
+    (`0.5143437440` vs `0.5135392585`, delta `+0.0008044855` log loss), so
+    close `#284` without opening any later Phase-2B rerun issue from this lane
+  - only after the completed cleanup child and negative faithful transfer study
+    closeout should
     [#269](https://github.com/bensonlee5/tab-foundry/issues/269) be revisited
     for any Muon upper-family move; treat any later larger-model probe as
     post-selector work instead of as a blocker on the current active reboot path
-  - only after a later Muon Phase-2B rerun produces a better-conditioned
+  - only after some later separate study produces a better-conditioned
     multi-geometry batch surface should
     [#259](https://github.com/bensonlee5/tab-foundry/issues/259) be revisited
     for the compute-frontier / Chinchilla-style branch; keep

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1170,10 +1170,14 @@ Legacy wording note:
     [#256](https://github.com/bensonlee5/tab-foundry/issues/256), and
     [#257](https://github.com/bensonlee5/tab-foundry/issues/257) remains
     preserved context only
-  - the next executable selector surface is now
-    `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`, a compact `12`-row
-    endpoint study over `128x2`, `144x4`, and `264x6` that ranks rows on a
-    corrected quality/time Pareto frontier before any later Muon Phase-2B rerun
+  - the active `#284` execution surface is now the faithful paper-derived
+    transfer pair:
+    `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1` followed by
+    `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+  - the earlier heuristic endpoint selector
+    `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` remains tracked
+    superseded context only; it is no longer the canonical training-dynamics
+    decision surface
 - Required work:
   - keep [#253](https://github.com/bensonlee5/tab-foundry/issues/253) as the
     authoritative umbrella for TF-RD-009, but treat the historical
@@ -1198,14 +1202,27 @@ Legacy wording note:
     kept winner, and fit/audit readiness, while failing fast on benchmark,
     baseline, corpus, anchor, and replay-completeness contract drift
   - after the cleanup child lands, execute
-    [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the compact
-    Muon training-dynamics selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`:
-    keep the corrected `openml_classification_medium_v1` benchmark and
-    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, run the
-    `128x2` / `144x4` / `264x6` endpoint matrix with carried low-batch,
-    carried high-batch, linear LR/batch, and momentum-timescale prescriptions,
-    and rank rows on the corrected quality/time Pareto frontier
-  - only after the cleanup child and compact selector land should
+    [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the
+    faithful Muon transfer study at fixed `144x4`: keep the corrected
+    `openml_classification_medium_v1` default anchor benchmark and
+    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, run the T0
+    screen `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`, then
+    validate the screened Regime `B` and Regime `D` winners against the carried
+    low-batch and carried high-batch baselines on
+    `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+  - derive the transfer rows directly from
+    [arXiv:2603.15958](https://arxiv.org/abs/2603.15958):
+    Regime `B` uses `B(T)=64`, `alpha(T)=alpha0*(T/T0)^(-1/2)`, and
+    `lr_max(T)=lr0*(T/T0)^(-3/4)`; Regime `D` uses
+    `B(T)=B0*(T/T0)^(1/6)`, `alpha(T)=alpha0*(T/T0)^(-1/3)`, and
+    `lr_max(T)=lr0*(T/T0)^(-7/12)` with `momentum(T)=1-alpha(T)` and
+    `min_lr=lr_max*1e-3`
+  - realize budgets deterministically on the existing rung ladder
+    `T0/T1/T2 = {625×64, 2500×64, 5000×64}` with `task_batch_size=16`,
+    nearest-realizable effective batch rounding, `max_steps=round_half_up(T/B)`,
+    and a default `2%` drift guard on realized batch and effective-budget
+    mismatch
+  - only after the cleanup child and faithful transfer study land should
     [#269](https://github.com/bensonlee5/tab-foundry/issues/269) be revisited
     for any Muon upper-family move; treat any later larger-model probe as
     post-selector work instead of as a blocker on the current active reboot path

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1170,10 +1170,13 @@ Legacy wording note:
     [#256](https://github.com/bensonlee5/tab-foundry/issues/256), and
     [#257](https://github.com/bensonlee5/tab-foundry/issues/257) remains
     preserved context only
-  - the active `#284` execution surface is now the faithful paper-derived
-    transfer pair:
-    `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1` followed by
-    `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+  - the active `#284` execution surface is now the strict shared-anchor LMO
+    transfer sweep:
+    `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
+  - the earlier screen-based transfer sweeps
+    `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1` and
+    `tf_rd_009_muon_training_dynamics_transfer_medium_v1` remain preserved
+    superseded context only
   - the earlier heuristic endpoint selector
     `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` remains tracked
     superseded context only; it is no longer the canonical training-dynamics
@@ -1203,13 +1206,21 @@ Legacy wording note:
     baseline, corpus, anchor, and replay-completeness contract drift
   - after the cleanup child lands, execute
     [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the
-    faithful Muon transfer study at fixed `144x4`: keep the corrected
-    `openml_classification_medium_v1` default anchor benchmark and
-    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, run the T0
-    screen `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`, then
-    validate the screened Regime `B` and Regime `D` winners against the carried
-    low-batch and carried high-batch baselines on
-    `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+    strict shared-anchor Muon transfer study at fixed `144x4`: keep the
+    corrected `openml_classification_medium_v1` default anchor benchmark and
+    `tf_rd_010_dagzoo_medium_control_curated_v6` corpus fixed, reuse one
+    carried low-batch `144x4` Muon `T0` artifact as the shared source of truth,
+    and derive Regime `B` and Regime `D` deterministically inside
+    `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
+  - for that transfer study, carry one exact sandwich architecture surface
+    rather than a generic family label: `d_icl=144`, `sandwich_layers=4`,
+    `sandwich_latents=24`, `sandwich_heads=1`,
+    `sandwich_summary_tokens_per_axis=3`, `sandwich_ff_expansion=2`,
+    `sandwich_self_attention_per_cross=4`,
+    `sandwich_pre_row_attention_layers=1`,
+    `sandwich_pre_column_attention_layers=1`, and
+    `sandwich_pre_column_inducing_tokens=16`; treat optimizer and batch laws as
+    the only active variable
   - derive the transfer rows directly from
     [arXiv:2603.15958](https://arxiv.org/abs/2603.15958):
     Regime `B` uses `B(T)=64`, `alpha(T)=alpha0*(T/T0)^(-1/2)`, and
@@ -1222,6 +1233,15 @@ Legacy wording note:
     nearest-realizable effective batch rounding, `max_steps=round_half_up(T/B)`,
     and a default `2%` drift guard on realized batch and effective-budget
     mismatch
+  - keep the active `#284` surface law-driven rather than screened: the
+    canonical sweep is a `10`-row validation surface with imported carried
+    low-batch baselines at `T0/T1/T2`, carried high-batch baselines at
+    `T0/T1/T2`, and Regime `B` / Regime `D` rows only at `T1/T2`; there is no
+    regime-specific `T0` search in the active path
+  - choose the kept law-derived regime by corrected benchmark log loss with a
+    `T2`-first, `T1` tie-break rule, then compare that winning regime against
+    the carried high-batch baseline at `T2` before opening any later Phase-2B
+    rerun issue
   - only after the cleanup child and faithful transfer study land should
     [#269](https://github.com/bensonlee5/tab-foundry/issues/269) be revisited
     for any Muon upper-family move; treat any later larger-model probe as

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -279,21 +279,24 @@ tab-foundry bench compare \
   --tabicl-root <path-to-tabicl>
 ```
 
-The canonical medium benchmark surface is
-`data/manifests/bench/openml_classification_medium_v1/manifest.parquet`. The
-canonical frozen control baseline id is `cls_benchmark_linear_v2`.
+The repo-wide default anchor benchmark is the medium multiclass surface with
+natural missingness preserved:
+`data/manifests/bench/openml_classification_medium_v1/manifest.parquet`. Until
+that default is intentionally changed, this is the anchor benchmark that sweep
+inspection, scaling inspection, and contract validation expect. The paired
+frozen control baseline id is `cls_benchmark_linear_multiclass_medium_v1`.
 
 Benchmark comparison and sweep execution consume manifest paths only. Use the
 repo-tracked bundle JSON only as a materialization input:
 
 ```bash
 tab-foundry bench materialize-openml-bundle \
-  --bundle-path src/tab_foundry/bench/openml_binary_medium_v1.json \
+  --bundle-path src/tab_foundry/bench/openml_classification_medium_v1.json \
   --out-root data/manifests/bench/openml_classification_medium_v1
 ```
 
-The checked-in `cls_benchmark_linear_v2` entry freezes the prior-trained staged
-anchor run at:
+The checked-in `cls_benchmark_linear_multiclass_medium_v1` entry freezes the
+prior-trained staged anchor run at:
 
 - `outputs/staged_ladder/01_nano_exact_md/prior_parity_fix`
 - `outputs/staged_ladder/01_nano_exact_md/prior_benchmark_binary_medium_v1/comparison_summary.json`
@@ -302,7 +305,7 @@ Re-freeze that control baseline from the current anchor when needed:
 
 ```bash
 tab-foundry bench registry freeze-baseline \
-  --baseline-id cls_benchmark_linear_v2 \
+  --baseline-id cls_benchmark_linear_multiclass_medium_v1 \
   --experiment cls_benchmark_staged_prior \
   --config-profile cls_benchmark_staged_prior \
   --run-dir outputs/staged_ladder/01_nano_exact_md/prior_parity_fix \
@@ -436,7 +439,7 @@ Train-only `screen_only` rows still need:
 `result_card.md`. `screen_only` rows are diagnostic only.
 
 Benchmark-facing writeups should cite the locked manifest path,
-`cls_benchmark_linear_v2`, `training_surface_record.json`,
+`cls_benchmark_linear_multiclass_medium_v1`, `training_surface_record.json`,
 `research_card.md`, `campaign.yaml`, and `result_card.md`.
 
 For scaling studies whose benchmark-only runs were executed with

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -530,7 +530,7 @@ The active Muon lineage is:
 - `tf_rd_009_muon_ns_one_epoch_medium_v1`
 - `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
 - `tf_rd_009_muon_phase2_one_epoch_v1`
-- active `#284` strict LMO transfer:
+- completed `#284` strict LMO transfer:
   `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
 
 `tf_rd_009_muon_width_screen_medium_v1` completed the fresh Muon width screen
@@ -539,15 +539,15 @@ on the full 2500-step `v6` contract, with `60x2=0.4172`, `48x2=0.4147`,
 as the formal external Muon anchor, but carry `128x2` forward as the current
 in-family baseline. The corrected Muon Phase-2 closeout in merged PR
 [#280](https://github.com/bensonlee5/tab-foundry/pull/280) keeps `L(N,S)` as a
-directional signal only, so the next defended execution lane is the faithful
-paper-derived strict shared-anchor LMO transfer study for
-[#284](https://github.com/bensonlee5/tab-foundry/issues/284): keep geometry
-fixed at `144x4`, keep the default anchor benchmark
-`openml_classification_medium_v1`, and compare the carried baselines against
+directional signal only. The completed faithful paper-derived strict
+shared-anchor LMO transfer study for
+[#284](https://github.com/bensonlee5/tab-foundry/issues/284) kept geometry
+fixed at `144x4`, kept the default anchor benchmark
+`openml_classification_medium_v1`, and compared the carried baselines against
 paper-derived Regime `B` and Regime `D` across the reused budget ladder
 `T0/T1/T2 = {625×64, 2500×64, 5000×64}`.
 
-The active `#284` sweep is the single shared-anchor transfer surface:
+The completed `#284` sweep is the single shared-anchor transfer surface:
 
 - `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
   - strict `10`-row comparison surface at `144x4`
@@ -567,7 +567,7 @@ The earlier screen-based transfer sweeps
 historical context only; they are no longer the active operator route for
 `#284`.
 
-The carried model architecture for the active `#284` sweep is the fixed
+The carried model architecture for the completed `#284` sweep is the fixed
 `tabfoundry_sandwich` surface:
 
 - geometry: `144x4`
@@ -599,12 +599,12 @@ The paper-derived transfer laws are implemented directly:
 - with `task_batch_size=16`, `weight_decay=0.01`, and warmup/cosine schedule
   shape held fixed
 
-Use the shared carried low-batch `T0` row as the one anchor source of truth,
-then compare Regime `B` and Regime `D` at `T2` first and `T1` second. After
-that regime choice, compare the winning law-derived regime against the carried
-high-batch baseline before opening any later Phase-2B rerun issue. The earlier
-endpoint selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` and the
-screen-based transfer pair remain tracked superseded context only.
+The completed result kept Regime `B` over Regime `D` by the tracked `T2`-then-
+`T1` rule, but `B@T2=0.5143437440` did not beat carried high-batch
+`T2=0.5135392585`, so `#284` closes with no later Phase-2B rerun issue from
+this lane. The earlier endpoint selector
+`tf_rd_009_muon_training_dynamics_endpoint_medium_v1` and the screen-based
+transfer pair remain tracked superseded context only.
 
 Treat `openml_classification_medium_v1` as the repo-wide default anchor
 benchmark until explicitly changed. Validation and inspection now fail fast if a

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -494,15 +494,15 @@ tab-foundry research sweep list-sweeps
 tab-foundry dev resolve-config \
   experiment=cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 tab-foundry research sweep inspect \
-  --sweep-id tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 \
+  --sweep-id tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 \
   --order 1 \
   --json
 tab-foundry research sweep inspect \
-  --sweep-id tf_rd_009_muon_training_dynamics_transfer_medium_v1 \
+  --sweep-id tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 \
   --order 7 \
   --json
 tab-foundry research sweep summarize \
-  --sweep-id tf_rd_009_muon_training_dynamics_transfer_medium_v1 \
+  --sweep-id tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 \
   --json
 tab-foundry research scaling inspect \
   --study tf_rd_009_muon_phase2_one_epoch_v1 \
@@ -530,8 +530,8 @@ The active Muon lineage is:
 - `tf_rd_009_muon_ns_one_epoch_medium_v1`
 - `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
 - `tf_rd_009_muon_phase2_one_epoch_v1`
-- active `#284` screen: `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
-- active `#284` validation: `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+- active `#284` strict LMO transfer:
+  `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
 
 `tf_rd_009_muon_width_screen_medium_v1` completed the fresh Muon width screen
 on the full 2500-step `v6` contract, with `60x2=0.4172`, `48x2=0.4147`,
@@ -540,27 +540,49 @@ as the formal external Muon anchor, but carry `128x2` forward as the current
 in-family baseline. The corrected Muon Phase-2 closeout in merged PR
 [#280](https://github.com/bensonlee5/tab-foundry/pull/280) keeps `L(N,S)` as a
 directional signal only, so the next defended execution lane is the faithful
-paper-derived transfer study for
+paper-derived strict shared-anchor LMO transfer study for
 [#284](https://github.com/bensonlee5/tab-foundry/issues/284): keep geometry
 fixed at `144x4`, keep the default anchor benchmark
 `openml_classification_medium_v1`, and compare the carried baselines against
 paper-derived Regime `B` and Regime `D` across the reused budget ladder
 `T0/T1/T2 = {625×64, 2500×64, 5000×64}`.
 
-The screen and validation sweeps are intentionally separate:
+The active `#284` sweep is the single shared-anchor transfer surface:
 
-- `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
-  - `30` train-only T0 rows at `144x4`
-  - Regime `B`: fixed batch `B(T)=64`, `6` rows over
-    `lr_max ∈ {1e-3, 2e-3}` and `momentum ∈ {0.90, 0.95, 0.975}`
-  - Regime `D`: `24` rows over realizable `B0 ∈ {64, 80, 96, 128}` with the
-    same LR and momentum grid
-- `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
-  - logical `12`-row comparison surface at `144x4`
+- `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
+  - strict `10`-row comparison surface at `144x4`
   - imported carried low-batch baselines at `T0/T1/T2`
-  - new carried high-batch baselines at `T0/T1/T2`
-  - screened Regime `B` winner transferred to `T0/T1/T2`
-  - screened Regime `D` winner transferred to `T0/T1/T2`
+  - carried high-batch baselines at `T0/T1/T2`
+  - law-derived Regime `B` rows at `T1/T2`
+  - law-derived Regime `D` rows at `T1/T2`
+  - no regime-specific `T0` rows, because both regimes share the same carried
+    low-batch `T0` anchor by construction
+  - no T0 hyperparameter search in the canonical `#284` path
+  - winner rule: lower corrected benchmark log loss at `T2`, then lower log
+    loss at `T1`
+
+The earlier screen-based transfer sweeps
+`tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1` and
+`tf_rd_009_muon_training_dynamics_transfer_medium_v1` remain preserved
+historical context only; they are no longer the active operator route for
+`#284`.
+
+The carried model architecture for the active `#284` sweep is the fixed
+`tabfoundry_sandwich` surface:
+
+- geometry: `144x4`
+- frozen non-scaling architecture knobs:
+  - `sandwich_latents=24`
+  - `sandwich_heads=1`
+  - `sandwich_ff_expansion=2`
+  - `sandwich_summary_tokens_per_axis=3`
+  - `sandwich_self_attention_per_cross=4`
+  - `sandwich_pre_row_attention_layers=1`
+  - `sandwich_pre_column_attention_layers=1`
+  - `sandwich_pre_column_inducing_tokens=16`
+  - `feature_type_conditioning=film`
+  - `floating_likelihood=single_gaussian`
+  - `integer_likelihood=hybrid_mixture`
 
 The paper-derived transfer laws are implemented directly:
 
@@ -577,11 +599,12 @@ The paper-derived transfer laws are implemented directly:
 - with `task_batch_size=16`, `weight_decay=0.01`, and warmup/cosine schedule
   shape held fixed
 
-Use the faithful screen first, then benchmark the regime winners and compare
-them against the carried baselines on corrected benchmark log loss. The earlier
-endpoint selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` remains
-tracked superseded context only; it is no longer the canonical `#284` decision
-surface.
+Use the shared carried low-batch `T0` row as the one anchor source of truth,
+then compare Regime `B` and Regime `D` at `T2` first and `T1` second. After
+that regime choice, compare the winning law-derived regime against the carried
+high-batch baseline before opening any later Phase-2B rerun issue. The earlier
+endpoint selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` and the
+screen-based transfer pair remain tracked superseded context only.
 
 Treat `openml_classification_medium_v1` as the repo-wide default anchor
 benchmark until explicitly changed. Validation and inspection now fail fast if a

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -494,8 +494,15 @@ tab-foundry research sweep list-sweeps
 tab-foundry dev resolve-config \
   experiment=cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 tab-foundry research sweep inspect \
-  --sweep-id tf_rd_009_muon_training_dynamics_endpoint_medium_v1 \
+  --sweep-id tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 \
   --order 1 \
+  --json
+tab-foundry research sweep inspect \
+  --sweep-id tf_rd_009_muon_training_dynamics_transfer_medium_v1 \
+  --order 7 \
+  --json
+tab-foundry research sweep summarize \
+  --sweep-id tf_rd_009_muon_training_dynamics_transfer_medium_v1 \
   --json
 tab-foundry research scaling inspect \
   --study tf_rd_009_muon_phase2_one_epoch_v1 \
@@ -523,7 +530,8 @@ The active Muon lineage is:
 - `tf_rd_009_muon_ns_one_epoch_medium_v1`
 - `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
 - `tf_rd_009_muon_phase2_one_epoch_v1`
-- next selector sweep: `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
+- active `#284` screen: `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
+- active `#284` validation: `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
 
 `tf_rd_009_muon_width_screen_medium_v1` completed the fresh Muon width screen
 on the full 2500-step `v6` contract, with `60x2=0.4172`, `48x2=0.4147`,
@@ -531,18 +539,55 @@ on the full 2500-step `v6` contract, with `60x2=0.4172`, `48x2=0.4147`,
 as the formal external Muon anchor, but carry `128x2` forward as the current
 in-family baseline. The corrected Muon Phase-2 closeout in merged PR
 [#280](https://github.com/bensonlee5/tab-foundry/pull/280) keeps `L(N,S)` as a
-directional signal only, so the next defended execution lane is the compact
-training-dynamics selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
-over `128x2`, `144x4`, and `264x6` at the fixed 5000-step endpoint.
+directional signal only, so the next defended execution lane is the faithful
+paper-derived transfer study for
+[#284](https://github.com/bensonlee5/tab-foundry/issues/284): keep geometry
+fixed at `144x4`, keep the default anchor benchmark
+`openml_classification_medium_v1`, and compare the carried baselines against
+paper-derived Regime `B` and Regime `D` across the reused budget ladder
+`T0/T1/T2 = {625×64, 2500×64, 5000×64}`.
 
-The selector keeps the corrected `openml_classification_medium_v1` benchmark,
-the fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus, and ranks rows
-on a quality/time Pareto frontier across four prescriptions per geometry:
+The screen and validation sweeps are intentionally separate:
 
-- carried low-batch baseline
-- carried high-batch empirical reference
-- linear LR/batch prescription
-- momentum-timescale prescription
+- `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
+  - `30` train-only T0 rows at `144x4`
+  - Regime `B`: fixed batch `B(T)=64`, `6` rows over
+    `lr_max ∈ {1e-3, 2e-3}` and `momentum ∈ {0.90, 0.95, 0.975}`
+  - Regime `D`: `24` rows over realizable `B0 ∈ {64, 80, 96, 128}` with the
+    same LR and momentum grid
+- `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+  - logical `12`-row comparison surface at `144x4`
+  - imported carried low-batch baselines at `T0/T1/T2`
+  - new carried high-batch baselines at `T0/T1/T2`
+  - screened Regime `B` winner transferred to `T0/T1/T2`
+  - screened Regime `D` winner transferred to `T0/T1/T2`
+
+The paper-derived transfer laws are implemented directly:
+
+- Regime `B`
+  - `B(T)=64`
+  - `alpha(T)=alpha0*(T/T0)^(-1/2)`
+  - `lr_max(T)=lr0*(T/T0)^(-3/4)`
+- Regime `D`
+  - `B(T)=B0*(T/T0)^(1/6)`
+  - `alpha(T)=alpha0*(T/T0)^(-1/3)`
+  - `lr_max(T)=lr0*(T/T0)^(-7/12)`
+- `momentum(T)=1-alpha(T)`
+- `min_lr=lr_max*1e-3`
+- with `task_batch_size=16`, `weight_decay=0.01`, and warmup/cosine schedule
+  shape held fixed
+
+Use the faithful screen first, then benchmark the regime winners and compare
+them against the carried baselines on corrected benchmark log loss. The earlier
+endpoint selector `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` remains
+tracked superseded context only; it is no longer the canonical `#284` decision
+surface.
+
+Treat `openml_classification_medium_v1` as the repo-wide default anchor
+benchmark until explicitly changed. Validation and inspection now fail fast if a
+default-anchor sweep resolves to the wrong manifest hash or to any binary
+benchmark surface, which closes the loophole that previously let stale binary
+contracts sneak back into TF-RD-009 recovery work.
 
 For the historical corrected one-epoch schedulefree rerun, materialize
 `tf_rd_010_dagzoo_medium_control_curated_v6` remotely first rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tab-foundry"
-version = "0.17.2"
+version = "0.17.3"
 description = "Tabular foundation model that generates its own training data via dagzoo, trains on it, and predicts on new tasks"
 readme = "README.md"
 license = "Apache-2.0"

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -511,29 +511,56 @@ Next sweep ordering after the corrected Phase-2 closeout:
   path should expose the active benchmark, corpus, formal anchor, carried
   baseline, linked study, kept winner, and fit/audit readiness from one place
 - third: run
-  [#284](https://github.com/bensonlee5/tab-foundry/issues/284), the compact
-  `12`-row Muon training-dynamics selector over `128x2`, `144x4`, and `264x6`
-  at a fixed 5000-step endpoint, and rank rows on the corrected quality/time
-  Pareto frontier
-- fourth: only after the selector keeps one dynamics contract should a later
+  [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the faithful
+  `144x4` Muon transfer study: first run the `30`-row T0 screen
+  `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`, then validate
+  the screened Regime `B` and Regime `D` winners against the carried baselines
+  on `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+- fourth: only after the transfer study keeps one dynamics contract should a later
   Muon Phase-2B rerun redesign the multi-geometry batch surface before
   revisiting `Bcrit(L)` or any `Cmin` story
 - fifth: keep larger-model follow-on work separate from this base study;
   [#269](https://github.com/bensonlee5/tab-foundry/issues/269) and
   [#259](https://github.com/bensonlee5/tab-foundry/issues/259) are both
-  downstream of the cleanup and selector work, not the immediate next action
+  downstream of the cleanup and faithful transfer work, not the immediate next
+  action
 - last: keep missingness as inference-time evaluation only, after the corrected
   multiclass benchmark contract is trusted
 
 TF-RD-009 adoption decision: use the corrected Muon Phase-2 study as the fresh
 directional `L(N,S)` surface for the Muon family, but do not use `Bcrit(L)` to
 derive `Cmin` and do not make Chinchilla-like compute-optimal claims until the
-cleanup lane and compact training-dynamics selector land, a kept dynamics
-contract is chosen, and a later multi-geometry batch rerun materially improves
-the conditioning of the batch surface. The corrected empirical lesson is
+cleanup lane and faithful transfer study land, a kept dynamics contract is
+chosen, and a later multi-geometry batch rerun materially improves the
+conditioning of the batch surface. The corrected empirical lesson is
 training-dynamics-first: on the trusted multiclass benchmark, batch-side gains
 were larger than geometry-only gains, so the next defended study should test
 optimizer and batch invariants before reopening larger-family work.
+
+The faithful transfer study is derived directly from
+[arXiv:2603.15958](https://arxiv.org/abs/2603.15958) rather than from the
+earlier heuristic endpoint selector. Keep geometry fixed at `144x4`, reuse the
+existing rung-equivalent effective-task budgets `T0/T1/T2 = {625×64, 2500×64,
+5000×64}`, and carry the repo-wide default anchor benchmark
+`openml_classification_medium_v1` forward as the only admissible benchmark
+surface until explicitly changed.
+
+- Regime `B`:
+  - `B(T)=64`
+  - `alpha(T)=alpha0*(T/T0)^(-1/2)`
+  - `lr_max(T)=lr0*(T/T0)^(-3/4)`
+- Regime `D`:
+  - `B(T)=B0*(T/T0)^(1/6)`
+  - `alpha(T)=alpha0*(T/T0)^(-1/3)`
+  - `lr_max(T)=lr0*(T/T0)^(-7/12)`
+- in both regimes:
+  - `momentum(T)=1-alpha(T)`
+  - `min_lr=lr_max*1e-3`
+  - `task_batch_size=16`
+  - realized effective batch is the nearest multiple of `16`
+  - `max_steps=round_half_up(target_effective_budget / realized_effective_batch)`
+  - validation should fail if realized batch or effective-budget drift exceeds
+    the default `2%` guard
 
 ## Joint Width-Depth Derivation For [#255](https://github.com/bensonlee5/tab-foundry/issues/255)
 

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -512,10 +512,9 @@ Next sweep ordering after the corrected Phase-2 closeout:
   baseline, linked study, kept winner, and fit/audit readiness from one place
 - third: run
   [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the faithful
-  `144x4` Muon transfer study: first run the `30`-row T0 screen
-  `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`, then validate
-  the screened Regime `B` and Regime `D` winners against the carried baselines
-  on `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+  `144x4` Muon transfer study as one strict shared-anchor LMO sweep:
+  `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`, with no T0
+  hyperparameter screen in the canonical path
 - fourth: only after the transfer study keeps one dynamics contract should a later
   Muon Phase-2B rerun redesign the multi-geometry batch surface before
   revisiting `Bcrit(L)` or any `Cmin` story
@@ -543,7 +542,19 @@ earlier heuristic endpoint selector. Keep geometry fixed at `144x4`, reuse the
 existing rung-equivalent effective-task budgets `T0/T1/T2 = {625×64, 2500×64,
 5000×64}`, and carry the repo-wide default anchor benchmark
 `openml_classification_medium_v1` forward as the only admissible benchmark
-surface until explicitly changed.
+contract. The active `#284` sweep uses one shared carried low-batch Muon `T0`
+artifact as the anchor source of truth, then derives Regime `B` and Regime `D`
+deterministically at `T1/T2`; there is no regime-specific T0 search in the
+canonical lane.
+surface until explicitly changed. The carried tested architecture is the
+concrete sandwich surface `d_icl=144`, `sandwich_layers=4`,
+`sandwich_latents=24`, `sandwich_heads=1`,
+`sandwich_summary_tokens_per_axis=3`, `sandwich_ff_expansion=2`,
+`sandwich_self_attention_per_cross=4`,
+`sandwich_pre_row_attention_layers=1`,
+`sandwich_pre_column_attention_layers=1`, and
+`sandwich_pre_column_inducing_tokens=16`; the study is testing training
+dynamics on that fixed architecture, not reopening architecture movement.
 
 - Regime `B`:
   - `B(T)=64`

--- a/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
+++ b/reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md
@@ -505,19 +505,21 @@ Next sweep ordering after the corrected Phase-2 closeout:
 - first: keep merged PR [#280](https://github.com/bensonlee5/tab-foundry/pull/280)
   as a directional Muon Phase-2 result and do not claim compute-optimality from
   it
-- second: land
-  [#283](https://github.com/bensonlee5/tab-foundry/issues/283) so the active
-  Muon lineage is easy to inspect and hard to misuse; the canonical operator
-  path should expose the active benchmark, corpus, formal anchor, carried
-  baseline, linked study, kept winner, and fit/audit readiness from one place
-- third: run
-  [#284](https://github.com/bensonlee5/tab-foundry/issues/284) as the faithful
-  `144x4` Muon transfer study as one strict shared-anchor LMO sweep:
-  `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`, with no T0
-  hyperparameter screen in the canonical path
-- fourth: only after the transfer study keeps one dynamics contract should a later
-  Muon Phase-2B rerun redesign the multi-geometry batch surface before
-  revisiting `Bcrit(L)` or any `Cmin` story
+- second:
+  [#283](https://github.com/bensonlee5/tab-foundry/issues/283) is satisfied on
+  this branch: the active Muon lineage is easy to inspect and hard to misuse,
+  with canonical sweep/scaling inspection surfaces, lineage/context display,
+  and fail-fast default-anchor contract guards
+- third:
+  [#284](https://github.com/bensonlee5/tab-foundry/issues/284) is complete as
+  the strict shared-anchor `144x4` Muon transfer sweep
+  `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`; the law-derived
+  Regime `B` beats Regime `D`, but `B@T2=0.5143437440` does not beat carried
+  high-batch `T2=0.5135392585`, so neither law-derived regime is strong enough
+  to justify a Phase-2B rerun from this study
+- fourth: only after some later separate study produces a better-conditioned
+  multi-geometry batch surface should any Muon Phase-2B rerun redesign the
+  batch surface before revisiting `Bcrit(L)` or any `Cmin` story
 - fifth: keep larger-model follow-on work separate from this base study;
   [#269](https://github.com/bensonlee5/tab-foundry/issues/269) and
   [#259](https://github.com/bensonlee5/tab-foundry/issues/259) are both
@@ -528,23 +530,22 @@ Next sweep ordering after the corrected Phase-2 closeout:
 
 TF-RD-009 adoption decision: use the corrected Muon Phase-2 study as the fresh
 directional `L(N,S)` surface for the Muon family, but do not use `Bcrit(L)` to
-derive `Cmin` and do not make Chinchilla-like compute-optimal claims until the
-cleanup lane and faithful transfer study land, a kept dynamics contract is
-chosen, and a later multi-geometry batch rerun materially improves the
-conditioning of the batch surface. The corrected empirical lesson is
-training-dynamics-first: on the trusted multiclass benchmark, batch-side gains
-were larger than geometry-only gains, so the next defended study should test
-optimizer and batch invariants before reopening larger-family work.
+derive `Cmin` and do not make Chinchilla-like compute-optimal claims. The
+cleanup lane is now satisfied, and the faithful transfer study is now complete:
+the corrected empirical lesson remains training-dynamics-first, but the strict
+shared-anchor LMO laws did not beat the carried high-batch baseline at `T2`, so
+this negative transfer result does not justify a later Phase-2B rerun by
+itself and does not reopen larger-family or compute-frontier work.
 
 The faithful transfer study is derived directly from
 [arXiv:2603.15958](https://arxiv.org/abs/2603.15958) rather than from the
-earlier heuristic endpoint selector. Keep geometry fixed at `144x4`, reuse the
-existing rung-equivalent effective-task budgets `T0/T1/T2 = {625×64, 2500×64,
-5000×64}`, and carry the repo-wide default anchor benchmark
-`openml_classification_medium_v1` forward as the only admissible benchmark
-contract. The active `#284` sweep uses one shared carried low-batch Muon `T0`
-artifact as the anchor source of truth, then derives Regime `B` and Regime `D`
-deterministically at `T1/T2`; there is no regime-specific T0 search in the
+earlier heuristic endpoint selector. It kept geometry fixed at `144x4`, reused
+the rung-equivalent effective-task budgets `T0/T1/T2 = {625×64, 2500×64,
+5000×64}`, and carried the repo-wide default anchor benchmark
+`openml_classification_medium_v1` as the only admissible benchmark contract.
+The completed `#284` sweep used one shared carried low-batch Muon `T0`
+artifact as the anchor source of truth, then derived Regime `B` and Regime `D`
+deterministically at `T1/T2`; there was no regime-specific T0 search in the
 canonical lane.
 surface until explicitly changed. The carried tested architecture is the
 concrete sandwich surface `d_icl=144`, `sandwich_layers=4`,
@@ -572,6 +573,14 @@ dynamics on that fixed architecture, not reopening architecture movement.
   - `max_steps=round_half_up(target_effective_budget / realized_effective_batch)`
   - validation should fail if realized batch or effective-budget drift exceeds
     the default `2%` guard
+- completed result:
+  - kept law-derived regime: `B`
+  - `B@T1=0.5239001271`, `B@T2=0.5143437440`
+  - `D@T1=0.5268794041`, `D@T2=0.5169818590`
+  - carried high-batch `T2=0.5135392585`
+  - imported carried low-batch `T2=0.4914031270`
+  - `B` lost to carried high-batch at `T2` by `+0.0008044855` log loss, so the
+    study closes without opening a later Phase-2B rerun issue
 
 ## Joint Width-Depth Derivation For [#255](https://github.com/bensonlee5/tab-foundry/issues/255)
 

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -10700,8 +10700,8 @@ deltas:
       batch fixed while transferring Muon momentum and lr with budget.
     upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
     expected_effect: If the paper fixed-batch transfer law is the better inductive
-      bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local
-      retuning.
+      bias, the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2
+      without local retuning.
     adequacy_knobs:
     - paper-derived budget transfer law
     - corrected openml_classification_medium_v1 anchor benchmark
@@ -10791,8 +10791,8 @@ deltas:
       default_plan: []
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Screen the faithful transfer candidates for regime B on T0,
-      then carry only the winning anchor into tf_rd_009_muon_training_dynamics_transfer_medium_v1.
+    default_next_action: Apply the strict shared-anchor LMO transfer law for regime
+      B from the carried low-batch T0 anchor inside tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1.
     applicability_guards: []
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1:
     dimension_family: training
@@ -10802,8 +10802,8 @@ deltas:
       effective batch, Muon momentum, and lr with budget.
     upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
     expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
-      bias, the screened T0 anchor should beat both carried baselines on corrected
-      benchmark log loss.
+      bias, the strict shared T0 anchor transfer should beat both carried baselines
+      on corrected benchmark log loss.
     adequacy_knobs:
     - paper-derived budget transfer law
     - corrected openml_classification_medium_v1 anchor benchmark
@@ -10893,6 +10893,6 @@ deltas:
       default_plan: []
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Screen the faithful transfer candidates for regime D on T0,
-      then carry only the winning anchor into tf_rd_009_muon_training_dynamics_transfer_medium_v1.
+    default_next_action: Apply the strict shared-anchor LMO transfer law for regime
+      D from the carried low-batch T0 anchor inside tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1.
     applicability_guards: []

--- a/reference/system_delta_catalog.yaml
+++ b/reference/system_delta_catalog.yaml
@@ -4,21 +4,24 @@ deltas:
     dimension_family: model
     family: target_conditioning
     binary_applicable: true
-    description: Replace mean-padded linear target conditioning with train-label embeddings plus a learned test token.
+    description: Replace mean-padded linear target conditioning with train-label embeddings
+      plus a learned test token.
     upstream_delta: Upstream nanoTabPFN does not use label tokens on the binary path.
-    expected_effect: Better label separation on some binary tasks with possible increased variance on tiny support sets.
+    expected_effect: Better label separation on some binary tasks with possible increased
+      variance on tiny support sets.
     adequacy_knobs:
-      - many_class_base should stay at 2 on the locked binary surface.
-      - Negative evidence should be checked for calibration drift before rejection.
+    - many_class_base should stay at 2 on the locked binary surface.
+    - Negative evidence should be checked for calibration drift before rejection.
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the isolated toggle before changing optimizer settings.
-        - If weak, inspect whether the issue is decision-boundary sharpness or late-curve drift.
+      - Confirm the isolated toggle before changing optimizer settings.
+      - If weak, inspect whether the issue is decision-boundary sharpness or late-curve
+        drift.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: label_token
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -34,28 +37,34 @@ deltas:
           corpus_ref: tf_rd_013_current_corpus_default_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Train the first anchor-only label-token run on the locked medium binary surface.
+    default_next_action: Train the first anchor-only label-token run on the locked
+      medium binary surface.
     applicability_guards: []
-
   delta_shared_feature_norm:
     dimension_family: model
     family: feature_encoding
     binary_applicable: true
-    description: Replace the internal nano feature path with the shared linear feature encoder while keeping scalar-per-feature tokenization.
-    upstream_delta: Upstream nanoTabPFN keeps its own internal feature normalization/encoding path.
-    expected_effect: Better transfer across heterogeneous columns, with risk that the shared path simply mismatches the compact binary anchor scale.
+    description: Replace the internal nano feature path with the shared linear feature
+      encoder while keeping scalar-per-feature tokenization.
+    upstream_delta: Upstream nanoTabPFN keeps its own internal feature normalization/encoding
+      path.
+    expected_effect: Better transfer across heterogeneous columns, with risk that
+      the shared path simply mismatches the compact binary anchor scale.
     adequacy_knobs:
-      - input_normalization remains train_zscore_clip on the anchor unless the queue row explicitly changes preprocessing.
-      - If performance drops, note whether the harm appears early or only after longer training.
+    - input_normalization remains train_zscore_clip on the anchor unless the queue
+      row explicitly changes preprocessing.
+    - If performance drops, note whether the harm appears early or only after longer
+      training.
     parameter_adequacy_policy:
       default_plan:
-        - Keep optimizer and row/context structure fixed for the first pass.
-        - Only treat a weak result as structural evidence after checking whether normalization mismatch is the dominant failure mode.
+      - Keep optimizer and row/context structure fixed for the first pass.
+      - Only treat a weak result as structural evidence after checking whether normalization
+        mismatch is the dominant failure mode.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: shared_norm
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -78,32 +87,33 @@ deltas:
             trace_activations: true
     default_next_action: Run the isolated shared-feature-encoder comparison.
     applicability_guards: []
-
   delta_anchor_activation_trace_baseline:
     dimension_family: training
     family: diagnostics
     binary_applicable: true
-    description: >-
-      Keep the locked anchor model surface fixed but rerun prior training with
-      activation tracing enabled so forward-pass norm dynamics are captured in
+    description: Keep the locked anchor model surface fixed but rerun prior training
+      with activation tracing enabled so forward-pass norm dynamics are captured in
       `gradient_history.jsonl` and `telemetry.json`.
-    upstream_delta: Upstream nanoTabPFN does not emit comparable forward-pass activation telemetry.
-    expected_effect: >-
-      No model-quality change is expected; this row establishes the traced
-      anchor baseline needed to interpret later shared-encoder stabilization
+    upstream_delta: Upstream nanoTabPFN does not emit comparable forward-pass activation
+      telemetry.
+    expected_effect: No model-quality change is expected; this row establishes the
+      traced anchor baseline needed to interpret later shared-encoder stabilization
       runs.
     adequacy_knobs:
-      - Treat this as a diagnostic rerun of the anchor, not a new structural model claim.
-      - Confirm the additive tracing overhead does not perturb the run contract or artifact schema.
+    - Treat this as a diagnostic rerun of the anchor, not a new structural model claim.
+    - Confirm the additive tracing overhead does not perturb the run contract or artifact
+      schema.
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the traced run preserves the anchor model, data, and preprocessing surfaces.
-        - Use the emitted activation norms as the baseline comparator for all later stabilization rows.
+      - Confirm the traced run preserves the anchor model, data, and preprocessing
+        surfaces.
+      - Use the emitted activation norms as the baseline comparator for all later
+        stabilization rows.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -122,33 +132,36 @@ deltas:
         overrides:
           runtime:
             trace_activations: true
-    default_next_action: Run the traced anchor baseline before comparing shared-encoder stabilization variants.
+    default_next_action: Run the traced anchor baseline before comparing shared-encoder
+      stabilization variants.
     applicability_guards: []
-
   delta_shared_feature_norm_with_post_layernorm:
     dimension_family: model
     family: feature_encoding
     binary_applicable: true
-    description: >-
-      Shared linear feature encoder with explicit post-encoder LayerNorm before
-      the transformer blocks.
-    upstream_delta: Upstream nanoTabPFN does not expose a separate post-encoder normalization stage on this path.
-    expected_effect: >-
-      LayerNorm after encoding should stabilize the activation scale entering
-      the transformer and improve late-curve retention relative to the plain
+    description: Shared linear feature encoder with explicit post-encoder LayerNorm
+      before the transformer blocks.
+    upstream_delta: Upstream nanoTabPFN does not expose a separate post-encoder normalization
+      stage on this path.
+    expected_effect: LayerNorm after encoding should stabilize the activation scale
+      entering the transformer and improve late-curve retention relative to the plain
       shared feature encoder row.
     adequacy_knobs:
-      - Compare pre-transformer and per-block activation growth directly against the traced shared-without-post-norm run.
-      - Keep optimizer, dataset bundle, and preprocessing fixed so only the post-encoder normalization changes.
+    - Compare pre-transformer and per-block activation growth directly against the
+      traced shared-without-post-norm run.
+    - Keep optimizer, dataset bundle, and preprocessing fixed so only the post-encoder
+      normalization changes.
     parameter_adequacy_policy:
       default_plan:
-        - Compare the traced shared baseline and this row jointly before drawing conclusions about structural encoder quality.
-        - If the row is mixed, inspect whether activation-scale stabilization improves drift even when final ROC AUC is neutral.
+      - Compare the traced shared baseline and this row jointly before drawing conclusions
+        about structural encoder quality.
+      - If the row is mixed, inspect whether activation-scale stabilization improves
+        drift even when final ROC AUC is neutral.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -167,33 +180,36 @@ deltas:
         overrides:
           runtime:
             trace_activations: true
-    default_next_action: Run after the traced shared-feature baseline to test whether LayerNorm fixes late-curve retention.
+    default_next_action: Run after the traced shared-feature baseline to test whether
+      LayerNorm fixes late-curve retention.
     applicability_guards: []
-
   delta_shared_feature_norm_with_post_rmsnorm:
     dimension_family: model
     family: feature_encoding
     binary_applicable: true
-    description: >-
-      Shared linear feature encoder with explicit post-encoder RMSNorm before
-      the transformer blocks.
-    upstream_delta: Upstream nanoTabPFN does not expose a separate post-encoder normalization stage on this path.
-    expected_effect: >-
-      RMSNorm may stabilize the shared encoder activation scale with less
-      feature rescaling than LayerNorm, offering a second normalization
-      hypothesis for the late-curve retention gap.
+    description: Shared linear feature encoder with explicit post-encoder RMSNorm
+      before the transformer blocks.
+    upstream_delta: Upstream nanoTabPFN does not expose a separate post-encoder normalization
+      stage on this path.
+    expected_effect: RMSNorm may stabilize the shared encoder activation scale with
+      less feature rescaling than LayerNorm, offering a second normalization hypothesis
+      for the late-curve retention gap.
     adequacy_knobs:
-      - Compare against both the traced shared baseline and the post-layernorm row before preferring one normalization family.
-      - Keep optimizer, dataset bundle, and preprocessing fixed so only the post-encoder normalization changes.
+    - Compare against both the traced shared baseline and the post-layernorm row before
+      preferring one normalization family.
+    - Keep optimizer, dataset bundle, and preprocessing fixed so only the post-encoder
+      normalization changes.
     parameter_adequacy_policy:
       default_plan:
-        - Compare activation traces and final ROC AUC jointly against the traced shared baseline.
-        - Use the result to separate normalization-family effects from the shared feature encoder itself.
+      - Compare activation traces and final ROC AUC jointly against the traced shared
+        baseline.
+      - Use the result to separate normalization-family effects from the shared feature
+        encoder itself.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -212,28 +228,32 @@ deltas:
         overrides:
           runtime:
             trace_activations: true
-    default_next_action: Run after the LayerNorm variant to compare normalization families on the shared encoder path.
+    default_next_action: Run after the LayerNorm variant to compare normalization
+      families on the shared encoder path.
     applicability_guards: []
-
   delta_prenorm_block:
     dimension_family: model
     family: table_block
     binary_applicable: true
-    description: Switch the cell transformer from the nano post-norm block to the staged pre-norm block, still without test self-attention.
+    description: Switch the cell transformer from the nano post-norm block to the
+      staged pre-norm block, still without test self-attention.
     upstream_delta: Upstream nanoTabPFN uses the post-norm block only.
-    expected_effect: Potentially smoother optimization and lower drift, with the risk that post-norm remains better matched to the benchmark wrapper.
+    expected_effect: Potentially smoother optimization and lower drift, with the risk
+      that post-norm remains better matched to the benchmark wrapper.
     adequacy_knobs:
-      - The relevant knobs are still tficl_n_heads, tficl_n_layers, and head_hidden_dim.
-      - A weak result is ambiguous unless late-curve stability clearly worsens despite similar best-step performance.
+    - The relevant knobs are still tficl_n_heads, tficl_n_layers, and head_hidden_dim.
+    - A weak result is ambiguous unless late-curve stability clearly worsens despite
+      similar best-step performance.
     parameter_adequacy_policy:
       default_plan:
-        - Compare best ROC AUC, final ROC AUC, and drift jointly.
-        - Defer rather than reject if only the late portion of training worsens without a clear hyperparameter adequacy check.
+      - Compare best ROC AUC, final ROC AUC, and drift jointly.
+      - Defer rather than reject if only the late portion of training worsens without
+        a clear hyperparameter adequacy check.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -249,24 +269,28 @@ deltas:
         surface_label: runtime_default
     default_next_action: Run the pre-norm-only ablation.
     applicability_guards: []
-
   delta_test_self_attention:
     dimension_family: model
     family: table_block
     binary_applicable: true
-    description: Allow test-token self-attention inside the pre-norm block without adding any test-to-test cross-attention.
-    upstream_delta: Upstream nanoTabPFN blocks test-token self attention in the direct path.
-    expected_effect: Better preservation of per-test-token state with possible over-conditioning on individual test rows.
+    description: Allow test-token self-attention inside the pre-norm block without
+      adding any test-to-test cross-attention.
+    upstream_delta: Upstream nanoTabPFN blocks test-token self attention in the direct
+      path.
+    expected_effect: Better preservation of per-test-token state with possible over-conditioning
+      on individual test rows.
     adequacy_knobs:
-      - Interpretation depends on the paired pre-norm-only result; a weak result may just indicate the block style itself remains unsettled.
+    - Interpretation depends on the paired pre-norm-only result; a weak result may
+      just indicate the block style itself remains unsettled.
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against both the anchor and the pre-norm-only row in the written interpretation.
+      - Compare directly against both the anchor and the pre-norm-only row in the
+        written interpretation.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: test_self
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -280,28 +304,35 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Queue after the pre-norm-only run so the masking effect has a local comparator.
+    default_next_action: Queue after the pre-norm-only run so the masking effect has
+      a local comparator.
     applicability_guards: []
-
   delta_architecture_screen_nano_exact_replay:
     dimension_family: training
     family: baseline_replay
     binary_applicable: true
-    description: Replay the public `nano_exact` stage on `cls_benchmark_staged` before comparing the shared-surface bridge rows.
-    upstream_delta: Not applicable; this is a repo-local architecture-screen replay of the public `nano_exact` stage.
-    expected_effect: Establish a telemetry-complete local comparator for the stage-native bridge rows without changing the public model stage.
+    description: Replay the public `nano_exact` stage on `cls_benchmark_staged` before
+      comparing the shared-surface bridge rows.
+    upstream_delta: Not applicable; this is a repo-local architecture-screen replay
+      of the public `nano_exact` stage.
+    expected_effect: Establish a telemetry-complete local comparator for the stage-native
+      bridge rows without changing the public model stage.
     adequacy_knobs:
-      - Keep data, preprocessing, and training surfaces fixed to the canonical architecture-screen contract.
-      - Treat benchmark ROC as primary and use emitted telemetry only to confirm same-lane artifact parity.
+    - Keep data, preprocessing, and training surfaces fixed to the canonical architecture-screen
+      contract.
+    - Treat benchmark ROC as primary and use emitted telemetry only to confirm same-lane
+      artifact parity.
     parameter_adequacy_policy:
       default_plan:
-        - Run this row first so the bridge sweep has a local `cls_benchmark_staged` comparator with `gradient_history.jsonl` and `telemetry.json`.
-        - Compare later bridge rows against this replay rather than treating the older prior-lane anchor as artifact-complete.
+      - Run this row first so the bridge sweep has a local `cls_benchmark_staged`
+        comparator with `gradient_history.jsonl` and `telemetry.json`.
+      - Compare later bridge rows against this replay rather than treating the older
+        prior-lane anchor as artifact-complete.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: nano_exact
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -316,28 +347,35 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Run first to establish the architecture-screen replay baseline for the shared-surface bridge.
+    default_next_action: Run first to establish the architecture-screen replay baseline
+      for the shared-surface bridge.
     applicability_guards: []
-
   delta_architecture_screen_shared_norm:
     dimension_family: model
     family: feature_encoding
     binary_applicable: true
-    description: Evaluate the public `shared_norm` stage as the first stage-native step off the PFN-only encoder path on `cls_benchmark_staged`.
-    upstream_delta: Upstream nanoTabPFN does not expose the public shared-surface bridge row represented by `shared_norm`.
-    expected_effect: Move feature handling onto the shared staged surface while keeping scalar-per-feature tokenization and the post-norm table block fixed.
+    description: Evaluate the public `shared_norm` stage as the first stage-native
+      step off the PFN-only encoder path on `cls_benchmark_staged`.
+    upstream_delta: Upstream nanoTabPFN does not expose the public shared-surface
+      bridge row represented by `shared_norm`.
+    expected_effect: Move feature handling onto the shared staged surface while keeping
+      scalar-per-feature tokenization and the post-norm table block fixed.
     adequacy_knobs:
-      - Compare directly against the architecture-screen `nano_exact` replay before attributing later bridge changes.
-      - Use activation and gradient telemetry to confirm whether the shared encoder remains stable enough to serve as the first bridge step.
+    - Compare directly against the architecture-screen `nano_exact` replay before
+      attributing later bridge changes.
+    - Use activation and gradient telemetry to confirm whether the shared encoder
+      remains stable enough to serve as the first bridge step.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the first mandatory shared-surface comparator, not as a tokenizer or row-pool experiment.
-        - If weak, keep the result as bridge evidence and do not skip straight to later shared-surface rows without recording the regression.
+      - Treat this as the first mandatory shared-surface comparator, not as a tokenizer
+        or row-pool experiment.
+      - If weak, keep the result as bridge evidence and do not skip straight to later
+        shared-surface rows without recording the regression.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: shared_norm
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -352,28 +390,34 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Compare directly against the architecture-screen `nano_exact` replay before moving deeper into the bridge.
+    default_next_action: Compare directly against the architecture-screen `nano_exact`
+      replay before moving deeper into the bridge.
     applicability_guards: []
-
   delta_architecture_screen_prenorm_block:
     dimension_family: model
     family: table_block
     binary_applicable: true
-    description: Evaluate the public `prenorm_block` stage as the first stage-native backbone change on the shared architecture-screen surface.
-    upstream_delta: Upstream nanoTabPFN does not expose the public staged pre-norm bridge row represented by `prenorm_block`.
-    expected_effect: Keep the shared encoder fixed while switching the main table block to the staged pre-norm implementation.
+    description: Evaluate the public `prenorm_block` stage as the first stage-native
+      backbone change on the shared architecture-screen surface.
+    upstream_delta: Upstream nanoTabPFN does not expose the public staged pre-norm
+      bridge row represented by `prenorm_block`.
+    expected_effect: Keep the shared encoder fixed while switching the main table
+      block to the staged pre-norm implementation.
     adequacy_knobs:
-      - Compare against both the architecture-screen `nano_exact` replay and the public `shared_norm` row.
-      - Use final-vs-best benchmark behavior plus stage-local telemetry to separate outright regressions from bridge instability.
+    - Compare against both the architecture-screen `nano_exact` replay and the public
+      `shared_norm` row.
+    - Use final-vs-best benchmark behavior plus stage-local telemetry to separate
+      outright regressions from bridge instability.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this row as the first backbone change after the shared encoder is active.
-        - If mixed, preserve it as explicit bridge evidence rather than collapsing the result into the older hybrid-diagnostic prenorm evidence.
+      - Treat this row as the first backbone change after the shared encoder is active.
+      - If mixed, preserve it as explicit bridge evidence rather than collapsing the
+        result into the older hybrid-diagnostic prenorm evidence.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -388,28 +432,36 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Compare against the shared-norm row before deciding whether the bridge should advance through the pre-norm block.
+    default_next_action: Compare against the shared-norm row before deciding whether
+      the bridge should advance through the pre-norm block.
     applicability_guards: []
-
   delta_architecture_screen_small_class_head:
     dimension_family: model
     family: head
     binary_applicable: true
-    description: Evaluate the public `small_class_head` stage as the first shared-surface bridge row with the small-class head contract enabled.
-    upstream_delta: Upstream nanoTabPFN does not expose the public staged small-class bridge row represented by `small_class_head`.
-    expected_effect: Keep the shared encoder and pre-norm block fixed while promoting the head to the small-class contract that later grouped-token work should inherit from.
+    description: Evaluate the public `small_class_head` stage as the first shared-surface
+      bridge row with the small-class head contract enabled.
+    upstream_delta: Upstream nanoTabPFN does not expose the public staged small-class
+      bridge row represented by `small_class_head`.
+    expected_effect: Keep the shared encoder and pre-norm block fixed while promoting
+      the head to the small-class contract that later grouped-token work should inherit
+      from.
     adequacy_knobs:
-      - Compare against `prenorm_block` before attributing any effect to grouped-token readiness.
-      - Watch whether head-contract changes are neutral, stabilizing, or clearly harmful on the fixed binary architecture-screen surface.
+    - Compare against `prenorm_block` before attributing any effect to grouped-token
+      readiness.
+    - Watch whether head-contract changes are neutral, stabilizing, or clearly harmful
+      on the fixed binary architecture-screen surface.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as a bridge row, not as a many-class promotion or tokenization change.
-        - Use it to decide whether later grouped-token work should inherit the small-class head rather than stopping at the pre-norm block.
+      - Treat this as a bridge row, not as a many-class promotion or tokenization
+        change.
+      - Use it to decide whether later grouped-token work should inherit the small-class
+        head rather than stopping at the pre-norm block.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: small_class_head
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -424,28 +476,35 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Compare directly against `prenorm_block` to decide whether the bridge should carry the small-class head forward.
+    default_next_action: Compare directly against `prenorm_block` to decide whether
+      the bridge should carry the small-class head forward.
     applicability_guards: []
-
   delta_architecture_screen_test_self:
     dimension_family: model
     family: table_block
     binary_applicable: true
-    description: Evaluate the public `test_self` stage as the last shared-surface bridge row before grouped-token work.
-    upstream_delta: Upstream nanoTabPFN does not expose the public staged test-self bridge row represented by `test_self`.
-    expected_effect: Keep the shared bridge surface fixed while enabling the public test-self attention setting that later grouped-token work may inherit.
+    description: Evaluate the public `test_self` stage as the last shared-surface
+      bridge row before grouped-token work.
+    upstream_delta: Upstream nanoTabPFN does not expose the public staged test-self
+      bridge row represented by `test_self`.
+    expected_effect: Keep the shared bridge surface fixed while enabling the public
+      test-self attention setting that later grouped-token work may inherit.
     adequacy_knobs:
-      - Compare against both `prenorm_block` and `small_class_head` before concluding that test-self attention should be the grouped-token predecessor.
-      - Use stage-local telemetry to distinguish a local repair from a genuinely stronger bridge handoff row.
+    - Compare against both `prenorm_block` and `small_class_head` before concluding
+      that test-self attention should be the grouped-token predecessor.
+    - Use stage-local telemetry to distinguish a local repair from a genuinely stronger
+      bridge handoff row.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the final shared-surface bridge candidate before grouped tokens, not as tokenizer work.
-        - Pick between `small_class_head` and `test_self` only after the full five-row bridge sweep is visible together.
+      - Treat this as the final shared-surface bridge candidate before grouped tokens,
+        not as tokenizer work.
+      - Pick between `small_class_head` and `test_self` only after the full five-row
+        bridge sweep is visible together.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: test_self
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -460,29 +519,35 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Compare directly against `small_class_head` and lock only one grouped-token predecessor after the full bridge sweep.
+    default_next_action: Compare directly against `small_class_head` and lock only
+      one grouped-token predecessor after the full bridge sweep.
     applicability_guards: []
-
   delta_architecture_screen_grouped_tokens:
     dimension_family: model
     family: tokenization
     binary_applicable: true
-    description: Replace scalar-per-feature tokenization with the public grouped-token staged recipe on the locked shared-surface handoff.
-    upstream_delta: Upstream nanoTabPFN keeps one scalar token per feature on the direct binary path.
-    expected_effect: The tokenizer change becomes active on the shared surface and should be interpreted as the first stage-native row-first preparation step.
+    description: Replace scalar-per-feature tokenization with the public grouped-token
+      staged recipe on the locked shared-surface handoff.
+    upstream_delta: Upstream nanoTabPFN keeps one scalar token per feature on the
+      direct binary path.
+    expected_effect: The tokenizer change becomes active on the shared surface and
+      should be interpreted as the first stage-native row-first preparation step.
     adequacy_knobs:
-      - Treat this as a structural milestone before row-CLS, TFCol, or QASS follow-ons.
-      - If the benchmark read is mixed, follow with bounded stability tracing before redirecting later migration rows.
+    - Treat this as a structural milestone before row-CLS, TFCol, or QASS follow-ons.
+    - If the benchmark read is mixed, follow with bounded stability tracing before
+      redirecting later migration rows.
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the locked `prenorm_block` shared-surface handoff on the architecture-screen lane.
-        - Treat the first run as tokenizer evidence, not as row-pool or context evidence.
-        - Require a bounded stability read before treating a weak benchmark result as decisive rejection.
+      - Compare directly against the locked `prenorm_block` shared-surface handoff
+        on the architecture-screen lane.
+      - Treat the first run as tokenizer evidence, not as row-pool or context evidence.
+      - Require a bounded stability read before treating a weak benchmark result as
+        decisive rejection.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: grouped_tokens
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -497,30 +562,39 @@ deltas:
       training:
         surface_label: training_default
         overrides: {}
-    default_next_action: Run the first stage-native grouped-token benchmark row on top of the locked `prenorm_block` handoff.
+    default_next_action: Run the first stage-native grouped-token benchmark row on
+      top of the locked `prenorm_block` handoff.
     applicability_guards: []
-
   delta_tf_rd_021a_sandwich_replay_v1:
     dimension_family: model
     family: architecture_capacity
     binary_applicable: true
-    description: Replay the current repeated-input `tabfoundry_sandwich` prior-benchmark baseline before reading latent-count movement.
-    upstream_delta: Perceiver-style latent bottlenecks motivate treating latent count as an explicit capacity knob, but this replay row is repo-local.
-    expected_effect: Establish one local sandwich benchmark reference on the locked batch64-sqrt prior surface before latent-only and width follow-up rows are interpreted.
+    description: Replay the current repeated-input `tabfoundry_sandwich` prior-benchmark
+      baseline before reading latent-count movement.
+    upstream_delta: Perceiver-style latent bottlenecks motivate treating latent count
+      as an explicit capacity knob, but this replay row is repo-local.
+    expected_effect: Establish one local sandwich benchmark reference on the locked
+      batch64-sqrt prior surface before latent-only and width follow-up rows are interpreted.
     adequacy_knobs:
-      - Keep the prior batch, LR scaling, and benchmark bundle fixed to the locked prior anchor surface.
-      - Treat this row as the sandwich local reference for later rows, not as a promotion claim.
-      - Rank rows by final log loss first, final Brier score second, final ROC AUC third, and runtime fourth.
+    - Keep the prior batch, LR scaling, and benchmark bundle fixed to the locked prior
+      anchor surface.
+    - Treat this row as the sandwich local reference for later rows, not as a promotion
+      claim.
+    - Rank rows by final log loss first, final Brier score second, final ROC AUC third,
+      and runtime fourth.
     parameter_adequacy_policy:
       default_plan:
-        - Run this row first so the sandwich screen has one explicit local baseline on the benchmark prior surface.
-        - Compare all later sandwich rows against both this replay and the staged prior anchor.
-        - Keep the repeated-input architecture fixed while reading latent count and width.
+      - Run this row first so the sandwich screen has one explicit local baseline
+        on the benchmark prior surface.
+      - Compare all later sandwich rows against both this replay and the staged prior
+        anchor.
+      - Keep the repeated-input architecture fixed while reading latent count and
+        width.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -553,7 +627,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -562,34 +638,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run first as the sandwich local replay before reading latent-count rows.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run first as the sandwich local replay before reading latent-count
+      rows.
     applicability_guards: []
-
   delta_tf_rd_021a_sandwich_latents24_v1:
     dimension_family: model
     family: architecture_capacity
     binary_applicable: true
-    description: Halve the sandwich latent count from 48 to 24 while keeping width and repeated-stage depth fixed.
-    upstream_delta: Perceiver-style models often trade latent count against compute and fidelity; this row is the lower-capacity bracket for the repo-local sandwich screen.
-    expected_effect: Fewer latents may cut training cost if the repeated-input sandwich is overprovisioned, but could reduce fit on the prior benchmark.
+    description: Halve the sandwich latent count from 48 to 24 while keeping width
+      and repeated-stage depth fixed.
+    upstream_delta: Perceiver-style models often trade latent count against compute
+      and fidelity; this row is the lower-capacity bracket for the repo-local sandwich
+      screen.
+    expected_effect: Fewer latents may cut training cost if the repeated-input sandwich
+      is overprovisioned, but could reduce fit on the prior benchmark.
     adequacy_knobs:
-      - Compare directly against the sandwich replay row before opening any width change.
-      - Treat this as the lower latent bracket, not as a final small-model promotion claim.
-      - Prefer this row only if the quality trade is clearly acceptable relative to the replay.
+    - Compare directly against the sandwich replay row before opening any width change.
+    - Treat this as the lower latent bracket, not as a final small-model promotion
+      claim.
+    - Prefer this row only if the quality trade is clearly acceptable relative to
+      the replay.
     parameter_adequacy_policy:
       default_plan:
-        - Run after the sandwich replay as the lower latent-count bracket.
-        - Use this row and the high-latent row to decide whether width follow-up should stay near the replay or move upward.
+      - Run after the sandwich replay as the lower latent-count bracket.
+      - Use this row and the high-latent row to decide whether width follow-up should
+        stay near the replay or move upward.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -622,7 +705,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -631,34 +716,40 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
     default_next_action: Run after the replay as the lower latent-count discriminator.
     applicability_guards: []
-
   delta_tf_rd_021a_sandwich_latents96_v1:
     dimension_family: model
     family: architecture_capacity
     binary_applicable: true
-    description: Double the sandwich latent count from 48 to 96 while keeping width and repeated-stage depth fixed.
-    upstream_delta: Perceiver-style models often improve fidelity by enlarging the latent bank; this row is the upper latent bracket for the repo-local sandwich screen.
-    expected_effect: More latents may improve fit if the current sandwich replay is memory-bottlenecked, though runtime and VRAM will increase.
+    description: Double the sandwich latent count from 48 to 96 while keeping width
+      and repeated-stage depth fixed.
+    upstream_delta: Perceiver-style models often improve fidelity by enlarging the
+      latent bank; this row is the upper latent bracket for the repo-local sandwich
+      screen.
+    expected_effect: More latents may improve fit if the current sandwich replay is
+      memory-bottlenecked, though runtime and VRAM will increase.
     adequacy_knobs:
-      - Compare directly against the sandwich replay before opening any width change.
-      - Use runtime and memory only as guardrails; benchmark quality remains primary.
-      - Treat this as the upper latent bracket for deciding the width follow-up starting point.
+    - Compare directly against the sandwich replay before opening any width change.
+    - Use runtime and memory only as guardrails; benchmark quality remains primary.
+    - Treat this as the upper latent bracket for deciding the width follow-up starting
+      point.
     parameter_adequacy_policy:
       default_plan:
-        - Run after the replay and the low-latent row to bracket the first latent-count read.
-        - If this row is clearly best, use it as the upper candidate for the blocked width follow-up.
+      - Run after the replay and the low-latent row to bracket the first latent-count
+        read.
+      - If this row is clearly best, use it as the upper candidate for the blocked
+        width follow-up.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -691,7 +782,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -700,33 +793,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the replay as the high-latent discriminator before width follow-up opens.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the replay as the high-latent discriminator before
+      width follow-up opens.
     applicability_guards: []
-
   delta_tf_rd_021a_sandwich_width128_latents48_v1:
     dimension_family: model
     family: architecture_capacity
     binary_applicable: true
-    description: Increase sandwich width from 96 to 128 while keeping the replay latent count fixed at 48.
-    upstream_delta: Perceiver-style width changes alter latent-channel capacity and attention projection width; this is the lower width follow-up row once the latent screen is visible.
-    expected_effect: More width may improve fit if the replay is width-bottlenecked, though it increases training cost and should not be interpreted before the latent screen.
+    description: Increase sandwich width from 96 to 128 while keeping the replay latent
+      count fixed at 48.
+    upstream_delta: Perceiver-style width changes alter latent-channel capacity and
+      attention projection width; this is the lower width follow-up row once the latent
+      screen is visible.
+    expected_effect: More width may improve fit if the replay is width-bottlenecked,
+      though it increases training cost and should not be interpreted before the latent
+      screen.
     adequacy_knobs:
-      - Keep this row blocked until the latent-only screen confirms that a width read is warranted.
-      - Compare this row against the replay row and the high-latent row once unblocked.
+    - Keep this row blocked until the latent-only screen confirms that a width read
+      is warranted.
+    - Compare this row against the replay row and the high-latent row once unblocked.
     parameter_adequacy_policy:
       default_plan:
-        - Unblock only after rows `01` through `03` establish whether the replay latent count remains a live candidate.
-        - If unblocked, compare directly against the replay row before treating width as a needed axis.
+      - Unblock only after rows `01` through `03` establish whether the replay latent
+        count remains a live candidate.
+      - If unblocked, compare directly against the replay row before treating width
+        as a needed axis.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_latent_screen
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -759,7 +860,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -768,33 +871,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Leave blocked until the latent-only screen says the replay latent count is worth widening.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Leave blocked until the latent-only screen says the replay
+      latent count is worth widening.
     applicability_guards: []
-
   delta_tf_rd_021a_sandwich_width128_latents96_v1:
     dimension_family: model
     family: architecture_capacity
     binary_applicable: true
-    description: Increase sandwich width from 96 to 128 around the upper latent candidate at 96 latents.
-    upstream_delta: Perceiver-style scaling often couples latent count and channel width; this row is the blocked width follow-up around the high-latent bracket.
-    expected_effect: Jointly larger width and latent count may improve fit if the sandwich screen is constrained on both bottlenecks, but it is intentionally deferred until the latent screen lands.
+    description: Increase sandwich width from 96 to 128 around the upper latent candidate
+      at 96 latents.
+    upstream_delta: Perceiver-style scaling often couples latent count and channel
+      width; this row is the blocked width follow-up around the high-latent bracket.
+    expected_effect: Jointly larger width and latent count may improve fit if the
+      sandwich screen is constrained on both bottlenecks, but it is intentionally
+      deferred until the latent screen lands.
     adequacy_knobs:
-      - Keep this row blocked until the latent-only screen shows that the 96-latent candidate remains live.
-      - Compare against both the 96-latent row and the replay row once unblocked.
+    - Keep this row blocked until the latent-only screen shows that the 96-latent
+      candidate remains live.
+    - Compare against both the 96-latent row and the replay row once unblocked.
     parameter_adequacy_policy:
       default_plan:
-        - Unblock only if the high-latent row is viable enough to justify a width follow-up.
-        - Treat this as a bounded second-pass size probe rather than a new architecture fork.
+      - Unblock only if the high-latent row is viable enough to justify a width follow-up.
+      - Treat this as a bounded second-pass size probe rather than a new architecture
+        fork.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_latent_screen
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -827,7 +936,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -836,33 +947,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
     default_next_action: Leave blocked until the 96-latent row earns a width follow-up.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_latents12_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Halve the hybrid sandwich latent bank from 24 to 12 while keeping the compact control otherwise fixed.
-    upstream_delta: Perceiver-style latent banks make latent count the first memory-vs-fidelity ablation on the hybrid sandwich line.
-    expected_effect: If the compact hybrid control is overprovisioned on latent tokens, quality should move only slightly while parameter count and compute fall.
+    description: Halve the hybrid sandwich latent bank from 24 to 12 while keeping
+      the compact control otherwise fixed.
+    upstream_delta: Perceiver-style latent banks make latent count the first memory-vs-fidelity
+      ablation on the hybrid sandwich line.
+    expected_effect: If the compact hybrid control is overprovisioned on latent tokens,
+      quality should move only slightly while parameter count and compute fall.
     adequacy_knobs:
-      - Keep the locked medium bundle, prior-dump surface, and 2500-step cosine budget fixed.
-      - Interpret directly against the registered compact hybrid control before width or head-MLP changes.
+    - Keep the locked medium bundle, prior-dump surface, and 2500-step cosine budget
+      fixed.
+    - Interpret directly against the registered compact hybrid control before width
+      or head-MLP changes.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as one factor in the bounded TF-RD-021B knob-sensitivity screen.
-        - Use final ROC AUC and final log loss together when deciding whether the latent bank remains a live scaling axis.
+      - Treat this as one factor in the bounded TF-RD-021B knob-sensitivity screen.
+      - Use final ROC AUC and final log loss together when deciding whether the latent
+        bank remains a live scaling axis.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -899,7 +1015,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -910,33 +1028,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_layers1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Reduce the hybrid sandwich repeated cross-attend stack from 2 stages to 1 while keeping the compact control otherwise fixed.
-    upstream_delta: Perceiver-style models expose repeated latent-read depth as a distinct capacity knob after the first full-input read.
-    expected_effect: If one repeated stage is already enough on this surface, the compact control may be deeper than necessary.
+    description: Reduce the hybrid sandwich repeated cross-attend stack from 2 stages
+      to 1 while keeping the compact control otherwise fixed.
+    upstream_delta: Perceiver-style models expose repeated latent-read depth as a
+      distinct capacity knob after the first full-input read.
+    expected_effect: If one repeated stage is already enough on this surface, the
+      compact control may be deeper than necessary.
     adequacy_knobs:
-      - Keep the stage-0 full-cell read, summary-token count, and train budget fixed.
-      - Read this as repeated-stage sensitivity, not as a general model-size change.
+    - Keep the stage-0 full-cell read, summary-token count, and train budget fixed.
+    - Read this as repeated-stage sensitivity, not as a general model-size change.
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the compact control before changing width, heads, or budget.
-        - If the drop is weak, treat repeated depth as a candidate knob to freeze at the simpler value.
+      - Compare directly against the compact control before changing width, heads,
+        or budget.
+      - If the drop is weak, treat repeated depth as a candidate knob to freeze at
+        the simpler value.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -973,7 +1096,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -984,33 +1109,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_heads2_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Reduce hybrid sandwich attention heads from 4 to 2 while keeping width and all other compact-control settings fixed.
-    upstream_delta: Attention head factorization is a standard transformer capacity axis that may be overprovisioned on compact tabular models.
-    expected_effect: If the hybrid control mostly needs width rather than head factorization, dropping to two heads should be only mildly harmful.
+    description: Reduce hybrid sandwich attention heads from 4 to 2 while keeping
+      width and all other compact-control settings fixed.
+    upstream_delta: Attention head factorization is a standard transformer capacity
+      axis that may be overprovisioned on compact tabular models.
+    expected_effect: If the hybrid control mostly needs width rather than head factorization,
+      dropping to two heads should be only mildly harmful.
     adequacy_knobs:
-      - Keep `d_icl=60` fixed so this row isolates attention partitioning rather than total width.
-      - Compare directly against the compact control before opening any width ladder.
+    - Keep `d_icl=60` fixed so this row isolates attention partitioning rather than
+      total width.
+    - Compare directly against the compact control before opening any width ladder.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the head-factorization read within the first bounded sandwich screen.
-        - If the ablation is close, prefer the simpler head count when later defining a compound scaling recipe.
+      - Treat this as the head-factorization read within the first bounded sandwich
+        screen.
+      - If the ablation is close, prefer the simpler head count when later defining
+        a compound scaling recipe.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1047,7 +1178,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1058,33 +1191,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_ffexp1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Reduce the hybrid sandwich feed-forward expansion from 2x to 1x while keeping the compact control otherwise fixed.
-    upstream_delta: FF expansion is one of the simplest capacity axes to simplify before introducing broader scaling laws.
-    expected_effect: If most of the current gain comes from attention structure rather than trunk MLP capacity, shrinking FF expansion should only weakly degrade performance.
+    description: Reduce the hybrid sandwich feed-forward expansion from 2x to 1x while
+      keeping the compact control otherwise fixed.
+    upstream_delta: FF expansion is one of the simplest capacity axes to simplify
+      before introducing broader scaling laws.
+    expected_effect: If most of the current gain comes from attention structure rather
+      than trunk MLP capacity, shrinking FF expansion should only weakly degrade performance.
     adequacy_knobs:
-      - Keep latent count, stage count, and summary-token count fixed so this row isolates FF capacity.
-      - Compare directly against the compact control before treating FF expansion as a live scaling axis.
+    - Keep latent count, stage count, and summary-token count fixed so this row isolates
+      FF capacity.
+    - Compare directly against the compact control before treating FF expansion as
+      a live scaling axis.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the FF-capacity ablation in the first bounded sandwich screen.
-        - Freeze FF expansion to the simpler value if the ablation is clearly low-impact.
+      - Treat this as the FF-capacity ablation in the first bounded sandwich screen.
+      - Freeze FF expansion to the simpler value if the ablation is clearly low-impact.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1121,7 +1259,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1132,33 +1272,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_summarytokens1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Reduce row and column summary token multiplicity from 4 tokens per axis position to 1 while keeping the compact control otherwise fixed.
-    upstream_delta: The hybrid successor deliberately widened the summary stream with `K=4`; this row tests whether that extra summary bandwidth actually matters.
-    expected_effect: If the gain comes mostly from stage-0 raw cells and the final cell readout, collapsing summary multiplicity back to 1 should only weakly hurt.
+    description: Reduce row and column summary token multiplicity from 4 tokens per
+      axis position to 1 while keeping the compact control otherwise fixed.
+    upstream_delta: The hybrid successor deliberately widened the summary stream with
+      `K=4`; this row tests whether that extra summary bandwidth actually matters.
+    expected_effect: If the gain comes mostly from stage-0 raw cells and the final
+      cell readout, collapsing summary multiplicity back to 1 should only weakly hurt.
     adequacy_knobs:
-      - Keep the stage-0 full-cell path and final full-cell readout fixed.
-      - Read this as summary-stream bandwidth sensitivity, not as a generic width ablation.
+    - Keep the stage-0 full-cell path and final full-cell readout fixed.
+    - Read this as summary-stream bandwidth sensitivity, not as a generic width ablation.
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the compact control before reopening any larger summary-token ladder.
-        - If the drop is weak, freeze `sandwich_summary_tokens_per_axis` to `1` before later scaling work.
+      - Compare directly against the compact control before reopening any larger summary-token
+        ladder.
+      - If the drop is weak, freeze `sandwich_summary_tokens_per_axis` to `1` before
+        later scaling work.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1195,7 +1340,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1206,33 +1353,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_selfattn1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Reduce latent self-attention refinement between cross-attention reads from 4 blocks to 1 while keeping the compact control otherwise fixed.
-    upstream_delta: The hybrid successor increased self-refinement depth between cross-attention segments; this row tests whether that extra latent processing is carrying quality.
-    expected_effect: If repeated latent self-processing is not the bottleneck, dropping to one self-attention block should preserve most of the fit.
+    description: Reduce latent self-attention refinement between cross-attention reads
+      from 4 blocks to 1 while keeping the compact control otherwise fixed.
+    upstream_delta: The hybrid successor increased self-refinement depth between cross-attention
+      segments; this row tests whether that extra latent processing is carrying quality.
+    expected_effect: If repeated latent self-processing is not the bottleneck, dropping
+      to one self-attention block should preserve most of the fit.
     adequacy_knobs:
-      - Keep stage count and latent count fixed so this row isolates self-refinement depth.
-      - Compare directly against the compact control before turning self-attention depth into a future scaling axis.
+    - Keep stage count and latent count fixed so this row isolates self-refinement
+      depth.
+    - Compare directly against the compact control before turning self-attention depth
+      into a future scaling axis.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the cross-segment self-attention ablation within the first bounded sandwich screen.
-        - Freeze this knob lower if the ablation is clearly low-impact.
+      - Treat this as the cross-segment self-attention ablation within the first bounded
+        sandwich screen.
+      - Freeze this knob lower if the ablation is clearly low-impact.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1269,7 +1422,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1280,33 +1435,42 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_selfattn0_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Remove latent self-attention refinement entirely between cross-attention reads while keeping the compact control otherwise fixed.
-    upstream_delta: The hybrid successor added repeated latent self-refinement between cross-attention segments; this row tests whether that feature can be removed outright.
-    expected_effect: If the structural gain comes from stage-0 full-cell access and dual readout more than from latent recycling, removing the self-attention stack may be only weakly harmful.
+    description: Remove latent self-attention refinement entirely between cross-attention
+      reads while keeping the compact control otherwise fixed.
+    upstream_delta: The hybrid successor added repeated latent self-refinement between
+      cross-attention segments; this row tests whether that feature can be removed
+      outright.
+    expected_effect: If the structural gain comes from stage-0 full-cell access and
+      dual readout more than from latent recycling, removing the self-attention stack
+      may be only weakly harmful.
     adequacy_knobs:
-      - Keep stage count, latent count, and FF expansion fixed so this row isolates removal of the latent self-refinement feature.
-      - Compare directly against the compact control before collapsing self-attention depth into later frozen defaults.
+    - Keep stage count, latent count, and FF expansion fixed so this row isolates
+      removal of the latent self-refinement feature.
+    - Compare directly against the compact control before collapsing self-attention
+      depth into later frozen defaults.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the removal-first replacement for the earlier self-attention-depth ablation.
-        - If the drop is weak, prefer removing this feature entirely rather than retaining a reduced nonzero count.
+      - Treat this as the removal-first replacement for the earlier self-attention-depth
+        ablation.
+      - If the drop is weak, prefer removing this feature entirely rather than retaining
+        a reduced nonzero count.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1343,7 +1507,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1354,33 +1520,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
     default_next_action: Run as part of the four-row TF-RD-021B feature-removal screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_selfattn0_ffexp1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Remove latent self-attention refinement and collapse feed-forward expansion to 1x while keeping the compact control otherwise fixed.
-    upstream_delta: After the completed single-knob screen, this row tests whether the simplest acceptable parent can remove the self-refinement feature and retain only minimal trunk MLP expansion.
-    expected_effect: If the hybrid path is structurally adequate already, combining self-attention removal with 1x FF expansion may preserve most of the fit while simplifying the trunk materially.
+    description: Remove latent self-attention refinement and collapse feed-forward
+      expansion to 1x while keeping the compact control otherwise fixed.
+    upstream_delta: After the completed single-knob screen, this row tests whether
+      the simplest acceptable parent can remove the self-refinement feature and retain
+      only minimal trunk MLP expansion.
+    expected_effect: If the hybrid path is structurally adequate already, combining
+      self-attention removal with 1x FF expansion may preserve most of the fit while
+      simplifying the trunk materially.
     adequacy_knobs:
-      - Keep summary-token multiplicity fixed so this row reads removal of latent refinement plus minimal FF capacity only.
-      - Compare directly against the compact control before carrying this compound simplification into harder-surface work.
+    - Keep summary-token multiplicity fixed so this row reads removal of latent refinement
+      plus minimal FF capacity only.
+    - Compare directly against the compact control before carrying this compound simplification
+      into harder-surface work.
     parameter_adequacy_policy:
       default_plan:
-        - Use this as the first compound removal candidate after the isolated removal row.
-        - Prefer this row over the anchor only if the combined simplification remains bounded on final quality and stability.
+      - Use this as the first compound removal candidate after the isolated removal
+        row.
+      - Prefer this row over the anchor only if the combined simplification remains
+        bounded on final quality and stability.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1417,7 +1591,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1428,33 +1604,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
     default_next_action: Run as part of the four-row TF-RD-021B feature-removal screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_selfattn0_ffexp1_summarytokens1_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Remove latent self-attention refinement, collapse feed-forward expansion to 1x, and reduce summary-token multiplicity to 1 while keeping the compact control otherwise fixed.
-    upstream_delta: This is the smallest removal-first parent expressible on the current sandwich surface without adding new zero-valued FF or summary-token semantics.
-    expected_effect: If the hybrid architecture mainly needs the stage-0 full-cell path and the final cell-stream readout, this compound simplification may preserve bounded quality with the smallest remaining nonzero summary/FF settings.
+    description: Remove latent self-attention refinement, collapse feed-forward expansion
+      to 1x, and reduce summary-token multiplicity to 1 while keeping the compact
+      control otherwise fixed.
+    upstream_delta: This is the smallest removal-first parent expressible on the current
+      sandwich surface without adding new zero-valued FF or summary-token semantics.
+    expected_effect: If the hybrid architecture mainly needs the stage-0 full-cell
+      path and the final cell-stream readout, this compound simplification may preserve
+      bounded quality with the smallest remaining nonzero summary/FF settings.
     adequacy_knobs:
-      - Treat this as the lower bound of the current expressible removal-first simplification package.
-      - Compare directly against both the anchor and the simpler compound row before freezing any defaults.
+    - Treat this as the lower bound of the current expressible removal-first simplification
+      package.
+    - Compare directly against both the anchor and the simpler compound row before
+      freezing any defaults.
     parameter_adequacy_policy:
       default_plan:
-        - Use this as the smallest currently supported parent in the TF-RD-021B removal-first screen.
-        - If this row is close enough to the anchor, the later freeze should prefer it over larger retained-feature variants.
+      - Use this as the smallest currently supported parent in the TF-RD-021B removal-first
+        screen.
+      - If this row is close enough to the anchor, the later freeze should prefer
+        it over larger retained-feature variants.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1491,7 +1675,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1502,33 +1688,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
     default_next_action: Run as part of the four-row TF-RD-021B feature-removal screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_prerow0_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Remove the pre-Perceiver per-row feature self-attention mixer while keeping the compact control otherwise fixed.
-    upstream_delta: The hybrid successor added a row-wise feature mixer before the first latent read; this row asks whether that axial pre-mixer is materially useful.
-    expected_effect: If most of the recovery comes from raw-cell access alone, removing the row-wise feature mixer may be only weakly harmful.
+    description: Remove the pre-Perceiver per-row feature self-attention mixer while
+      keeping the compact control otherwise fixed.
+    upstream_delta: The hybrid successor added a row-wise feature mixer before the
+      first latent read; this row asks whether that axial pre-mixer is materially
+      useful.
+    expected_effect: If most of the recovery comes from raw-cell access alone, removing
+      the row-wise feature mixer may be only weakly harmful.
     adequacy_knobs:
-      - Keep the column-wise pre-mixer on so the ablation isolates row-wise feature mixing.
-      - Compare directly against the compact control before adding deeper axial pre-mixers.
+    - Keep the column-wise pre-mixer on so the ablation isolates row-wise feature
+      mixing.
+    - Compare directly against the compact control before adding deeper axial pre-mixers.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the row-axis pre-mixer ablation inside the first bounded sandwich screen.
-        - If the drop is strong, keep row-wise feature mixing live in the later compound scaling recipe.
+      - Treat this as the row-axis pre-mixer ablation inside the first bounded sandwich
+        screen.
+      - If the drop is strong, keep row-wise feature mixing live in the later compound
+        scaling recipe.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1565,7 +1757,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1576,33 +1770,40 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_precol0_v1:
     dimension_family: model
     family: architecture_sensitivity
     binary_applicable: true
-    description: Remove the pre-Perceiver per-column row self-attention mixer while keeping the compact control otherwise fixed.
-    upstream_delta: The hybrid successor added a column-wise row mixer before the first latent read; this row tests whether that second axial pass is necessary.
-    expected_effect: If the row-wise feature mixer already captures most of the useful pre-latent structure, removing the column-wise row mixer may be low-impact.
+    description: Remove the pre-Perceiver per-column row self-attention mixer while
+      keeping the compact control otherwise fixed.
+    upstream_delta: The hybrid successor added a column-wise row mixer before the
+      first latent read; this row tests whether that second axial pass is necessary.
+    expected_effect: If the row-wise feature mixer already captures most of the useful
+      pre-latent structure, removing the column-wise row mixer may be low-impact.
     adequacy_knobs:
-      - Keep the row-wise feature mixer on so the ablation isolates column-wise row mixing.
-      - Compare directly against the compact control before deeper axial-mixer changes are considered.
+    - Keep the row-wise feature mixer on so the ablation isolates column-wise row
+      mixing.
+    - Compare directly against the compact control before deeper axial-mixer changes
+      are considered.
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the column-axis pre-mixer ablation inside the first bounded sandwich screen.
-        - Freeze this knob lower if the drop is weak enough to simplify the later compound recipe.
+      - Treat this as the column-axis pre-mixer ablation inside the first bounded
+        sandwich screen.
+      - Freeze this knob lower if the drop is weak enough to simplify the later compound
+        recipe.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -1639,7 +1840,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1650,33 +1853,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity screen.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run as part of the eight-row TF-RD-021B knob-sensitivity
+      screen.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_dicl48_v1:
     dimension_family: model
     family: width_capacity
     binary_applicable: true
-    description: Reduce hybrid sandwich width from 60 to 48 while keeping head count fixed at 4 and the rest of the compact control unchanged.
-    upstream_delta: Width is the first direct channel-capacity probe once sandwich-specific topology sensitivity is known.
-    expected_effect: If the compact control is width-overprovisioned, dropping to `d_icl=48` should preserve most of the benchmark fit.
+    description: Reduce hybrid sandwich width from 60 to 48 while keeping head count
+      fixed at 4 and the rest of the compact control unchanged.
+    upstream_delta: Width is the first direct channel-capacity probe once sandwich-specific
+      topology sensitivity is known.
+    expected_effect: If the compact control is width-overprovisioned, dropping to
+      `d_icl=48` should preserve most of the benchmark fit.
     adequacy_knobs:
-      - Keep `sandwich_heads=4` fixed so this row isolates channel width rather than attention partitioning.
-      - Execute only after the stage-1 knob screen is interpreted.
+    - Keep `sandwich_heads=4` fixed so this row isolates channel width rather than
+      attention partitioning.
+    - Execute only after the stage-1 knob screen is interpreted.
     parameter_adequacy_policy:
       default_plan:
-        - Use this row as the lower width bracket in the post-sensitivity follow-up.
-        - Promote a smaller width only if the benchmark loss is clearly negligible relative to the compact control.
+      - Use this row as the lower width bracket in the post-sensitivity follow-up.
+      - Promote a smaller width only if the benchmark loss is clearly negligible relative
+        to the compact control.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_knob_sensitivity
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -1713,7 +1921,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1724,33 +1934,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Wait for the stage-1 knob-sensitivity read before executing the width or head-capacity follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Wait for the stage-1 knob-sensitivity read before executing
+      the width or head-capacity follow-up.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_dicl96_v1:
     dimension_family: model
     family: width_capacity
     binary_applicable: true
-    description: Increase hybrid sandwich width from 60 to 96 while keeping head count fixed at 4 and the rest of the compact control unchanged.
-    upstream_delta: Width is the primary candidate scaling axis if sandwich-specific topology knobs prove low-sensitivity.
-    expected_effect: If the compact control is width-limited, increasing `d_icl` to `96` should improve fit enough to justify later power-curve work.
+    description: Increase hybrid sandwich width from 60 to 96 while keeping head count
+      fixed at 4 and the rest of the compact control unchanged.
+    upstream_delta: Width is the primary candidate scaling axis if sandwich-specific
+      topology knobs prove low-sensitivity.
+    expected_effect: If the compact control is width-limited, increasing `d_icl` to
+      `96` should improve fit enough to justify later power-curve work.
     adequacy_knobs:
-      - Keep `sandwich_heads=4` fixed so the width read is not confounded by head-factor changes.
-      - Execute only after the stage-1 knob screen is interpreted.
+    - Keep `sandwich_heads=4` fixed so the width read is not confounded by head-factor
+      changes.
+    - Execute only after the stage-1 knob screen is interpreted.
     parameter_adequacy_policy:
       default_plan:
-        - Use this row as the upper width bracket in the post-sensitivity follow-up.
-        - If this row wins, note whether the benchmark curve is still improving at final step before collapsing width into a later scaling toggle.
+      - Use this row as the upper width bracket in the post-sensitivity follow-up.
+      - If this row wins, note whether the benchmark curve is still improving at final
+        step before collapsing width into a later scaling toggle.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_knob_sensitivity
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -1787,7 +2002,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1798,33 +2015,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Wait for the stage-1 knob-sensitivity read before executing the width or head-capacity follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Wait for the stage-1 knob-sensitivity read before executing
+      the width or head-capacity follow-up.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_headhidden64_v1:
     dimension_family: model
     family: width_capacity
     binary_applicable: true
-    description: Reduce the prediction head hidden size from 96 to 64 while keeping the hybrid trunk fixed at the compact control.
-    upstream_delta: Head MLP size is a narrower capacity axis than trunk width and may be unnecessary if the trunk is the real bottleneck.
-    expected_effect: If the compact control is trunk-limited rather than head-limited, shrinking the head hidden size should have little effect.
+    description: Reduce the prediction head hidden size from 96 to 64 while keeping
+      the hybrid trunk fixed at the compact control.
+    upstream_delta: Head MLP size is a narrower capacity axis than trunk width and
+      may be unnecessary if the trunk is the real bottleneck.
+    expected_effect: If the compact control is trunk-limited rather than head-limited,
+      shrinking the head hidden size should have little effect.
     adequacy_knobs:
-      - Keep `d_icl=60` and all sandwich-specific knobs fixed so this row isolates readout-head capacity.
-      - Execute only after the stage-1 knob screen is interpreted.
+    - Keep `d_icl=60` and all sandwich-specific knobs fixed so this row isolates readout-head
+      capacity.
+    - Execute only after the stage-1 knob screen is interpreted.
     parameter_adequacy_policy:
       default_plan:
-        - Use this row as the lower head-capacity bracket after the stage-1 sensitivity read.
-        - Freeze the head lower if the quality drop is negligible relative to the compact control.
+      - Use this row as the lower head-capacity bracket after the stage-1 sensitivity
+        read.
+      - Freeze the head lower if the quality drop is negligible relative to the compact
+        control.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_knob_sensitivity
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -1861,7 +2084,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1872,33 +2097,39 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Wait for the stage-1 knob-sensitivity read before executing the width or head-capacity follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Wait for the stage-1 knob-sensitivity read before executing
+      the width or head-capacity follow-up.
     applicability_guards: []
-
   delta_tf_rd_021b_sandwich_headhidden128_v1:
     dimension_family: model
     family: width_capacity
     binary_applicable: true
-    description: Increase the prediction head hidden size from 96 to 128 while keeping the hybrid trunk fixed at the compact control.
-    upstream_delta: Head hidden size is the bounded readout-capacity follow-up once sandwich-specific topology sensitivity is understood.
-    expected_effect: If the compact control is head-limited at readout time, increasing the head hidden size may improve fit even when trunk width stays fixed.
+    description: Increase the prediction head hidden size from 96 to 128 while keeping
+      the hybrid trunk fixed at the compact control.
+    upstream_delta: Head hidden size is the bounded readout-capacity follow-up once
+      sandwich-specific topology sensitivity is understood.
+    expected_effect: If the compact control is head-limited at readout time, increasing
+      the head hidden size may improve fit even when trunk width stays fixed.
     adequacy_knobs:
-      - Keep `d_icl=60` and all sandwich-specific knobs fixed so this row isolates head capacity.
-      - Execute only after the stage-1 knob screen is interpreted.
+    - Keep `d_icl=60` and all sandwich-specific knobs fixed so this row isolates head
+      capacity.
+    - Execute only after the stage-1 knob screen is interpreted.
     parameter_adequacy_policy:
       default_plan:
-        - Use this row as the upper head-capacity bracket in the immediate post-sensitivity follow-up.
-        - Keep head hidden size as a live axis only if it matters independently of trunk width.
+      - Use this row as the upper head-capacity bracket in the immediate post-sensitivity
+        follow-up.
+      - Keep head hidden size as a live axis only if it matters independently of trunk
+        width.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_knob_sensitivity
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -1935,7 +2166,9 @@ deltas:
             name: schedulefree_adamw
             require_requested: true
             weight_decay: 0.0
-            betas: [0.9, 0.999]
+            betas:
+            - 0.9
+            - 0.999
             min_lr: 0.004
             muon_per_parameter_lr: false
           runtime:
@@ -1946,34 +2179,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Wait for the stage-1 knob-sensitivity read before executing the width or head-capacity follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Wait for the stage-1 knob-sensitivity read before executing
+      the width or head-capacity follow-up.
     applicability_guards: []
-
   delta_tf_rd_022_cls_runtime_control_noamp_v1:
     dimension_family: training
     family: runtime_policy
     binary_applicable: false
-    description: Replay the closed TF-RD-010 classification control recipe with no AMP, no activation trace, and no activation checkpointing.
-    upstream_delta: Not applicable; this is the no-AMP runtime-policy control for TF-RD-022 on the closed classification benchmark contract.
-    expected_effect: Establish the benchmark-safe runtime and VRAM baseline before any low-risk runtime knob is considered.
+    description: Replay the closed TF-RD-010 classification control recipe with no
+      AMP, no activation trace, and no activation checkpointing.
+    upstream_delta: Not applicable; this is the no-AMP runtime-policy control for
+      TF-RD-022 on the closed classification benchmark contract.
+    expected_effect: Establish the benchmark-safe runtime and VRAM baseline before
+      any low-risk runtime knob is considered.
     adequacy_knobs:
-      - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`, `grad_clip=0.0`, `max_steps=2500`
-      - runtime knobs only; architecture, corpus choice, optimizer family, and schedule family remain frozen
+    - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`,
+      `grad_clip=0.0`, `max_steps=2500`
+    - runtime knobs only; architecture, corpus choice, optimizer family, and schedule
+      family remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute this row first as the same-bundle control replay for the TF-RD-022 runtime ladder.
-        - Use `final_log_loss_at_matched_regime_budget` as the primary ranking key, then inspect runtime and VRAM only as guardrails and tie-breakers.
+      - Execute this row first as the same-bundle control replay for the TF-RD-022
+        runtime ladder.
+      - Use `final_log_loss_at_matched_regime_budget` as the primary ranking key,
+        then inspect runtime and VRAM only as guardrails and tie-breakers.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2014,7 +2254,7 @@ deltas:
           optimizer:
             min_lr: 1.0e-05
           runtime:
-            mixed_precision: "no"
+            mixed_precision: 'no'
             grad_clip: 0.0
             grad_accum_steps: 4
             trace_activations: false
@@ -2025,34 +2265,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute this row first as the no-AMP control for the TF-RD-022 runtime ladder.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute this row first as the no-AMP control for the TF-RD-022
+      runtime ladder.
     applicability_guards: []
-
   delta_tf_rd_022_cls_runtime_bf16_v1:
     dimension_family: training
     family: runtime_policy
     binary_applicable: false
-    description: Switch only `mixed_precision` to `bf16` on the closed TF-RD-010 classification control recipe.
-    upstream_delta: Not applicable; this is the first low-risk AMP candidate for TF-RD-022 on the closed classification benchmark contract.
-    expected_effect: If AMP is benchmark-safe on the carried sandwich recipe, bf16 should preserve log loss while reducing runtime or VRAM cost versus the no-AMP control.
+    description: Switch only `mixed_precision` to `bf16` on the closed TF-RD-010 classification
+      control recipe.
+    upstream_delta: Not applicable; this is the first low-risk AMP candidate for TF-RD-022
+      on the closed classification benchmark contract.
+    expected_effect: If AMP is benchmark-safe on the carried sandwich recipe, bf16
+      should preserve log loss while reducing runtime or VRAM cost versus the no-AMP
+      control.
     adequacy_knobs:
-      - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`, `grad_clip=0.0`, `max_steps=2500`
-      - runtime knobs only; architecture, corpus choice, optimizer family, and schedule family remain frozen
+    - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`,
+      `grad_clip=0.0`, `max_steps=2500`
+    - runtime knobs only; architecture, corpus choice, optimizer family, and schedule
+      family remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the no-AMP control row on `final_log_loss_at_matched_regime_budget`.
-        - Treat lower peak reserved VRAM, then higher token throughput, then lower non-train overhead as tie-breakers only if benchmark quality is non-worse.
+      - Compare directly against the no-AMP control row on `final_log_loss_at_matched_regime_budget`.
+      - Treat lower peak reserved VRAM, then higher token throughput, then lower non-train
+        overhead as tie-breakers only if benchmark quality is non-worse.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2104,34 +2351,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute after the no-AMP control and carry it forward only if benchmark quality is non-worse.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute after the no-AMP control and carry it forward only
+      if benchmark quality is non-worse.
     applicability_guards: []
-
   delta_tf_rd_022_cls_runtime_trace_v1:
     dimension_family: training
     family: runtime_policy
     binary_applicable: false
-    description: Enable benchmark-facing activation tracing on top of the bf16 TF-RD-022 runtime candidate.
-    upstream_delta: Not applicable; this is the bounded activation-trace diagnostic for TF-RD-022 on the closed classification benchmark contract.
-    expected_effect: Benchmark-facing activation tracing should remain a measurable overhead unless it is effectively free on the carried classification recipe.
+    description: Enable benchmark-facing activation tracing on top of the bf16 TF-RD-022
+      runtime candidate.
+    upstream_delta: Not applicable; this is the bounded activation-trace diagnostic
+      for TF-RD-022 on the closed classification benchmark contract.
+    expected_effect: Benchmark-facing activation tracing should remain a measurable
+      overhead unless it is effectively free on the carried classification recipe.
     adequacy_knobs:
-      - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`, `grad_clip=0.0`, `max_steps=2500`
-      - runtime knobs only; architecture, corpus choice, optimizer family, and schedule family remain frozen
+    - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`,
+      `grad_clip=0.0`, `max_steps=2500`
+    - runtime knobs only; architecture, corpus choice, optimizer family, and schedule
+      family remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Compare this row against the simpler bf16 row first, not only against the no-AMP control.
-        - Treat this row as a diagnostic loser unless it is benchmark-safe and also beats the simpler bf16 row on the runtime tie-breakers.
+      - Compare this row against the simpler bf16 row first, not only against the
+        no-AMP control.
+      - Treat this row as a diagnostic loser unless it is benchmark-safe and also
+        beats the simpler bf16 row on the runtime tie-breakers.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2183,34 +2437,42 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute after the simpler bf16 row and keep it only if tracing remains benchmark-safe and runtime-competitive.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute after the simpler bf16 row and keep it only if tracing
+      remains benchmark-safe and runtime-competitive.
     applicability_guards: []
-
   delta_tf_rd_022_cls_runtime_checkpoint_v1:
     dimension_family: training
     family: runtime_policy
     binary_applicable: false
-    description: Enable activation checkpointing on top of the bf16 TF-RD-022 runtime candidate.
-    upstream_delta: Not applicable; this is the bounded activation-checkpointing diagnostic for TF-RD-022 on the closed classification benchmark contract.
-    expected_effect: Activation checkpointing may reduce reserved VRAM at the cost of runtime; it should stay deferred unless that trade remains benchmark-safe and materially useful.
+    description: Enable activation checkpointing on top of the bf16 TF-RD-022 runtime
+      candidate.
+    upstream_delta: Not applicable; this is the bounded activation-checkpointing diagnostic
+      for TF-RD-022 on the closed classification benchmark contract.
+    expected_effect: Activation checkpointing may reduce reserved VRAM at the cost
+      of runtime; it should stay deferred unless that trade remains benchmark-safe
+      and materially useful.
     adequacy_knobs:
-      - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`, `grad_clip=0.0`, `max_steps=2500`
-      - runtime knobs only; architecture, corpus choice, optimizer family, and schedule family remain frozen
+    - closed TF-RD-010 medium benchmark contract on `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - fixed `task_batch_size=16`, `prior_dump_batch_size=64`, `grad_accum_steps=4`,
+      `grad_clip=0.0`, `max_steps=2500`
+    - runtime knobs only; architecture, corpus choice, optimizer family, and schedule
+      family remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Compare this row against the simpler bf16 row first, not only against the no-AMP control.
-        - Treat this row as a diagnostic loser unless it is benchmark-safe and also beats the simpler bf16 row on the runtime tie-breakers.
+      - Compare this row against the simpler bf16 row first, not only against the
+        no-AMP control.
+      - Treat this row as a diagnostic loser unless it is benchmark-safe and also
+        beats the simpler bf16 row on the runtime tie-breakers.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2262,34 +2524,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute after the simpler bf16 row and keep it only if checkpointing remains benchmark-safe and runtime-competitive.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute after the simpler bf16 row and keep it only if checkpointing
+      remains benchmark-safe and runtime-competitive.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_latents12_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the lower-bracket latent-bank family by reducing `sandwich_latents` from `24` to `12` on the TF-RD-010 multiclass benchmark contract after TF-RD-022 freezes the runtime policy.
-    upstream_delta: Reuses the TF-RD-021B latent-count family on the current classification benchmark surface instead of opening a new architecture path.
-    expected_effect: If the classification sandwich remains overprovisioned on latent tokens after TF-RD-022, the lower latent bracket should preserve most benchmark quality at lower runtime cost.
+    description: Reuse the lower-bracket latent-bank family by reducing `sandwich_latents`
+      from `24` to `12` on the TF-RD-010 multiclass benchmark contract after TF-RD-022
+      freezes the runtime policy.
+    upstream_delta: Reuses the TF-RD-021B latent-count family on the current classification
+      benchmark surface instead of opening a new architecture path.
+    expected_effect: If the classification sandwich remains overprovisioned on latent
+      tokens after TF-RD-022, the lower latent bracket should preserve most benchmark
+      quality at lower runtime cost.
     adequacy_knobs:
-      - closed TF-RD-010 medium contract with curated `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - inherited TF-RD-022 runtime policy surface
-      - latent-bank count only; width, layers, batch, LR, and clipping remain frozen
+    - closed TF-RD-010 medium contract with curated `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - inherited TF-RD-022 runtime policy surface
+    - latent-bank count only; width, layers, batch, LR, and clipping remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Wait for the TF-RD-022 keep anchor, then execute this row on the inherited policy surface without changing optimizer or schedule settings.
-        - Validate any kept medium-screen signal on the closed large-rung TF-RD-010 contract before treating latent count as a persistent follow-on knob.
+      - Wait for the TF-RD-022 keep anchor, then execute this row on the inherited
+        policy surface without changing optimizer or schedule settings.
+      - Validate any kept medium-screen signal on the closed large-rung TF-RD-010
+        contract before treating latent count as a persistent follow-on knob.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2339,34 +2608,43 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row as part of the first TF-RD-024 architecture-knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row as
+      part of the first TF-RD-024 architecture-knob sweep.
     applicability_guards: []
-
   delta_model_sandwich_block_norm_none_v1:
     dimension_family: model
     family: activation_followup
     binary_applicable: false
-    description: Disable the internal sandwich block pre-norm modules while keeping the global `norm_type=layernorm` contract fixed on the TF-RD-010 multiclass benchmark surface.
-    upstream_delta: This is a repo-local norm-free sandwich screen that uses the new `sandwich_block_norm=none` surface without reopening the rest of the benchmark contract.
-    expected_effect: Removing the internal block norms may improve the sandwich family's core FF routing on this surface, but it also risks a training-stability regression.
+    description: Disable the internal sandwich block pre-norm modules while keeping
+      the global `norm_type=layernorm` contract fixed on the TF-RD-010 multiclass
+      benchmark surface.
+    upstream_delta: This is a repo-local norm-free sandwich screen that uses the new
+      `sandwich_block_norm=none` surface without reopening the rest of the benchmark
+      contract.
+    expected_effect: Removing the internal block norms may improve the sandwich family's
+      core FF routing on this surface, but it also risks a training-stability regression.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract on curated `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - CPU no-AMP screening surface inherited from the TF-RD-022 runtime-policy contract
-      - internal sandwich block norm only; activation family, width, depth, optimizer, and corpus remain frozen
+    - fixed TF-RD-010 medium benchmark contract on curated `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - CPU no-AMP screening surface inherited from the TF-RD-022 runtime-policy contract
+    - internal sandwich block norm only; activation family, width, depth, optimizer,
+      and corpus remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Run this as the norm-free GELU control row before interpreting any rational-activation result.
-        - Compare directly against the carried TF-RD-010 anchor on stability, runtime, and final validation metrics before deciding whether norm-free sandwich is worth carrying forward.
+      - Run this as the norm-free GELU control row before interpreting any rational-activation
+        result.
+      - Compare directly against the carried TF-RD-010 anchor on stability, runtime,
+        and final validation metrics before deciding whether norm-free sandwich is
+        worth carrying forward.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2404,7 +2682,7 @@ deltas:
           optimizer:
             min_lr: 1.0e-05
           runtime:
-            mixed_precision: "no"
+            mixed_precision: 'no'
             grad_clip: 0.0
             grad_accum_steps: 4
             trace_activations: false
@@ -2415,34 +2693,42 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run as the norm-free GELU control row in TF-RD-025 before interpreting the rational row.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run as the norm-free GELU control row in TF-RD-025 before
+      interpreting the rational row.
     applicability_guards: []
-
   delta_model_sandwich_activation_rational_v1:
     dimension_family: model
     family: activation_followup
     binary_applicable: false
-    description: Starting from the norm-free sandwich control surface, replace GELU with the local version-A `5/4` GELU-initialized rational activation.
-    upstream_delta: Reuses the repo-local rational activation module on the current TF-RD-010 multiclass sandwich contract rather than adding a separate dependency or reopening the wider architecture ladder.
-    expected_effect: The rational activation may preserve more useful curvature than GELU on the norm-free sandwich surface, with the main risk being optimizer or stability regressions.
+    description: Starting from the norm-free sandwich control surface, replace GELU
+      with the local version-A `5/4` GELU-initialized rational activation.
+    upstream_delta: Reuses the repo-local rational activation module on the current
+      TF-RD-010 multiclass sandwich contract rather than adding a separate dependency
+      or reopening the wider architecture ladder.
+    expected_effect: The rational activation may preserve more useful curvature than
+      GELU on the norm-free sandwich surface, with the main risk being optimizer or
+      stability regressions.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract on curated `tf_rd_010_dagzoo_medium_control_curated_v5`
-      - CPU no-AMP screening surface inherited from the TF-RD-022 runtime-policy contract
-      - activation family only on top of `sandwich_block_norm=none`; width, depth, optimizer, and corpus remain frozen
+    - fixed TF-RD-010 medium benchmark contract on curated `tf_rd_010_dagzoo_medium_control_curated_v5`
+    - CPU no-AMP screening surface inherited from the TF-RD-022 runtime-policy contract
+    - activation family only on top of `sandwich_block_norm=none`; width, depth, optimizer,
+      and corpus remain frozen
     parameter_adequacy_policy:
       default_plan:
-        - Run this row only after the norm-free GELU control is defined so the rational swap can be read as the incremental change.
-        - Compare directly against both the norm-free GELU row and the carried anchor before deciding whether the rational path earns a benchmark rerun.
+      - Run this row only after the norm-free GELU control is defined so the rational
+        swap can be read as the incremental change.
+      - Compare directly against both the norm-free GELU row and the carried anchor
+        before deciding whether the rational path earns a benchmark rerun.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -2480,7 +2766,7 @@ deltas:
           optimizer:
             min_lr: 1.0e-05
           runtime:
-            mixed_precision: "no"
+            mixed_precision: 'no'
             grad_clip: 0.0
             grad_accum_steps: 4
             trace_activations: false
@@ -2491,34 +2777,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run after the norm-free GELU control row and carry forward only if it wins the CPU screen clearly enough to justify a benchmark rerun.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run after the norm-free GELU control row and carry forward
+      only if it wins the CPU screen clearly enough to justify a benchmark rerun.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_heads2_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the historical head-partition family by reducing `sandwich_heads` from `4` to `2` on the TF-RD-010 multiclass benchmark contract.
-    upstream_delta: Reuses the TF-RD-021B attention-head family on the current classification benchmark surface.
-    expected_effect: If the retained sandwich is width-limited rather than head-factorization-limited after TF-RD-022, this lower head count should be close on the inherited benchmark contract.
+    description: Reuse the historical head-partition family by reducing `sandwich_heads`
+      from `4` to `2` on the TF-RD-010 multiclass benchmark contract.
+    upstream_delta: Reuses the TF-RD-021B attention-head family on the current classification
+      benchmark surface.
+    expected_effect: If the retained sandwich is width-limited rather than head-factorization-limited
+      after TF-RD-022, this lower head count should be close on the inherited benchmark
+      contract.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - head factorization only; `d_icl`, `sandwich_layers`, optimizer, and batch remain frozen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - head factorization only; `d_icl`, `sandwich_layers`, optimizer, and batch remain
+      frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute only after the TF-RD-022 runtime policy is explicit and the anchor is rerun on that surface.
-        - Keep head count as a live follow-on dimension only if the row stays close on medium and earns large-rung validation.
+      - Execute only after the TF-RD-022 runtime policy is explicit and the anchor
+        is rerun on that surface.
+      - Keep head count as a live follow-on dimension only if the row stays close
+        on medium and earns large-rung validation.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2568,34 +2861,40 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_ffexp1_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the lower-MLP bracket by reducing `sandwich_ff_expansion` from `2` to `1` on the inherited multiclass benchmark surface.
-    upstream_delta: Reuses the TF-RD-021B feed-forward expansion family on the current classification contract.
-    expected_effect: If the retained sandwich gains are still mostly structural after TF-RD-022, the lower FF expansion should remain competitive on the benchmark contract.
+    description: Reuse the lower-MLP bracket by reducing `sandwich_ff_expansion` from
+      `2` to `1` on the inherited multiclass benchmark surface.
+    upstream_delta: Reuses the TF-RD-021B feed-forward expansion family on the current
+      classification contract.
+    expected_effect: If the retained sandwich gains are still mostly structural after
+      TF-RD-022, the lower FF expansion should remain competitive on the benchmark
+      contract.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - feed-forward expansion only; no training-dynamics or width/depth reopen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - feed-forward expansion only; no training-dynamics or width/depth reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after TF-RD-022 closes and keep the schedule, optimizer, and data front identical to the anchor.
-        - Promote the lower FF bracket only if the medium delta is negligible and large-rung validation does not reverse the read.
+      - Execute after TF-RD-022 closes and keep the schedule, optimizer, and data
+        front identical to the anchor.
+      - Promote the lower FF bracket only if the medium delta is negligible and large-rung
+        validation does not reverse the read.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2645,34 +2944,40 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_summarytokens1_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the lower summary-stream bracket by reducing `sandwich_summary_tokens_per_axis` from `3` to `1` on the inherited multiclass benchmark surface.
-    upstream_delta: Reuses the TF-RD-021B summary-token family while respecting the current direct-multiclass benchmark contract.
-    expected_effect: If the retained sandwich mostly benefits from the broader hybrid structure rather than extra summary bandwidth, the lower summary-token bracket should stay competitive after TF-RD-022.
+    description: Reuse the lower summary-stream bracket by reducing `sandwich_summary_tokens_per_axis`
+      from `3` to `1` on the inherited multiclass benchmark surface.
+    upstream_delta: Reuses the TF-RD-021B summary-token family while respecting the
+      current direct-multiclass benchmark contract.
+    expected_effect: If the retained sandwich mostly benefits from the broader hybrid
+      structure rather than extra summary bandwidth, the lower summary-token bracket
+      should stay competitive after TF-RD-022.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - summary-stream bandwidth only; width, layers, optimizer, and batch stay frozen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - summary-stream bandwidth only; width, layers, optimizer, and batch stay frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute only after the TF-RD-022 runtime policy closes and the anchor is rerun on that surface.
-        - Carry this as a follow-on knob only if medium and large validation both show it is not materially harmful.
+      - Execute only after the TF-RD-022 runtime policy closes and the anchor is rerun
+        on that surface.
+      - Carry this as a follow-on knob only if medium and large validation both show
+        it is not materially harmful.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2722,34 +3027,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_selfattn1_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the lower latent-refinement bracket by reducing `sandwich_self_attention_per_cross` from `4` to `1` on the inherited multiclass benchmark surface.
-    upstream_delta: Reuses the TF-RD-021B latent self-refinement family on the current classification benchmark contract.
-    expected_effect: If most of the retained gain comes from the hybrid full-cell bypasses rather than repeated latent self-refinement, the lower self-attention bracket should stay near-anchor after TF-RD-022.
+    description: Reuse the lower latent-refinement bracket by reducing `sandwich_self_attention_per_cross`
+      from `4` to `1` on the inherited multiclass benchmark surface.
+    upstream_delta: Reuses the TF-RD-021B latent self-refinement family on the current
+      classification benchmark contract.
+    expected_effect: If most of the retained gain comes from the hybrid full-cell
+      bypasses rather than repeated latent self-refinement, the lower self-attention
+      bracket should stay near-anchor after TF-RD-022.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - latent self-attention depth only; width, layers, batch, LR, and clipping stay frozen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - latent self-attention depth only; width, layers, batch, LR, and clipping stay
+      frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-022 runtime policy closes, then compare directly against the inherited benchmark anchor before any broader follow-up.
-        - Carry this as a live axis only if both medium and large validation say the lower bracket is competitive.
+      - Execute after the TF-RD-022 runtime policy closes, then compare directly against
+        the inherited benchmark anchor before any broader follow-up.
+      - Carry this as a live axis only if both medium and large validation say the
+        lower bracket is competitive.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2799,34 +3111,40 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_headhidden64_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the lower readout-capacity bracket by reducing `head_hidden_dim` from `96` to `64` on the inherited multiclass benchmark surface.
-    upstream_delta: Reuses the TF-RD-021B head-hidden family on the current classification benchmark contract.
-    expected_effect: If the retained sandwich is still trunk-limited rather than head-limited after TF-RD-022, the smaller readout bracket should stay close to anchor quality.
+    description: Reuse the lower readout-capacity bracket by reducing `head_hidden_dim`
+      from `96` to `64` on the inherited multiclass benchmark surface.
+    upstream_delta: Reuses the TF-RD-021B head-hidden family on the current classification
+      benchmark contract.
+    expected_effect: If the retained sandwich is still trunk-limited rather than head-limited
+      after TF-RD-022, the smaller readout bracket should stay close to anchor quality.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - readout capacity only; `d_icl`, `sandwich_layers`, optimizer, and batch remain frozen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - readout capacity only; `d_icl`, `sandwich_layers`, optimizer, and batch remain
+      frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-022 runtime policy closes and compare directly against the inherited benchmark anchor.
-        - Keep the lower head bracket only if medium and large validation both show negligible loss.
+      - Execute after the TF-RD-022 runtime policy closes and compare directly against
+        the inherited benchmark anchor.
+      - Keep the lower head bracket only if medium and large validation both show
+        negligible loss.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2876,34 +3194,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_cls_sandwich_headhidden128_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Reuse the upper readout-capacity bracket by increasing `head_hidden_dim` from `96` to `128` on the inherited multiclass benchmark surface.
-    upstream_delta: Reuses the TF-RD-021B head-hidden family on the current classification benchmark contract.
-    expected_effect: If the retained sandwich is readout-limited after TF-RD-022, the larger head-hidden bracket should improve the inherited benchmark fit enough to justify a later large-rung validation.
+    description: Reuse the upper readout-capacity bracket by increasing `head_hidden_dim`
+      from `96` to `128` on the inherited multiclass benchmark surface.
+    upstream_delta: Reuses the TF-RD-021B head-hidden family on the current classification
+      benchmark contract.
+    expected_effect: If the retained sandwich is readout-limited after TF-RD-022,
+      the larger head-hidden bracket should improve the inherited benchmark fit enough
+      to justify a later large-rung validation.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 runtime policy surface
-      - readout capacity only; `d_icl`, `sandwich_layers`, optimizer, and batch remain frozen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 runtime policy surface
+    - readout capacity only; `d_icl`, `sandwich_layers`, optimizer, and batch remain
+      frozen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-022 runtime policy closes and compare directly against the inherited benchmark anchor.
-        - Keep the higher head bracket as a live follow-on only if the medium gain survives large-rung validation.
+      - Execute after the TF-RD-022 runtime policy closes and compare directly against
+        the inherited benchmark anchor.
+      - Keep the higher head bracket as a live follow-on only if the medium gain survives
+        large-rung validation.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: blocked_on_runtime_policy
     default_initial_interpretation_status: blocked
     default_effective_surface:
@@ -2953,34 +3278,40 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside the bounded TF-RD-024 knob sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Wait for the TF-RD-022 keep anchor, then run this row inside
+      the bounded TF-RD-024 knob sweep.
     applicability_guards: []
-
   delta_tf_rd_024_followup_cls_sandwich_heads1_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Extend the TF-RD-024 head-partition follow-up by reducing `sandwich_heads` from `4` to `1` on the inherited multiclass benchmark surface.
-    upstream_delta: Extends the TF-RD-024 attention-head family one bracket lower after `sandwich_heads=2` won the initial medium screen.
-    expected_effect: If the medium gain from the lower-head bracket reflects excess head factorization rather than a narrow `2`-head sweet spot, `sandwich_heads=1` may remain competitive or improve further on the closed medium contract.
+    description: Extend the TF-RD-024 head-partition follow-up by reducing `sandwich_heads`
+      from `4` to `1` on the inherited multiclass benchmark surface.
+    upstream_delta: Extends the TF-RD-024 attention-head family one bracket lower
+      after `sandwich_heads=2` won the initial medium screen.
+    expected_effect: If the medium gain from the lower-head bracket reflects excess
+      head factorization rather than a narrow `2`-head sweet spot, `sandwich_heads=1`
+      may remain competitive or improve further on the closed medium contract.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime policy surface
-      - attention partitioning only; no width, depth, batching, or optimizer reopen
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime policy surface
+    - attention partitioning only; no width, depth, batching, or optimizer reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute as an independent follow-up against the fresh compile-eager-dynamic anchor instead of stacking on top of `sandwich_heads=2`.
-        - Carry the lower head count into TF-RD-009 only if it beats the current best medium result from `sandwich_heads=2`.
+      - Execute as an independent follow-up against the fresh compile-eager-dynamic
+        anchor instead of stacking on top of `sandwich_heads=2`.
+      - Carry the lower head count into TF-RD-009 only if it beats the current best
+        medium result from `sandwich_heads=2`.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3030,34 +3361,41 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run as order 1 in the TF-RD-024 two-row follow-up sweep, then compare directly against the current best medium result from `sandwich_heads=2`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run as order 1 in the TF-RD-024 two-row follow-up sweep,
+      then compare directly against the current best medium result from `sandwich_heads=2`.
     applicability_guards: []
-
   delta_tf_rd_024_followup_cls_sandwich_prerow2_v1:
     dimension_family: model
     family: architecture_followup
     binary_applicable: false
-    description: Extend the row pre-mixer family by increasing `sandwich_pre_row_attention_layers` from `1` to `2` on the inherited multiclass benchmark surface.
-    upstream_delta: Extends the historical TF-RD-021B row pre-mixer family upward after the `prerow=0` ablation showed that row-wise feature mixing is materially useful.
-    expected_effect: If the row-wise pre-Perceiver mixer is still capacity-limited on the current multiclass contract, the deeper row pre-mixer bracket may improve medium benchmark fit enough to justify the scaling handoff.
+    description: Extend the row pre-mixer family by increasing `sandwich_pre_row_attention_layers`
+      from `1` to `2` on the inherited multiclass benchmark surface.
+    upstream_delta: Extends the historical TF-RD-021B row pre-mixer family upward
+      after the `prerow=0` ablation showed that row-wise feature mixing is materially
+      useful.
+    expected_effect: If the row-wise pre-Perceiver mixer is still capacity-limited
+      on the current multiclass contract, the deeper row pre-mixer bracket may improve
+      medium benchmark fit enough to justify the scaling handoff.
     adequacy_knobs:
-      - fixed TF-RD-010 medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime policy surface
-      - row pre-mixer depth only; no compounded head, width, or latent changes
+    - fixed TF-RD-010 medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime policy surface
+    - row pre-mixer depth only; no compounded head, width, or latent changes
     parameter_adequacy_policy:
       default_plan:
-        - Execute as an independent topology probe against the fresh compile-eager-dynamic anchor instead of stacking with `sandwich_heads=1`.
-        - Carry the deeper row pre-mixer into TF-RD-009 only if it beats the current best medium result from `sandwich_heads=2`.
+      - Execute as an independent topology probe against the fresh compile-eager-dynamic
+        anchor instead of stacking with `sandwich_heads=1`.
+      - Carry the deeper row pre-mixer into TF-RD-009 only if it beats the current
+        best medium result from `sandwich_heads=2`.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3107,36 +3445,43 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run as order 2 in the TF-RD-024 two-row follow-up sweep, then compare directly against the current best medium result from `sandwich_heads=2`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run as order 2 in the TF-RD-024 two-row follow-up sweep,
+      then compare directly against the current best medium result from `sandwich_heads=2`.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl48_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Reduce TF-RD-009 classification sandwich width from `d_icl=60` to `48` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022 runtime bundle fixed.
-    upstream_delta: TF-RD-009 treats width as the first live scaling axis after the TF-RD-024 heads1 replay establishes the benchmark-registry-backed anchor.
-    expected_effect: If the carried heads1 classification surface is width-overprovisioned on the closed medium contract, dropping to `d_icl=48` should preserve most benchmark quality at the matched regime budget.
+    description: Reduce TF-RD-009 classification sandwich width from `d_icl=60` to
+      `48` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022
+      runtime bundle fixed.
+    upstream_delta: TF-RD-009 treats width as the first live scaling axis after the
+      TF-RD-024 heads1 replay establishes the benchmark-registry-backed anchor.
+    expected_effect: If the carried heads1 classification surface is width-overprovisioned
+      on the closed medium contract, dropping to `d_icl=48` should preserve most benchmark
+      quality at the matched regime budget.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - width only; no layers, optimizer retune, curriculum, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - width only; no layers, optimizer retune, curriculum, or token-budget reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
-        - Compare directly against the replayed `d_icl=60` anchor at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Interpret this contraction only in the context of the full four-width family `{48, 60(anchor), 96, 128}`.
+      - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
+      - Compare directly against the replayed `d_icl=60` anchor at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Interpret this contraction only in the context of the full four-width family
+        `{48, 60(anchor), 96, 128}`.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3186,36 +3531,43 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as the lower-width bracket in `tf_rd_009_width_transfer_medium_v1` after the replayed heads1 anchor is promoted.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as the lower-width bracket in `tf_rd_009_width_transfer_medium_v1`
+      after the replayed heads1 anchor is promoted.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl96_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Increase TF-RD-009 classification sandwich width from `d_icl=60` to `96` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022 runtime bundle fixed.
-    upstream_delta: TF-RD-009 treats width as the clean first transfer axis after the heads1 replay anchor is benchmark-registry-backed.
-    expected_effect: If the carried heads1 classification surface is still width-limited on the closed medium contract, increasing to `d_icl=96` should improve benchmark fit without reopening any other sandwich knob.
+    description: Increase TF-RD-009 classification sandwich width from `d_icl=60`
+      to `96` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022
+      runtime bundle fixed.
+    upstream_delta: TF-RD-009 treats width as the clean first transfer axis after
+      the heads1 replay anchor is benchmark-registry-backed.
+    expected_effect: If the carried heads1 classification surface is still width-limited
+      on the closed medium contract, increasing to `d_icl=96` should improve benchmark
+      fit without reopening any other sandwich knob.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - width only; no layers, optimizer retune, curriculum, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - width only; no layers, optimizer retune, curriculum, or token-budget reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
-        - Compare directly against the replayed `d_icl=60` anchor at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Use the result to decide whether width-only movement remains a live TF-RD-009 family before joint width-depth work opens.
+      - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
+      - Compare directly against the replayed `d_icl=60` anchor at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Use the result to decide whether width-only movement remains a live TF-RD-009
+        family before joint width-depth work opens.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3265,36 +3617,43 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as the first upper-width bracket in `tf_rd_009_width_transfer_medium_v1` after the replayed heads1 anchor is promoted.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as the first upper-width bracket in `tf_rd_009_width_transfer_medium_v1`
+      after the replayed heads1 anchor is promoted.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Increase TF-RD-009 classification sandwich width from `d_icl=60` to `128` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022 runtime bundle fixed.
-    upstream_delta: This is the larger-width bracket for the first TF-RD-009 width-transfer family once the carried heads1 anchor is replayed and registered.
-    expected_effect: If width-only improvement remains monotone beyond `d_icl=96`, expanding to `128` should either continue the gain or show that width-only transfer is flattening before joint width-depth scaling begins.
+    description: Increase TF-RD-009 classification sandwich width from `d_icl=60`
+      to `128` while keeping the carried `sandwich_heads=1` architecture and the TF-RD-022
+      runtime bundle fixed.
+    upstream_delta: This is the larger-width bracket for the first TF-RD-009 width-transfer
+      family once the carried heads1 anchor is replayed and registered.
+    expected_effect: If width-only improvement remains monotone beyond `d_icl=96`,
+      expanding to `128` should either continue the gain or show that width-only transfer
+      is flattening before joint width-depth scaling begins.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - width only; no layers, optimizer retune, curriculum, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - width only; no layers, optimizer retune, curriculum, or token-budget reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
-        - Compare directly against the replayed `d_icl=60` anchor at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Treat this row as evidence about the upper edge of the first width-only family, not as permission to retune optimizer or open a compute-optimal frontier yet.
+      - Execute after the TF-RD-009 heads1 replay anchor is registered and promoted.
+      - Compare directly against the replayed `d_icl=60` anchor at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Treat this row as evidence about the upper edge of the first width-only family,
+        not as permission to retune optimizer or open a compute-optimal frontier yet.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3344,36 +3703,52 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as the largest width bracket in `tf_rd_009_width_transfer_medium_v1` after the replayed heads1 anchor is promoted.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as the largest width bracket in `tf_rd_009_width_transfer_medium_v1`
+      after the replayed heads1 anchor is promoted.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl72_layers1_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the lower diagonal TF-RD-009 joint width-depth row at `d_icl=72`, `sandwich_layers=1`, derived by matching the formal `60x2` anchor against the empirical depth-aware sandwich parameter bridge rather than the older `L * d^2` proxy.
-    upstream_delta: TF-RD-009 uses the literature-backed rule that width and depth must be co-designed once depth moves, then picks the concrete lower row from the empirical sandwich bridge `P_local(d, L) ≈ 29966.47 + 75.38 * d^2 + 48.43 * L * d^2` on the frozen medium surface. That bridge chooses the queue row only; the reported law fit is deferred to measured benchmark-registry `model_size.total_params`.
-    expected_effect: If the sandwich target can trade one layer for more width while staying genuinely close to the formal `60x2` anchor in parameter scale, `72x1` should show whether the lower diagonal stays competitive against the active carried in-family baseline at matched regime budget.
+    description: Execute the lower diagonal TF-RD-009 joint width-depth row at `d_icl=72`,
+      `sandwich_layers=1`, derived by matching the formal `60x2` anchor against the
+      empirical depth-aware sandwich parameter bridge rather than the older `L * d^2`
+      proxy.
+    upstream_delta: TF-RD-009 uses the literature-backed rule that width and depth
+      must be co-designed once depth moves, then picks the concrete lower row from
+      the empirical sandwich bridge `P_local(d, L) ≈ 29966.47 + 75.38 * d^2 + 48.43
+      * L * d^2` on the frozen medium surface. That bridge chooses the queue row only;
+      the reported law fit is deferred to measured benchmark-registry `model_size.total_params`.
+    expected_effect: If the sandwich target can trade one layer for more width while
+      staying genuinely close to the formal `60x2` anchor in parameter scale, `72x1`
+      should show whether the lower diagonal stays competitive against the active
+      carried in-family baseline at matched regime budget.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the active width-only baseline is fixed for the current family; this row is the empirical depth-aware parameter bridge's lower anchor-equivalent probe.
-        - Compare directly against the carried in-family baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Report relative to the formal `60x2` TF-RD-009 anchor, but interpret this row inside the diagonal family `{72x1, 96x2, 112x3, 128x4, 152x5, 176x6}` rather than as a standalone keep/reject claim.
+      - Execute after the active width-only baseline is fixed for the current family;
+        this row is the empirical depth-aware parameter bridge's lower anchor-equivalent
+        probe.
+      - Compare directly against the carried in-family baseline at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Report relative to the formal `60x2` TF-RD-009 anchor, but interpret this
+        row inside the diagonal family `{72x1, 96x2, 112x3, 128x4, 152x5, 176x6}`
+        rather than as a standalone keep/reject claim.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3423,36 +3798,49 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 1 in the active TF-RD-009 width-depth family against the carried in-family baseline.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 1 in the active TF-RD-009 width-depth family
+      against the carried in-family baseline.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl112_layers3_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the upper diagonal TF-RD-009 joint width-depth row at `d_icl=112`, `sandwich_layers=3`, derived by matching the width-only upper evidence row `128x2` against the empirical depth-aware sandwich parameter bridge.
-    upstream_delta: TF-RD-009 treats this as the paper-constrained upper seed for the broadened medium-rung family, after which the ladder extends toward the retained `rtx8000_44gb` ceiling using the same row-construction bridge instead of a grid search.
-    expected_effect: If the fixed-budget law continues above the carried in-family baseline, `112x3` should improve the matched-regime-budget objective while staying within a cleaner stability envelope than the already-warned width-only `128x2` row.
+    description: Execute the upper diagonal TF-RD-009 joint width-depth row at `d_icl=112`,
+      `sandwich_layers=3`, derived by matching the width-only upper evidence row `128x2`
+      against the empirical depth-aware sandwich parameter bridge.
+    upstream_delta: TF-RD-009 treats this as the paper-constrained upper seed for
+      the broadened medium-rung family, after which the ladder extends toward the
+      retained `rtx8000_44gb` ceiling using the same row-construction bridge instead
+      of a grid search.
+    expected_effect: If the fixed-budget law continues above the carried in-family
+      baseline, `112x3` should improve the matched-regime-budget objective while staying
+      within a cleaner stability envelope than the already-warned width-only `128x2`
+      row.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the lower diagonal `72x1` row so the first TF-RD-009 joint family remains an ordered diagonal around the width-only `128x2` upper evidence target rather than a grid.
-        - Compare directly against the carried in-family baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - If benchmark-backed but health=`warn`, keep the row as evidence and do not silently replace it with a different upper geometry in the same branch.
+      - Execute after the lower diagonal `72x1` row so the first TF-RD-009 joint family
+        remains an ordered diagonal around the width-only `128x2` upper evidence target
+        rather than a grid.
+      - Compare directly against the carried in-family baseline at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - If benchmark-backed but health=`warn`, keep the row as evidence and do not
+        silently replace it with a different upper geometry in the same branch.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3502,36 +3890,48 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 2 in the active TF-RD-009 width-depth family after the lower diagonal row is benchmark-backed.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 2 in the active TF-RD-009 width-depth family
+      after the lower diagonal row is benchmark-backed.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_layers4_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the first post-seed upper TF-RD-009 joint width-depth row at `d_icl=128`, `sandwich_layers=4`, extending the diagonal family by log-spacing predicted parameter scale between the `112x3` seed and the intended `176x6` ceiling probe on the frozen sandwich surface.
-    upstream_delta: TF-RD-009 keeps the literature-backed width-depth co-design shape, then extends the upper ladder by log-spacing predicted parameter scale between the `112x3` seed and the intended `176x6` ceiling probe under the empirical depth-aware bridge.
-    expected_effect: If the joint law remains smooth beyond the first upper seed, `128x4` should continue the matched-budget trend without consuming an outsized share of the `rtx8000_44gb` VRAM budget.
+    description: Execute the first post-seed upper TF-RD-009 joint width-depth row
+      at `d_icl=128`, `sandwich_layers=4`, extending the diagonal family by log-spacing
+      predicted parameter scale between the `112x3` seed and the intended `176x6`
+      ceiling probe on the frozen sandwich surface.
+    upstream_delta: TF-RD-009 keeps the literature-backed width-depth co-design shape,
+      then extends the upper ladder by log-spacing predicted parameter scale between
+      the `112x3` seed and the intended `176x6` ceiling probe under the empirical
+      depth-aware bridge.
+    expected_effect: If the joint law remains smooth beyond the first upper seed,
+      `128x4` should continue the matched-budget trend without consuming an outsized
+      share of the `rtx8000_44gb` VRAM budget.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after `112x3` is benchmark-backed so the broadened family preserves an ordered dense diagonal.
-        - Compare directly against the carried `96x2` baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Treat this row as an intermediate reported-fit point once benchmark-backed, not a final keep/reject decision in isolation.
+      - Execute after `112x3` is benchmark-backed so the broadened family preserves
+        an ordered dense diagonal.
+      - Compare directly against the carried `96x2` baseline at matched regime budget
+        using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Treat this row as an intermediate reported-fit point once benchmark-backed,
+        not a final keep/reject decision in isolation.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3581,63 +3981,83 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 3 in `tf_rd_009_width_depth_medium_v1` after `112x3` is benchmark-backed.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 3 in `tf_rd_009_width_depth_medium_v1` after
+      `112x3` is benchmark-backed.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
-    upstream_delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
-    expected_effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+    description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row
+      at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior
+      target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+    upstream_delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed
+      width screen plus the frozen RTX 8000 planning formulas, then uses log-space
+      parameter interpolation instead of inheriting the historical schedulefree ladder.
+    expected_effect: If the fresh Muon fixed-budget law stays smooth beyond the upper
+      seed, `144x4` should provide the first interior Phase-1 measurement between
+      the carried `128x2` baseline and the retained ceiling probe.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - carried post-#271 packed Muon runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - carried post-#271 packed Muon runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after the `72x1` and `112x3` fresh-Muon seed rows so the rederived family stays an ordered diagonal around the landed width screen.
-        - Compare directly against the carried `128x2` Muon baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Treat this row as interior fresh-Muon Phase-1 evidence rather than as an upper-family reopen selector output.
+      - Execute after the `72x1` and `112x3` fresh-Muon seed rows so the rederived
+        family stays an ordered diagonal around the landed width screen.
+      - Compare directly against the carried `128x2` Muon baseline at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Treat this row as interior fresh-Muon Phase-1 evidence rather than as an upper-family
+        reopen selector output.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Execute as order 3 in `tf_rd_009_muon_width_depth_medium_v1` after the fresh-Muon seed rows are benchmark-backed.
+    default_next_action: Execute as order 3 in `tf_rd_009_muon_width_depth_medium_v1`
+      after the fresh-Muon seed rows are benchmark-backed.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl152_layers5_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the penultimate TF-RD-009 joint width-depth upper row at `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended `rtx8000_44gb` ceiling probe.
-    upstream_delta: TF-RD-009 uses this row to extend the empirically bridged parameter ladder far enough to fit curvature and identify where hardware guardrails begin to dominate, without switching to a width-depth grid.
-    expected_effect: If the medium-rung joint law is still smooth at higher effective size, `152x5` should improve the matched-budget objective or expose the first clear bend in the runtime and stability guardrails.
+    description: Execute the penultimate TF-RD-009 joint width-depth upper row at
+      `d_icl=152`, `sandwich_layers=5`, continuing the dense diagonal toward the intended
+      `rtx8000_44gb` ceiling probe.
+    upstream_delta: TF-RD-009 uses this row to extend the empirically bridged parameter
+      ladder far enough to fit curvature and identify where hardware guardrails begin
+      to dominate, without switching to a width-depth grid.
+    expected_effect: If the medium-rung joint law is still smooth at higher effective
+      size, `152x5` should improve the matched-budget objective or expose the first
+      clear bend in the runtime and stability guardrails.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after `128x4` is benchmark-backed so the family remains a dense diagonal rather than a sparse extrapolation.
-        - Compare directly against the carried `96x2` baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Keep any health=`warn` outcome as explicit ceiling evidence rather than silently replacing this row.
+      - Execute after `128x4` is benchmark-backed so the family remains a dense diagonal
+        rather than a sparse extrapolation.
+      - Compare directly against the carried `96x2` baseline at matched regime budget
+        using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Keep any health=`warn` outcome as explicit ceiling evidence rather than silently
+        replacing this row.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3687,36 +4107,49 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 4 in `tf_rd_009_width_depth_medium_v1` after `128x4` is benchmark-backed.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 4 in `tf_rd_009_width_depth_medium_v1` after
+      `128x4` is benchmark-backed.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl176_layers6_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the intended TF-RD-009 ceiling probe at `d_icl=176`, `sandwich_layers=6`, chosen to land near the retained `rtx8000_44gb` surface's `32-33 GB` reserved-memory target while staying on the same dense diagonal family.
-    upstream_delta: TF-RD-009 treats this as an intentional hardware-ceiling probe derived from the empirical sandwich parameter bridge and the carried RTX 8000 VRAM fit rather than a paper-claimed closed-form exponent. The final reported law is still fit later on measured benchmark-registry `model_size.total_params`.
-    expected_effect: "`176x6` should either extend the matched-budget law into the near-saturation regime or fail cleanly enough to mark the first medium-rung hardware ceiling on the carried runtime surface."
+    description: Execute the intended TF-RD-009 ceiling probe at `d_icl=176`, `sandwich_layers=6`,
+      chosen to land near the retained `rtx8000_44gb` surface's `32-33 GB` reserved-memory
+      target while staying on the same dense diagonal family.
+    upstream_delta: TF-RD-009 treats this as an intentional hardware-ceiling probe
+      derived from the empirical sandwich parameter bridge and the carried RTX 8000
+      VRAM fit rather than a paper-claimed closed-form exponent. The final reported
+      law is still fit later on measured benchmark-registry `model_size.total_params`.
+    expected_effect: '`176x6` should either extend the matched-budget law into the
+      near-saturation regime or fail cleanly enough to mark the first medium-rung
+      hardware ceiling on the carried runtime surface.'
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute last as the explicit `rtx8000_44gb` ceiling probe for the first broadened TF-RD-009 family; this rounded row is chosen to land near the empirical `32-33 GB` reserved-memory target rather than the older underfit `144x6` estimate.
-        - Compare directly against the carried `96x2` baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - If the row fails before benchmark registration, keep that failure as valid ceiling evidence and leave `#255` open rather than substituting a new upper row in the same branch.
+      - Execute last as the explicit `rtx8000_44gb` ceiling probe for the first broadened
+        TF-RD-009 family; this rounded row is chosen to land near the empirical `32-33
+        GB` reserved-memory target rather than the older underfit `144x6` estimate.
+      - Compare directly against the carried `96x2` baseline at matched regime budget
+        using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - If the row fails before benchmark registration, keep that failure as valid
+        ceiling evidence and leave `#255` open rather than substituting a new upper
+        row in the same branch.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -3766,426 +4199,560 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 5 in `tf_rd_009_width_depth_medium_v1` after `152x5` is benchmark-backed; treat failure as ceiling evidence.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 5 in `tf_rd_009_width_depth_medium_v1` after
+      `152x5` is benchmark-backed; treat failure as ceiling evidence.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl192_layers5_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the second fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=192`, `sandwich_layers=5`, using the higher rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
-    upstream_delta: TF-RD-009 keeps the fresh Muon Phase-1 family below the reopened upper-extension branch by interpolating interior rows on the frozen RTX 8000 bridge rather than by reviving the historical schedulefree ladder or running a grid search.
-    expected_effect: If the fresh Muon fixed-budget law remains smooth in the pre-ceiling region, `192x5` should extend the interior Phase-1 evidence without collapsing directly into the later upper-family reopen.
+    description: Execute the second fresh-Muon interpolated TF-RD-009 width-depth
+      row at `d_icl=192`, `sandwich_layers=5`, using the higher rederived log-space
+      interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling
+      probe.
+    upstream_delta: TF-RD-009 keeps the fresh Muon Phase-1 family below the reopened
+      upper-extension branch by interpolating interior rows on the frozen RTX 8000
+      bridge rather than by reviving the historical schedulefree ladder or running
+      a grid search.
+    expected_effect: If the fresh Muon fixed-budget law remains smooth in the pre-ceiling
+      region, `192x5` should extend the interior Phase-1 evidence without collapsing
+      directly into the later upper-family reopen.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - carried post-#271 packed Muon runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - carried post-#271 packed Muon runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute after `144x4` so the fresh Muon Phase-1 family spans the interior pre-ceiling region in order.
-        - Compare directly against the carried `128x2` Muon baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - Keep this row in the base Muon Phase-1 family; rerun the reopened upper-family selector only after Muon Phase 2 lands.
+      - Execute after `144x4` so the fresh Muon Phase-1 family spans the interior
+        pre-ceiling region in order.
+      - Compare directly against the carried `128x2` Muon baseline at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - Keep this row in the base Muon Phase-1 family; rerun the reopened upper-family
+        selector only after Muon Phase 2 lands.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Execute as order 4 in `tf_rd_009_muon_width_depth_medium_v1` after `144x4` is benchmark-backed.
+    default_next_action: Execute as order 4 in `tf_rd_009_muon_width_depth_medium_v1`
+      after `144x4` is benchmark-backed.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl264_layers6_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the retained fresh-Muon TF-RD-009 ceiling probe at `d_icl=264`, `sandwich_layers=6`, chosen to land near the carried `32.5 GB` RTX 8000 reserved-memory target while staying in the base Phase-1 family.
-    upstream_delta: TF-RD-009 treats this as an intentional Muon Phase-1 ceiling probe derived from the frozen RTX 8000 planning formulas and the landed width screen, rather than as a reopened upper-family row.
-    expected_effect: If the rederived Muon Phase-1 family can reach the retained local ceiling cleanly, `264x6` should either extend the matched-budget law into the near-saturation regime or provide explicit ceiling evidence without needing the later upper-family selector.
+    description: Execute the retained fresh-Muon TF-RD-009 ceiling probe at `d_icl=264`,
+      `sandwich_layers=6`, chosen to land near the carried `32.5 GB` RTX 8000 reserved-memory
+      target while staying in the base Phase-1 family.
+    upstream_delta: TF-RD-009 treats this as an intentional Muon Phase-1 ceiling probe
+      derived from the frozen RTX 8000 planning formulas and the landed width screen,
+      rather than as a reopened upper-family row.
+    expected_effect: If the rederived Muon Phase-1 family can reach the retained local
+      ceiling cleanly, `264x6` should either extend the matched-budget law into the
+      near-saturation regime or provide explicit ceiling evidence without needing
+      the later upper-family selector.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - carried post-#271 packed Muon runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+    - fixed TF-RD-010 curated medium benchmark contract
+    - carried post-#271 packed Muon runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+      reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute last as the retained fresh-Muon Phase-1 ceiling probe under the carried `32.5 GB` reserved-memory target.
-        - Compare directly against the carried `128x2` Muon baseline at matched regime budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
-        - If this row fails before benchmark registration, keep that failure as valid Phase-1 ceiling evidence and rerun the upper-family selector only after Muon Phase 2 lands.
+      - Execute last as the retained fresh-Muon Phase-1 ceiling probe under the carried
+        `32.5 GB` reserved-memory target.
+      - Compare directly against the carried `128x2` Muon baseline at matched regime
+        budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+      - If this row fails before benchmark registration, keep that failure as valid
+        Phase-1 ceiling evidence and rerun the upper-family selector only after Muon
+        Phase 2 lands.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Execute as order 5 in `tf_rd_009_muon_width_depth_medium_v1` after `192x5` is benchmark-backed; treat failure as fresh-Muon ceiling evidence.
+    default_next_action: Execute as order 5 in `tf_rd_009_muon_width_depth_medium_v1`
+      after `192x5` is benchmark-backed; treat failure as fresh-Muon ceiling evidence.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`) as the selector floor.
-    upstream_delta: This is the compact endpoint selector baseline that follows corrected Muon Phase 2 and the cleanup-first navigation lane; it keeps the corrected multiclass benchmark contract and the `v6` training corpus fixed while measuring the carried low-batch dynamics point directly.
-    expected_effect: If the carried low-batch Muon surface is still on the quality/time frontier after the corrected Phase-2 closeout, this row should remain the compact selector floor that later higher-batch prescriptions must beat.
+    description: Re-run the carried Muon `128x2` in-family baseline at the fixed 5000-step
+      endpoint with the low-batch `B_eff=64` contract (`task_batch_size=16`, `grad_accum_steps=4`)
+      as the selector floor.
+    upstream_delta: This is the compact endpoint selector baseline that follows corrected
+      Muon Phase 2 and the cleanup-first navigation lane; it keeps the corrected multiclass
+      benchmark contract and the `v6` training corpus fixed while measuring the carried
+      low-batch dynamics point directly.
+    expected_effect: If the carried low-batch Muon surface is still on the quality/time
+      frontier after the corrected Phase-2 closeout, this row should remain the compact
+      selector floor that later higher-batch prescriptions must beat.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
-      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+    - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the `128x2` low-batch selector floor after the active Muon lineage cleanup is landed.
-        - Compare directly against the high-batch and literature-backed `128x2` prescriptions on corrected benchmark loss and end-to-end train wall time.
-        - Carry forward only if the corrected Pareto frontier still prefers the low-batch contract once the selector is complete.
+      - Execute as the `128x2` low-batch selector floor after the active Muon lineage
+        cleanup is landed.
+      - Compare directly against the high-batch and literature-backed `128x2` prescriptions
+        on corrected benchmark loss and end-to-end train wall time.
+      - Carry forward only if the corrected Pareto frontier still prefers the low-batch
+        contract once the selector is complete.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `128x2` low-batch endpoint in `tf_rd_009_muon_training_dynamics_endpoint_medium_v1` and keep it only if it remains on the corrected quality/time Pareto frontier.
+    default_next_action: Benchmark this `128x2` low-batch endpoint in `tf_rd_009_muon_training_dynamics_endpoint_medium_v1`
+      and keep it only if it remains on the corrected quality/time Pareto frontier.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`) and the original Muon LR/beta surface unchanged.
-    upstream_delta: Corrected Muon Phase 2 showed that batch-side movement dominated geometry-only movement; this row tests whether the measured high-batch gain transfers to the compact `128x2` selector geometry without opening the optimizer prescription yet.
-    expected_effect: If the Phase-2 batch-side gain transfers cleanly, this row should beat or match the low-batch `128x2` floor at acceptable extra training time and justify keeping high-batch dynamics in the next law-conditioning lane.
+    description: Re-run the carried Muon `128x2` geometry at the fixed 5000-step endpoint
+      with the empirical high-batch `B_eff=256` carry-forward contract (`grad_accum_steps=16`)
+      and the original Muon LR/beta surface unchanged.
+    upstream_delta: Corrected Muon Phase 2 showed that batch-side movement dominated
+      geometry-only movement; this row tests whether the measured high-batch gain
+      transfers to the compact `128x2` selector geometry without opening the optimizer
+      prescription yet.
+    expected_effect: If the Phase-2 batch-side gain transfers cleanly, this row should
+      beat or match the low-batch `128x2` floor at acceptable extra training time
+      and justify keeping high-batch dynamics in the next law-conditioning lane.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon LR, beta, and weight-decay surface
-      - high-batch empirical reference only; no broader optimizer reopen
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon LR, beta, and weight-decay surface
+    - high-batch empirical reference only; no broader optimizer reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the empirical high-batch carry-forward row for `128x2`.
-        - Compare directly against the low-batch `128x2` row on corrected benchmark loss, throughput, and wall time.
-        - Keep this contract only if the measured gain justifies the time cost before any later Phase-2B rerun.
+      - Execute as the empirical high-batch carry-forward row for `128x2`.
+      - Compare directly against the low-batch `128x2` row on corrected benchmark
+        loss, throughput, and wall time.
+      - Keep this contract only if the measured gain justifies the time cost before
+        any later Phase-2B rerun.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `128x2` high-batch empirical reference and compare it directly against the low-batch selector floor.
+    default_next_action: Benchmark this `128x2` high-batch empirical reference and
+      compare it directly against the low-batch selector floor.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the literature-backed linear LR/batch prescription on `128x2` at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping `betas=(0.9, 0.95)` and `weight_decay=0.01`.
-    upstream_delta: This row encodes the first defended optimizer-timescale variant for the compact selector after corrected Muon Phase 2, testing the simplest `eta proportional to batch` prescription under the fixed corpus, benchmark, and horizon contract.
-    expected_effect: If the corrected Muon surface follows the linear LR/batch invariant closely enough, this row should improve quality at the high-batch endpoint without requiring a separate geometry change.
+    description: Test the literature-backed linear LR/batch prescription on `128x2`
+      at `B_eff=256`, scaling `lr_max` to `4e-3` and `min_lr` to `4e-6` while keeping
+      `betas=(0.9, 0.95)` and `weight_decay=0.01`.
+    upstream_delta: This row encodes the first defended optimizer-timescale variant
+      for the compact selector after corrected Muon Phase 2, testing the simplest
+      `eta proportional to batch` prescription under the fixed corpus, benchmark,
+      and horizon contract.
+    expected_effect: If the corrected Muon surface follows the linear LR/batch invariant
+      closely enough, this row should improve quality at the high-batch endpoint without
+      requiring a separate geometry change.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with linear LR scaling
-      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with linear LR scaling
+    - '`weight_decay=0.01` stays frozen while batch and LR move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the first literature-backed high-batch prescription for `128x2`.
-        - Compare directly against both carried `128x2` rows to test whether linear LR scaling is a better kept invariant than the pure carry-forward contract.
-        - Promote only if it lands on the corrected quality/time Pareto frontier.
+      - Execute as the first literature-backed high-batch prescription for `128x2`.
+      - Compare directly against both carried `128x2` rows to test whether linear
+        LR scaling is a better kept invariant than the pure carry-forward contract.
+      - Promote only if it lands on the corrected quality/time Pareto frontier.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `128x2` linear LR/batch prescription and keep it only if it materially improves the corrected quality/time frontier.
+    default_next_action: Benchmark this `128x2` linear LR/batch prescription and keep
+      it only if it materially improves the corrected quality/time frontier.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the momentum-timescale Muon selector prescription on `128x2` at `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising `beta1` to `0.975`.
-    upstream_delta: Corrected Muon Phase 2 justified training-dynamics-first work; this row is the second defended invariant-backed probe, testing whether a larger effective momentum timescale transfers better than simple linear LR scaling on the compact selector geometry.
-    expected_effect: If momentum-timescale coupling matters on the corrected Muon surface, this row should outperform the linear LR/batch prescription at comparable wall time on `128x2`.
+    description: Test the momentum-timescale Muon selector prescription on `128x2`
+      at `B_eff=256`, keeping `lr_max=4e-3`, `min_lr=4e-6`, `beta2=0.95`, and raising
+      `beta1` to `0.975`.
+    upstream_delta: Corrected Muon Phase 2 justified training-dynamics-first work;
+      this row is the second defended invariant-backed probe, testing whether a larger
+      effective momentum timescale transfers better than simple linear LR scaling
+      on the compact selector geometry.
+    expected_effect: If momentum-timescale coupling matters on the corrected Muon
+      surface, this row should outperform the linear LR/batch prescription at comparable
+      wall time on `128x2`.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with `beta1=0.975`
-      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with `beta1=0.975`
+    - '`weight_decay=0.01` stays frozen while LR and momentum move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the momentum-timescale comparator for the `128x2` selector geometry.
-        - Compare directly against the carried high-batch and linear LR/batch `128x2` rows.
-        - Promote only if the corrected benchmark gain is real enough to justify the additional training-time cost.
+      - Execute as the momentum-timescale comparator for the `128x2` selector geometry.
+      - Compare directly against the carried high-batch and linear LR/batch `128x2`
+        rows.
+      - Promote only if the corrected benchmark gain is real enough to justify the
+        additional training-time cost.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `128x2` momentum-timescale prescription and compare it against the other `128x2` selector rows on corrected loss and wall time.
+    default_next_action: Benchmark this `128x2` momentum-timescale prescription and
+      compare it against the other `128x2` selector rows on corrected loss and wall
+      time.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run the corrected Muon NS winner geometry `144x4` at the fixed 5000-step endpoint with the carried low-batch `B_eff=64` contract.
-    upstream_delta: Corrected Muon Phase 2 showed that `144x4` is the best NS geometry while `264x6` only wins after batch tuning; this row carries the NS winner into the compact training-dynamics selector without changing the geometry.
-    expected_effect: If `144x4` remains the best compact geometry under the selector contract, this low-batch row should establish the geometry’s time-efficient frontier point before any higher-batch or literature-backed prescription is kept.
+    description: Re-run the corrected Muon NS winner geometry `144x4` at the fixed
+      5000-step endpoint with the carried low-batch `B_eff=64` contract.
+    upstream_delta: Corrected Muon Phase 2 showed that `144x4` is the best NS geometry
+      while `264x6` only wins after batch tuning; this row carries the NS winner into
+      the compact training-dynamics selector without changing the geometry.
+    expected_effect: If `144x4` remains the best compact geometry under the selector
+      contract, this low-batch row should establish the geometry’s time-efficient
+      frontier point before any higher-batch or literature-backed prescription is
+      kept.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
-      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+    - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the `144x4` low-batch selector floor.
-        - Compare against the corresponding high-batch and literature-backed `144x4` rows plus the carried `128x2` floor.
-        - Keep the geometry only if at least one `144x4` dynamics contract stays on the corrected Pareto frontier.
+      - Execute as the `144x4` low-batch selector floor.
+      - Compare against the corresponding high-batch and literature-backed `144x4`
+        rows plus the carried `128x2` floor.
+      - Keep the geometry only if at least one `144x4` dynamics contract stays on
+        the corrected Pareto frontier.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `144x4` low-batch endpoint and use it as the corrected NS-winner floor for the selector.
+    default_next_action: Benchmark this `144x4` low-batch endpoint and use it as the
+      corrected NS-winner floor for the selector.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
-    upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
-    expected_effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+    description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical
+      high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+    upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side
+      gain also improves the `144x4` NS winner when geometry is held fixed.
+    expected_effect: If batch-side movement generalizes across the compact frontier,
+      this row should improve `144x4` materially enough to challenge the carried low-batch
+      point on the corrected quality/time frontier.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon LR, beta, and weight-decay surface
-      - empirical high-batch reference only; no broader optimizer reopen
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon LR, beta, and weight-decay surface
+    - empirical high-batch reference only; no broader optimizer reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the empirical high-batch carry-forward row for `144x4`.
-        - Compare directly against the `144x4` low-batch floor and the two literature-backed `144x4` prescriptions.
-        - Keep this contract only if the corrected gain is large enough to offset the extra train time.
+      - Execute as the empirical high-batch carry-forward row for `144x4`.
+      - Compare directly against the `144x4` low-batch floor and the two literature-backed
+        `144x4` prescriptions.
+      - Keep this contract only if the corrected gain is large enough to offset the
+        extra train time.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `144x4` high-batch empirical reference and compare it against the other `144x4` selector rows.
+    default_next_action: Benchmark this `144x4` high-batch empirical reference and
+      compare it against the other `144x4` selector rows.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the linear LR/batch Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
-    upstream_delta: This row applies the simplest defended high-batch optimizer invariant to the corrected NS-winner geometry so the selector can decide whether `144x4` wants a new dynamics contract before any later Phase-2B rerun.
-    expected_effect: If `eta proportional to batch` is a better organizing invariant than pure carry-forward at `144x4`, this row should improve corrected benchmark quality enough to stay on the Pareto frontier.
+    description: Test the linear LR/batch Muon selector prescription on `144x4` at
+      `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+    upstream_delta: This row applies the simplest defended high-batch optimizer invariant
+      to the corrected NS-winner geometry so the selector can decide whether `144x4`
+      wants a new dynamics contract before any later Phase-2B rerun.
+    expected_effect: If `eta proportional to batch` is a better organizing invariant
+      than pure carry-forward at `144x4`, this row should improve corrected benchmark
+      quality enough to stay on the Pareto frontier.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with linear LR scaling
-      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with linear LR scaling
+    - '`weight_decay=0.01` stays frozen while batch and LR move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the first literature-backed high-batch prescription for `144x4`.
-        - Compare directly against both carried `144x4` rows and the momentum-timescale `144x4` variant.
-        - Promote only if it lands on the corrected quality/time Pareto frontier.
+      - Execute as the first literature-backed high-batch prescription for `144x4`.
+      - Compare directly against both carried `144x4` rows and the momentum-timescale
+        `144x4` variant.
+      - Promote only if it lands on the corrected quality/time Pareto frontier.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `144x4` linear LR/batch prescription and keep it only if it improves the corrected Pareto frontier.
+    default_next_action: Benchmark this `144x4` linear LR/batch prescription and keep
+      it only if it improves the corrected Pareto frontier.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the momentum-timescale Muon selector prescription on `144x4` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
-    upstream_delta: This row is the second invariant-backed training-dynamics probe for the corrected NS-winner geometry, testing whether a longer effective momentum timescale gives a cleaner high-batch transfer than the linear LR/batch rule.
-    expected_effect: If momentum-timescale coupling is the better invariant on `144x4`, this row should outperform the linear LR/batch `144x4` prescription at comparable high-batch wall time.
+    description: Test the momentum-timescale Muon selector prescription on `144x4`
+      at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`,
+      and `weight_decay=0.01`.
+    upstream_delta: This row is the second invariant-backed training-dynamics probe
+      for the corrected NS-winner geometry, testing whether a longer effective momentum
+      timescale gives a cleaner high-batch transfer than the linear LR/batch rule.
+    expected_effect: If momentum-timescale coupling is the better invariant on `144x4`,
+      this row should outperform the linear LR/batch `144x4` prescription at comparable
+      high-batch wall time.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with `beta1=0.975`
-      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with `beta1=0.975`
+    - '`weight_decay=0.01` stays frozen while LR and momentum move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the momentum-timescale comparator for `144x4`.
-        - Compare directly against the carried high-batch and linear LR/batch `144x4` rows.
-        - Promote only if the corrected gain is large enough to justify the same or higher wall time.
+      - Execute as the momentum-timescale comparator for `144x4`.
+      - Compare directly against the carried high-batch and linear LR/batch `144x4`
+        rows.
+      - Promote only if the corrected gain is large enough to justify the same or
+        higher wall time.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `144x4` momentum-timescale prescription and compare it against the other `144x4` selector rows on corrected loss and wall time.
+    default_next_action: Benchmark this `144x4` momentum-timescale prescription and
+      compare it against the other `144x4` selector rows on corrected loss and wall
+      time.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run the corrected overall Muon Phase-2 winner geometry `264x6` at the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward contract.
-    upstream_delta: Corrected Muon Phase 2 showed that `264x6` only wins once effective batch is pushed up; this row measures the larger geometry’s low-batch floor inside the compact selector so the later high-batch gain can be interpreted cleanly.
-    expected_effect: If `264x6` is genuinely under-optimized at low batch, this row should underperform the high-batch `264x6` rows and justify training-dynamics-first sequencing over immediate larger-family reopen.
+    description: Re-run the corrected overall Muon Phase-2 winner geometry `264x6`
+      at the fixed 5000-step endpoint with the low-batch `B_eff=64` carry-forward
+      contract.
+    upstream_delta: Corrected Muon Phase 2 showed that `264x6` only wins once effective
+      batch is pushed up; this row measures the larger geometry’s low-batch floor
+      inside the compact selector so the later high-batch gain can be interpreted
+      cleanly.
+    expected_effect: If `264x6` is genuinely under-optimized at low batch, this row
+      should underperform the high-batch `264x6` rows and justify training-dynamics-first
+      sequencing over immediate larger-family reopen.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon runtime and optimizer surface with `weight_decay=0.01`
-      - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon runtime and optimizer surface with `weight_decay=0.01`
+    - no repeats; selector ranks rows on the corrected quality/time Pareto frontier
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the `264x6` low-batch floor so the selector can separate geometry size from optimization effects.
-        - Compare directly against the corresponding high-batch and literature-backed `264x6` rows plus the compact `128x2` and `144x4` candidates.
-        - Keep the larger geometry only if at least one `264x6` dynamics contract justifies its time cost on the corrected Pareto frontier.
+      - Execute as the `264x6` low-batch floor so the selector can separate geometry
+        size from optimization effects.
+      - Compare directly against the corresponding high-batch and literature-backed
+        `264x6` rows plus the compact `128x2` and `144x4` candidates.
+      - Keep the larger geometry only if at least one `264x6` dynamics contract justifies
+        its time cost on the corrected Pareto frontier.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `264x6` low-batch endpoint and use it as the larger-geometry floor for the selector.
+    default_next_action: Benchmark this `264x6` low-batch endpoint and use it as the
+      larger-geometry floor for the selector.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Re-run `264x6` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
-    upstream_delta: This row carries forward the corrected Phase-2 result that made `264x6` the best overall row, but now inside the compact selector where quality is judged jointly with training time.
-    expected_effect: If the corrected Phase-2 high-batch gain is robust enough to survive the selector replay, this row should stay on the corrected quality/time Pareto frontier and justify keeping `264x6` in later Phase-2B planning.
+    description: Re-run `264x6` at the fixed 5000-step endpoint with the empirical
+      high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+    upstream_delta: This row carries forward the corrected Phase-2 result that made
+      `264x6` the best overall row, but now inside the compact selector where quality
+      is judged jointly with training time.
+    expected_effect: If the corrected Phase-2 high-batch gain is robust enough to
+      survive the selector replay, this row should stay on the corrected quality/time
+      Pareto frontier and justify keeping `264x6` in later Phase-2B planning.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - carried Muon LR, beta, and weight-decay surface
-      - empirical high-batch reference only; no broader optimizer reopen
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - carried Muon LR, beta, and weight-decay surface
+    - empirical high-batch reference only; no broader optimizer reopen
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the empirical high-batch carry-forward row for `264x6`.
-        - Compare directly against the `264x6` low-batch floor and both literature-backed `264x6` prescriptions.
-        - Keep this contract only if the corrected gain remains large enough to justify its wall-time cost.
+      - Execute as the empirical high-batch carry-forward row for `264x6`.
+      - Compare directly against the `264x6` low-batch floor and both literature-backed
+        `264x6` prescriptions.
+      - Keep this contract only if the corrected gain remains large enough to justify
+        its wall-time cost.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `264x6` high-batch empirical reference and compare it against the other `264x6` selector rows.
+    default_next_action: Benchmark this `264x6` high-batch empirical reference and
+      compare it against the other `264x6` selector rows.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the linear LR/batch Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
-    upstream_delta: This row asks whether the larger corrected winner geometry wants the simple `eta proportional to batch` prescription strongly enough to beat the empirical carry-forward contract once quality and time are judged together.
-    expected_effect: If linear LR scaling is the better invariant for the larger geometry, this row should improve corrected benchmark quality enough to remain Pareto-admissible despite the geometry’s higher training cost.
+    description: Test the linear LR/batch Muon selector prescription on `264x6` at
+      `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `betas=(0.9, 0.95)`, and `weight_decay=0.01`.
+    upstream_delta: This row asks whether the larger corrected winner geometry wants
+      the simple `eta proportional to batch` prescription strongly enough to beat
+      the empirical carry-forward contract once quality and time are judged together.
+    expected_effect: If linear LR scaling is the better invariant for the larger geometry,
+      this row should improve corrected benchmark quality enough to remain Pareto-admissible
+      despite the geometry’s higher training cost.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with linear LR scaling
-      - "`weight_decay=0.01` stays frozen while batch and LR move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with linear LR scaling
+    - '`weight_decay=0.01` stays frozen while batch and LR move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the first literature-backed high-batch prescription for `264x6`.
-        - Compare directly against both carried `264x6` rows and the momentum-timescale `264x6` variant.
-        - Promote only if it stays on the corrected quality/time Pareto frontier.
+      - Execute as the first literature-backed high-batch prescription for `264x6`.
+      - Compare directly against both carried `264x6` rows and the momentum-timescale
+        `264x6` variant.
+      - Promote only if it stays on the corrected quality/time Pareto frontier.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `264x6` linear LR/batch prescription and keep it only if it improves the corrected Pareto frontier.
+    default_next_action: Benchmark this `264x6` linear LR/batch prescription and keep
+      it only if it improves the corrected Pareto frontier.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1:
     dimension_family: training
     family: classification_scaling_law
     binary_applicable: false
-    description: Test the momentum-timescale Muon selector prescription on `264x6` at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`, and `weight_decay=0.01`.
-    upstream_delta: This row is the second invariant-backed high-batch probe for the larger corrected winner geometry, testing whether a longer momentum timescale produces a better kept dynamics contract than simple linear LR scaling.
-    expected_effect: If momentum-timescale coupling is the better organizing invariant for the larger geometry, this row should beat the linear LR/batch `264x6` prescription on corrected benchmark quality at comparable wall time.
+    description: Test the momentum-timescale Muon selector prescription on `264x6`
+      at `B_eff=256` with `lr_max=4e-3`, `min_lr=4e-6`, `beta1=0.975`, `beta2=0.95`,
+      and `weight_decay=0.01`.
+    upstream_delta: This row is the second invariant-backed high-batch probe for the
+      larger corrected winner geometry, testing whether a longer momentum timescale
+      produces a better kept dynamics contract than simple linear LR scaling.
+    expected_effect: If momentum-timescale coupling is the better organizing invariant
+      for the larger geometry, this row should beat the linear LR/batch `264x6` prescription
+      on corrected benchmark quality at comparable wall time.
     adequacy_knobs:
-      - corrected `openml_classification_medium_v1` benchmark contract
-      - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
-      - fixed `5000`-step one-epoch endpoint
-      - high-batch `B_eff=256` endpoint with `beta1=0.975`
-      - "`weight_decay=0.01` stays frozen while LR and momentum move together"
+    - corrected `openml_classification_medium_v1` benchmark contract
+    - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+    - fixed `5000`-step one-epoch endpoint
+    - high-batch `B_eff=256` endpoint with `beta1=0.975`
+    - '`weight_decay=0.01` stays frozen while LR and momentum move together'
     parameter_adequacy_policy:
       default_plan:
-        - Execute as the momentum-timescale comparator for `264x6`.
-        - Compare directly against the carried high-batch and linear LR/batch `264x6` rows.
-        - Promote only if the corrected gain is real enough to justify the larger geometry’s time cost.
+      - Execute as the momentum-timescale comparator for `264x6`.
+      - Compare directly against the carried high-batch and linear LR/batch `264x6`
+        rows.
+      - Promote only if the corrected gain is real enough to justify the larger geometry’s
+        time cost.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
-    default_next_action: Benchmark this `264x6` momentum-timescale prescription and compare it against the other `264x6` selector rows on corrected loss and wall time.
+    default_next_action: Benchmark this `264x6` momentum-timescale prescription and
+      compare it against the other `264x6` selector rows on corrected loss and wall
+      time.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl192_layers7_upper_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the first reopened TF-RD-009 upper-family gate row at `d_icl=192`, `sandwich_layers=7`, selected by the deterministic post-`#257` validation `L(N,S)` information-gain design pass.
-    upstream_delta: TF-RD-009 deliberately reopens the fixed-budget upper family after the corrected `#257` large-rung gate froze a lower-memory hardware model. This row belongs to the winning continuation `192x7 -> 208x8 -> 224x9 -> 248x10`, chosen by D-optimal information gain on the current validation `L(N,S)` fit rather than by direct model chasing.
-    expected_effect: If the corrected headroom can support a wider reopened upper family, `192x7` should widen the validation `L(N,S)` design space at the carried matched-budget row while preserving the fixed-contract architecture surface.
+    description: Execute the first reopened TF-RD-009 upper-family gate row at `d_icl=192`,
+      `sandwich_layers=7`, selected by the deterministic post-`#257` validation `L(N,S)`
+      information-gain design pass.
+    upstream_delta: TF-RD-009 deliberately reopens the fixed-budget upper family after
+      the corrected `#257` large-rung gate froze a lower-memory hardware model. This
+      row belongs to the winning continuation `192x7 -> 208x8 -> 224x9 -> 248x10`,
+      chosen by D-optimal information gain on the current validation `L(N,S)` fit
+      rather than by direct model chasing.
+    expected_effect: If the corrected headroom can support a wider reopened upper
+      family, `192x7` should widen the validation `L(N,S)` design space at the carried
+      matched-budget row while preserving the fixed-contract architecture surface.
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - upper-family gate-first policy before any reopened NS ladder spend
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - upper-family gate-first policy before any reopened NS ladder spend
     parameter_adequacy_policy:
       default_plan:
-        - Execute only at the carried fixed-budget gate row before spending any NS-ladder budget on reopened upper geometries.
-        - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed and health=`ok`; keep health=`warn` as upper-family evidence only.
-        - Use this row for validation `L(N,S)` information gain even if it is weaker than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze a new preferred baseline without a fresh large-rung validation gate.
+      - Execute only at the carried fixed-budget gate row before spending any NS-ladder
+        budget on reopened upper geometries.
+      - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed
+        and health=`ok`; keep health=`warn` as upper-family evidence only.
+      - Use this row for validation `L(N,S)` information gain even if it is weaker
+        than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze
+        a new preferred baseline without a fresh large-rung validation gate.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -4235,36 +4802,45 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 1 in `tf_rd_009_width_depth_upper_extension_medium_v1`, then expand only after health=`ok`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 1 in `tf_rd_009_width_depth_upper_extension_medium_v1`,
+      then expand only after health=`ok`.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl208_layers8_upper_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the second reopened TF-RD-009 upper-family gate row at `d_icl=208`, `sandwich_layers=8`, continuing the winning post-`#257` information-first continuation.
-    upstream_delta: TF-RD-009 reopens the upper family under the corrected medium-evidence parameter and VRAM fits, then spends compute only on rows selected by the deterministic validation `L(N,S)` design helper.
-    expected_effect: "`208x8` should probe whether a deeper upper row remains healthy enough to improve law information before the reopened branch reaches the near-40 GB regime."
+    description: Execute the second reopened TF-RD-009 upper-family gate row at `d_icl=208`,
+      `sandwich_layers=8`, continuing the winning post-`#257` information-first continuation.
+    upstream_delta: TF-RD-009 reopens the upper family under the corrected medium-evidence
+      parameter and VRAM fits, then spends compute only on rows selected by the deterministic
+      validation `L(N,S)` design helper.
+    expected_effect: '`208x8` should probe whether a deeper upper row remains healthy
+      enough to improve law information before the reopened branch reaches the near-40
+      GB regime.'
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - upper-family gate-first policy before any reopened NS ladder spend
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - upper-family gate-first policy before any reopened NS ladder spend
     parameter_adequacy_policy:
       default_plan:
-        - Execute only at the carried fixed-budget gate row before spending any NS-ladder budget on reopened upper geometries.
-        - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed and health=`ok`; keep health=`warn` as upper-family evidence only.
-        - Use this row for validation `L(N,S)` information gain even if it is weaker than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze a new preferred baseline without a fresh large-rung validation gate.
+      - Execute only at the carried fixed-budget gate row before spending any NS-ladder
+        budget on reopened upper geometries.
+      - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed
+        and health=`ok`; keep health=`warn` as upper-family evidence only.
+      - Use this row for validation `L(N,S)` information gain even if it is weaker
+        than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze
+        a new preferred baseline without a fresh large-rung validation gate.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -4314,36 +4890,46 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 2 in `tf_rd_009_width_depth_upper_extension_medium_v1`, then expand only after health=`ok`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 2 in `tf_rd_009_width_depth_upper_extension_medium_v1`,
+      then expand only after health=`ok`.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl224_layers9_upper_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the third reopened TF-RD-009 upper-family gate row at `d_icl=224`, `sandwich_layers=9`, continuing the winning post-`#257` information-first continuation.
-    upstream_delta: This row exists because the corrected frozen VRAM fit showed materially more headroom than the original `176x6` branch assumed, so TF-RD-009 now reopens the upper family by explicit validation-law design rather than by ad hoc capacity chasing.
-    expected_effect: "`224x9` should test whether the reopened upper family keeps adding validation `L(N,S)` curvature information near the corrected medium-rung ceiling."
+    description: Execute the third reopened TF-RD-009 upper-family gate row at `d_icl=224`,
+      `sandwich_layers=9`, continuing the winning post-`#257` information-first continuation.
+    upstream_delta: This row exists because the corrected frozen VRAM fit showed materially
+      more headroom than the original `176x6` branch assumed, so TF-RD-009 now reopens
+      the upper family by explicit validation-law design rather than by ad hoc capacity
+      chasing.
+    expected_effect: '`224x9` should test whether the reopened upper family keeps
+      adding validation `L(N,S)` curvature information near the corrected medium-rung
+      ceiling.'
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - upper-family gate-first policy before any reopened NS ladder spend
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - upper-family gate-first policy before any reopened NS ladder spend
     parameter_adequacy_policy:
       default_plan:
-        - Execute only at the carried fixed-budget gate row before spending any NS-ladder budget on reopened upper geometries.
-        - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed and health=`ok`; keep health=`warn` as upper-family evidence only.
-        - Use this row for validation `L(N,S)` information gain even if it is weaker than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze a new preferred baseline without a fresh large-rung validation gate.
+      - Execute only at the carried fixed-budget gate row before spending any NS-ladder
+        budget on reopened upper geometries.
+      - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed
+        and health=`ok`; keep health=`warn` as upper-family evidence only.
+      - Use this row for validation `L(N,S)` information gain even if it is weaker
+        than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze
+        a new preferred baseline without a fresh large-rung validation gate.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -4393,36 +4979,47 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 3 in `tf_rd_009_width_depth_upper_extension_medium_v1`, then expand only after health=`ok`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 3 in `tf_rd_009_width_depth_upper_extension_medium_v1`,
+      then expand only after health=`ok`.
     applicability_guards: []
-
   delta_tf_rd_009_cls_sandwich_dicl248_layers10_upper_v1:
     dimension_family: model
     family: classification_scaling_law
     binary_applicable: false
-    description: Execute the reopened TF-RD-009 near-ceiling gate row at `d_icl=248`, `sandwich_layers=10`, selected as the largest member of the winning post-`#257` information-first continuation.
-    upstream_delta: TF-RD-009 no longer stops at `176x6` by policy; it now intentionally reopens the upper family under the corrected frozen hardware model, but still gates every new geometry at the carried fixed-budget row before spending full NS-ladder budget.
-    expected_effect: "`248x10` should act as the reopened near-ceiling evidence row for the corrected `~40 GB` target while still participating in the same deterministic validation-law design set as the lower reopened rows."
+    description: Execute the reopened TF-RD-009 near-ceiling gate row at `d_icl=248`,
+      `sandwich_layers=10`, selected as the largest member of the winning post-`#257`
+      information-first continuation.
+    upstream_delta: TF-RD-009 no longer stops at `176x6` by policy; it now intentionally
+      reopens the upper family under the corrected frozen hardware model, but still
+      gates every new geometry at the carried fixed-budget row before spending full
+      NS-ladder budget.
+    expected_effect: '`248x10` should act as the reopened near-ceiling evidence row
+      for the corrected `~40 GB` target while still participating in the same deterministic
+      validation-law design set as the lower reopened rows.'
     adequacy_knobs:
-      - fixed TF-RD-010 curated medium benchmark contract
-      - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
-      - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
-      - upper-family gate-first policy before any reopened NS ladder spend
+    - fixed TF-RD-010 curated medium benchmark contract
+    - inherited TF-RD-022 compile-eager-dynamic runtime and optimizer surface
+    - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+    - upper-family gate-first policy before any reopened NS ladder spend
     parameter_adequacy_policy:
       default_plan:
-        - Execute only at the carried fixed-budget gate row before spending any NS-ladder budget on reopened upper geometries.
-        - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed and health=`ok`; keep health=`warn` as upper-family evidence only.
-        - Use this row for validation `L(N,S)` information gain even if it is weaker than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze a new preferred baseline without a fresh large-rung validation gate.
+      - Execute only at the carried fixed-budget gate row before spending any NS-ladder
+        budget on reopened upper geometries.
+      - Promote to `tf_rd_009_ns_upper_extension_medium_v1` only if benchmark-backed
+        and health=`ok`; keep health=`warn` as upper-family evidence only.
+      - Use this row for validation `L(N,S)` information gain even if it is weaker
+        than `152x5` on `final_log_loss_at_matched_regime_budget`, and do not freeze
+        a new preferred baseline without a fresh large-rung validation gate.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     default_initial_status: ready
     default_initial_interpretation_status: pending
     default_effective_surface:
@@ -4472,31 +5069,33 @@ deltas:
             max_steps: 2500
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.001
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Execute as order 4 in `tf_rd_009_width_depth_upper_extension_medium_v1`, then expand only after health=`ok`.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Execute as order 4 in `tf_rd_009_width_depth_upper_extension_medium_v1`,
+      then expand only after health=`ok`.
     applicability_guards: []
-
   delta_shifted_grouped_tokenizer:
     dimension_family: model
     family: tokenization
     binary_applicable: true
-    description: Replace scalar-per-feature tokenization with the shifted grouped tokenizer while keeping downstream row/context structure anchored.
+    description: Replace scalar-per-feature tokenization with the shifted grouped
+      tokenizer while keeping downstream row/context structure anchored.
     upstream_delta: Upstream nanoTabPFN keeps one scalar token per feature.
-    expected_effect: None until the tokenizer becomes part of the effective computation graph on this surface.
+    expected_effect: None until the tokenizer becomes part of the effective computation
+      graph on this surface.
     adequacy_knobs:
-      - Revisit only after the comparison surface switches to a non-nano feature encoder.
+    - Revisit only after the comparison surface switches to a non-nano feature encoder.
     parameter_adequacy_policy:
       default_plan:
-        - Do not run while tokenizer changes are bypassed by the active feature encoder.
+      - Do not run while tokenizer changes are bypassed by the active feature encoder.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: grouped_tokens
     default_initial_status: blocked_on_surface_semantics
     default_initial_interpretation_status: blocked
@@ -4509,37 +5108,44 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Unblock only after the comparison surface makes tokenizer changes effective, or replace this row with a genuinely isolatable tokenization experiment.
+    default_next_action: Unblock only after the comparison surface makes tokenizer
+      changes effective, or replace this row with a genuinely isolatable tokenization
+      experiment.
     applicability_guards:
-      - kind: requires_anchor_model_selection
-        key: feature_encoder
-        any_of:
-          - shared
-        failure_status: blocked_on_surface_semantics
-        failure_interpretation_status: blocked
-        failure_next_action: Unblock only after the comparison surface makes tokenizer changes effective, or replace this row with a genuinely isolatable tokenization experiment.
-
+    - kind: requires_anchor_model_selection
+      key: feature_encoder
+      any_of:
+      - shared
+      failure_status: blocked_on_surface_semantics
+      failure_interpretation_status: blocked
+      failure_next_action: Unblock only after the comparison surface makes tokenizer
+        changes effective, or replace this row with a genuinely isolatable tokenization
+        experiment.
   delta_row_cls_pool:
     dimension_family: model
     family: row_pool
     binary_applicable: true
-    description: Replace target-column pooling with CLS-based row pooling while leaving tokenizer, column encoder, and context encoder otherwise anchored.
+    description: Replace target-column pooling with CLS-based row pooling while leaving
+      tokenizer, column encoder, and context encoder otherwise anchored.
     upstream_delta: Upstream nanoTabPFN does not use row-level CLS pooling.
-    expected_effect: Richer row aggregation with substantial added capacity and masking sensitivity.
+    expected_effect: Richer row aggregation with substantial added capacity and masking
+      sensitivity.
     adequacy_knobs:
-      - tfrow_n_heads
-      - tfrow_n_layers
-      - tfrow_cls_tokens
+    - tfrow_n_heads
+    - tfrow_n_layers
+    - tfrow_cls_tokens
     parameter_adequacy_policy:
       default_plan:
-        - Initial run isolates the structural toggle only.
-        - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers, and tfrow_cls_tokens before any reject decision.
-        - Document whether the row pool appears under-capacity, over-capacity, or simply incompatible with the anchor tokenizer.
+      - Initial run isolates the structural toggle only.
+      - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers,
+        and tfrow_cls_tokens before any reject decision.
+      - Document whether the row pool appears under-capacity, over-capacity, or simply
+        incompatible with the anchor tokenizer.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4552,30 +5158,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run the isolated row-pool toggle and require interpretation before any verdict.
+    default_next_action: Run the isolated row-pool toggle and require interpretation
+      before any verdict.
     applicability_guards: []
-
   delta_row_cls_pool_rmsnorm:
     dimension_family: model
     family: row_pool
     binary_applicable: true
-    description: Keep the row-CLS pooling path but replace its row-encoder LayerNorm modules with RMSNorm.
-    upstream_delta: Upstream nanoTabPFN does not use row-level CLS pooling or this row-encoder normalization path.
-    expected_effect: Potentially more stable row-CLS optimization, with the risk that normalization changes only mask a deeper mechanism mismatch.
+    description: Keep the row-CLS pooling path but replace its row-encoder LayerNorm
+      modules with RMSNorm.
+    upstream_delta: Upstream nanoTabPFN does not use row-level CLS pooling or this
+      row-encoder normalization path.
+    expected_effect: Potentially more stable row-CLS optimization, with the risk that
+      normalization changes only mask a deeper mechanism mismatch.
     adequacy_knobs:
-      - tfrow_n_heads
-      - tfrow_n_layers
-      - tfrow_cls_tokens
+    - tfrow_n_heads
+    - tfrow_n_layers
+    - tfrow_cls_tokens
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against both the anchor and the resolved row-CLS evidence.
-        - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers, and tfrow_cls_tokens before any reject decision.
-        - Document whether RMSNorm improves stability, quality, or neither.
+      - Compare directly against both the anchor and the resolved row-CLS evidence.
+      - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers,
+        and tfrow_cls_tokens before any reject decision.
+      - Document whether RMSNorm improves stability, quality, or neither.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4589,29 +5199,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run after the row-CLS adequacy sweep to test whether row-encoder normalization changes the stability story.
+    default_next_action: Run after the row-CLS adequacy sweep to test whether row-encoder
+      normalization changes the stability story.
     applicability_guards: []
-
   delta_plain_context_encoder:
     dimension_family: model
     family: context_encoder
     binary_applicable: true
-    description: Add the plain sequence context encoder over row embeddings while leaving tokenizer, row pooling, and column encoding otherwise fixed.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context encoder.
-    expected_effect: Better row-sequence conditioning than the row-pool-only surface, with materially less added complexity than QASS.
+    description: Add the plain sequence context encoder over row embeddings while
+      leaving tokenizer, row pooling, and column encoding otherwise fixed.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context
+      encoder.
+    expected_effect: Better row-sequence conditioning than the row-pool-only surface,
+      with materially less added complexity than QASS.
     adequacy_knobs:
-      - tficl_n_heads
-      - tficl_n_layers
-      - tficl_ff_expansion
+    - tficl_n_heads
+    - tficl_n_layers
+    - tficl_ff_expansion
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against both the grouped-token anchor and the isolated row-pool row.
-        - Distinguish plain-context value from row-pool-only effects before introducing column-set or QASS changes.
+      - Compare directly against both the grouped-token anchor and the isolated row-pool
+        row.
+      - Distinguish plain-context value from row-pool-only effects before introducing
+        column-set or QASS changes.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4624,30 +5239,36 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run only after the isolated row-pool row so context gains are not conflated with readout changes.
+    default_next_action: Run only after the isolated row-pool row so context gains
+      are not conflated with readout changes.
     applicability_guards: []
-
   delta_row_embeddings_no_context_v2:
     dimension_family: model
     family: row_pool
     binary_applicable: true
-    description: Use the public `row_cls_pool` stage on the grouped-token replay surface, but disable plain context so row embeddings are measured without added context depth.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no row-level CLS pooling or separate context encoder.
-    expected_effect: Stage-native row embeddings without plain-context help, isolating whether row-level aggregation alone improves the grouped-token replay surface.
+    description: Use the public `row_cls_pool` stage on the grouped-token replay surface,
+      but disable plain context so row embeddings are measured without added context
+      depth.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no row-level CLS pooling
+      or separate context encoder.
+    expected_effect: Stage-native row embeddings without plain-context help, isolating
+      whether row-level aggregation alone improves the grouped-token replay surface.
     adequacy_knobs:
-      - tfrow_n_heads
-      - tfrow_n_layers
-      - tfrow_cls_tokens
+    - tfrow_n_heads
+    - tfrow_n_layers
+    - tfrow_cls_tokens
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the grouped-token replay anchor before enabling plain row-level context.
-        - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers, and tfrow_cls_tokens before any reject decision.
-        - Treat this as the no-context control for the paired plain-context row.
+      - Compare directly against the grouped-token replay anchor before enabling plain
+        row-level context.
+      - If neutral-to-bad, perform a bounded adequacy sweep over tfrow_n_heads, tfrow_n_layers,
+        and tfrow_cls_tokens before any reject decision.
+      - Treat this as the no-context control for the paired plain-context row.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4661,29 +5282,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first as the stage-native row-embedding control, then compare against the paired plain-context row.
+    default_next_action: Run first as the stage-native row-embedding control, then
+      compare against the paired plain-context row.
     applicability_guards: []
-
   delta_row_embeddings_plain_context_v2:
     dimension_family: model
     family: context_encoder
     binary_applicable: true
-    description: Use the public `row_cls_pool` stage unchanged so plain row-level context is measured against the no-context row-embedding control.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no row-level CLS pooling or separate context encoder.
-    expected_effect: The public row-embedding stage may justify its added plain-context depth if row-level context is genuinely useful on the grouped-token replay surface.
+    description: Use the public `row_cls_pool` stage unchanged so plain row-level
+      context is measured against the no-context row-embedding control.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no row-level CLS pooling
+      or separate context encoder.
+    expected_effect: The public row-embedding stage may justify its added plain-context
+      depth if row-level context is genuinely useful on the grouped-token replay surface.
     adequacy_knobs:
-      - tficl_n_heads
-      - tficl_n_layers
-      - tficl_ff_expansion
+    - tficl_n_heads
+    - tficl_n_layers
+    - tficl_ff_expansion
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against both the grouped-token replay anchor and the no-context row-embedding row.
-        - Keep column-set and QASS disabled so plain-context value is separated from later row-first structure.
+      - Compare directly against both the grouped-token replay anchor and the no-context
+        row-embedding row.
+      - Keep column-set and QASS disabled so plain-context value is separated from
+        later row-first structure.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4695,29 +5321,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second and interpret it directly against the no-context row-embedding control before moving to column-set.
+    default_next_action: Run second and interpret it directly against the no-context
+      row-embedding control before moving to column-set.
     applicability_guards: []
-
   delta_column_set_plain_context_v2:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `column_set` stage unchanged so TF-RD-006 is measured on top of the established plain-context row-embedding surface.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder.
-    expected_effect: Better feature-set aggregation on the stage-native row-first surface, with inducing-point and capacity risk kept explicit.
+    description: Use the public `column_set` stage unchanged so TF-RD-006 is measured
+      on top of the established plain-context row-embedding surface.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder.
+    expected_effect: Better feature-set aggregation on the stage-native row-first
+      surface, with inducing-point and capacity risk kept explicit.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the plain-context row-embedding row before reading any QASS result.
-        - If neutral-to-bad, interpret whether the issue looks like under-capacity, inducing-point mismatch, or interaction with the unchanged plain context path.
+      - Compare directly against the plain-context row-embedding row before reading
+        any QASS result.
+      - If neutral-to-bad, interpret whether the issue looks like under-capacity,
+        inducing-point mismatch, or interaction with the unchanged plain context path.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: column_set
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4729,29 +5360,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run only after the plain-context row so TF-RD-006 stays attributable before QASS is introduced.
+    default_next_action: Run only after the plain-context row so TF-RD-006 stays attributable
+      before QASS is introduced.
     applicability_guards: []
-
   delta_qass_context_v2:
     dimension_family: model
     family: context_encoder
     binary_applicable: true
-    description: Use the public `qass_context` stage unchanged so QASS is measured against the matched plain-context `column_set` row.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context encoder and no QASS stage.
-    expected_effect: Richer row-sequence conditioning than the matched plain-context column-set row, with any gain or loss attributable to QASS rather than to row embeddings or TFCol.
+    description: Use the public `qass_context` stage unchanged so QASS is measured
+      against the matched plain-context `column_set` row.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context
+      encoder and no QASS stage.
+    expected_effect: Richer row-sequence conditioning than the matched plain-context
+      column-set row, with any gain or loss attributable to QASS rather than to row
+      embeddings or TFCol.
     adequacy_knobs:
-      - tficl_n_heads
-      - tficl_n_layers
-      - tficl_ff_expansion
+    - tficl_n_heads
+    - tficl_n_layers
+    - tficl_ff_expansion
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the matched plain-context `column_set` row.
-        - Treat the plain-context `column_set` row as the non-QASS added-depth control for TF-RD-007.
+      - Compare directly against the matched plain-context `column_set` row.
+      - Treat the plain-context `column_set` row as the non-QASS added-depth control
+        for TF-RD-007.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4763,29 +5399,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run last and interpret only against the matched plain-context column-set row.
+    default_next_action: Run last and interpret only against the matched plain-context
+      column-set row.
     applicability_guards: []
-
   delta_qass_no_column_v3:
     dimension_family: model
     family: context_encoder
     binary_applicable: true
-    description: Use the public `qass_context` stage, but disable the column-set encoder so QASS is measured directly on top of the winning no-context row-embedding surface.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context encoder and no QASS stage.
-    expected_effect: Isolate whether QASS itself helps on the row-embedding surface without TFCol confounding the result.
+    description: Use the public `qass_context` stage, but disable the column-set encoder
+      so QASS is measured directly on top of the winning no-context row-embedding
+      surface.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context
+      encoder and no QASS stage.
+    expected_effect: Isolate whether QASS itself helps on the row-embedding surface
+      without TFCol confounding the result.
     adequacy_knobs:
-      - tficl_n_heads
-      - tficl_n_layers
-      - tficl_ff_expansion
+    - tficl_n_heads
+    - tficl_n_layers
+    - tficl_ff_expansion
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the v2 no-context row-embedding anchor before reading any TFCol result.
-        - Treat this as the QASS-only corner of the row-first follow-up factorization.
+      - Compare directly against the v2 no-context row-embedding anchor before reading
+        any TFCol result.
+      - Treat this as the QASS-only corner of the row-first follow-up factorization.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4802,29 +5443,33 @@ deltas:
           corpus_ref: tf_rd_013_current_corpus_default_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first and compare directly against the v2 no-context row-embedding anchor before attributing any TFCol effect.
+    default_next_action: Run first and compare directly against the v2 no-context
+      row-embedding anchor before attributing any TFCol effect.
     applicability_guards: []
-
   delta_column_set_no_context_v3:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `column_set` stage, but disable plain context so TFCol is measured directly on top of the winning no-context row-embedding surface.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder.
-    expected_effect: Isolate whether TFCol itself helps on the row-embedding surface without plain or QASS context confounding the result.
+    description: Use the public `column_set` stage, but disable plain context so TFCol
+      is measured directly on top of the winning no-context row-embedding surface.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder.
+    expected_effect: Isolate whether TFCol itself helps on the row-embedding surface
+      without plain or QASS context confounding the result.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the v2 no-context row-embedding anchor before reading any QASS-plus-TFCol result.
-        - Treat this as the TFCol-only corner of the row-first follow-up factorization.
+      - Compare directly against the v2 no-context row-embedding anchor before reading
+        any QASS-plus-TFCol result.
+      - Treat this as the TFCol-only corner of the row-first follow-up factorization.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: column_set
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4838,29 +5483,34 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second and read it as TFCol-only evidence on the no-context row-embedding base.
+    default_next_action: Run second and read it as TFCol-only evidence on the no-context
+      row-embedding base.
     applicability_guards: []
-
   delta_qass_context_v3:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `qass_context` stage unchanged so TFCol is measured as the incremental addition to the QASS-only row-first surface.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder and no separate context encoder.
-    expected_effect: Determine whether TFCol adds value once QASS is already present on top of the row-embedding base.
+    description: Use the public `qass_context` stage unchanged so TFCol is measured
+      as the incremental addition to the QASS-only row-first surface.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder and no separate context encoder.
+    expected_effect: Determine whether TFCol adds value once QASS is already present
+      on top of the row-embedding base.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the matched QASS-only row so the incremental TFCol effect stays isolated.
-        - Do not interpret this row as plain-context evidence; v2 already resolved that branch.
+      - Compare directly against the matched QASS-only row so the incremental TFCol
+        effect stays isolated.
+      - Do not interpret this row as plain-context evidence; v2 already resolved that
+        branch.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4872,29 +5522,36 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run last and interpret only against the QASS-only row to decide whether TFCol belongs in the promoted row-first line.
+    default_next_action: Run last and interpret only against the QASS-only row to
+      decide whether TFCol belongs in the promoted row-first line.
     applicability_guards: []
-
   delta_qass_context_tfcol_inducing64_v1:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `qass_context` stage, but reduce TFCol inducing points to 64 so the calibration-winning row-first surface tests whether the current set size is overbuilt.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder and no separate context encoder.
-    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing TFCol capacity enough to recover ROC or runtime if the default inducing set is oversized.
+    description: Use the public `qass_context` stage, but reduce TFCol inducing points
+      to 64 so the calibration-winning row-first surface tests whether the current
+      set size is overbuilt.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder and no separate context encoder.
+    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing
+      TFCol capacity enough to recover ROC or runtime if the default inducing set
+      is oversized.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the completed `delta_qass_context_v3` anchor and keep the calibration-first objective fixed.
-        - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3` and improves either ROC or training time versus the anchor.
+      - Compare directly against the completed `delta_qass_context_v3` anchor and
+        keep the calibration-first objective fixed.
+      - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3`
+        and improves either ROC or training time versus the anchor.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4907,29 +5564,37 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first and compare directly against the completed `delta_qass_context_v3` anchor to see whether a smaller inducing set preserves calibration while recovering ROC or runtime.
+    default_next_action: Run first and compare directly against the completed `delta_qass_context_v3`
+      anchor to see whether a smaller inducing set preserves calibration while recovering
+      ROC or runtime.
     applicability_guards: []
-
   delta_qass_context_tfcol_layers1_v1:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `qass_context` stage, but reduce TFCol depth to one layer so the calibration-winning row-first surface tests whether excess column-encoder depth is driving the ROC penalty.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder and no separate context encoder.
-    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing depth enough to recover ROC or runtime if the default column stack is too deep for this bundle.
+    description: Use the public `qass_context` stage, but reduce TFCol depth to one
+      layer so the calibration-winning row-first surface tests whether excess column-encoder
+      depth is driving the ROC penalty.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder and no separate context encoder.
+    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing
+      depth enough to recover ROC or runtime if the default column stack is too deep
+      for this bundle.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the completed `delta_qass_context_v3` anchor and keep the calibration-first objective fixed.
-        - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3` and improves either ROC or training time versus the anchor.
+      - Compare directly against the completed `delta_qass_context_v3` anchor and
+        keep the calibration-first objective fixed.
+      - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3`
+        and improves either ROC or training time versus the anchor.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4942,29 +5607,37 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second and compare directly against the completed `delta_qass_context_v3` anchor to see whether shallower TFCol depth preserves calibration while improving ROC or runtime.
+    default_next_action: Run second and compare directly against the completed `delta_qass_context_v3`
+      anchor to see whether shallower TFCol depth preserves calibration while improving
+      ROC or runtime.
     applicability_guards: []
-
   delta_qass_context_tfcol_heads4_v1:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Use the public `qass_context` stage, but reduce TFCol attention heads to four so the calibration-winning row-first surface tests whether a lighter attention budget can keep calibration while softening the ROC penalty.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set encoder and no separate context encoder.
-    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing TFCol attention cost enough to recover ROC or runtime if the default head count is unnecessary.
+    description: Use the public `qass_context` stage, but reduce TFCol attention heads
+      to four so the calibration-winning row-first surface tests whether a lighter
+      attention budget can keep calibration while softening the ROC penalty.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no dedicated column-set
+      encoder and no separate context encoder.
+    expected_effect: Preserve the calibration gain of the QASS+TFCol line while reducing
+      TFCol attention cost enough to recover ROC or runtime if the default head count
+      is unnecessary.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the completed `delta_qass_context_v3` anchor and keep the calibration-first objective fixed.
-        - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3` and improves either ROC or training time versus the anchor.
+      - Compare directly against the completed `delta_qass_context_v3` anchor and
+        keep the calibration-first objective fixed.
+      - Promote only if the row keeps the calibration win over `delta_qass_no_column_v3`
+        and improves either ROC or training time versus the anchor.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -4977,28 +5650,32 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run third and compare directly against the completed `delta_qass_context_v3` anchor to see whether fewer TFCol heads preserve calibration while improving ROC or runtime.
+    default_next_action: Run third and compare directly against the completed `delta_qass_context_v3`
+      anchor to see whether fewer TFCol heads preserve calibration while improving
+      ROC or runtime.
     applicability_guards: []
-
   delta_column_set_encoder:
     dimension_family: model
     family: column_encoding
     binary_applicable: true
-    description: Add the TFCol/ISAB-style set encoder over columns while keeping row pooling and context encoding otherwise fixed.
+    description: Add the TFCol/ISAB-style set encoder over columns while keeping row
+      pooling and context encoding otherwise fixed.
     upstream_delta: Upstream nanoTabPFN does not include a dedicated column-set encoder.
-    expected_effect: Better feature-set aggregation with extra capacity and inducing-point sensitivity.
+    expected_effect: Better feature-set aggregation with extra capacity and inducing-point
+      sensitivity.
     adequacy_knobs:
-      - tfcol_n_heads
-      - tfcol_n_layers
-      - tfcol_n_inducing
+    - tfcol_n_heads
+    - tfcol_n_layers
+    - tfcol_n_inducing
     parameter_adequacy_policy:
       default_plan:
-        - If the first run underperforms, interpret whether the issue looks like under-capacity, inducing-point mismatch, or interaction with the unchanged row pool.
+      - If the first run underperforms, interpret whether the issue looks like under-capacity,
+        inducing-point mismatch, or interaction with the unchanged row pool.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: column_set
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5011,28 +5688,30 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run the isolated column-set encoder delta after the row-pool row is understood.
+    default_next_action: Run the isolated column-set encoder delta after the row-pool
+      row is understood.
     applicability_guards: []
-
   delta_qass_context:
     dimension_family: model
     family: context_encoder
     binary_applicable: true
     description: Add the QASS-based sequence context encoder over row embeddings.
-    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context encoder.
-    expected_effect: Richer row-sequence conditioning with risk of unnecessary depth on the compact binary surface.
+    upstream_delta: Upstream nanoTabPFN direct binary path has no separate context
+      encoder.
+    expected_effect: Richer row-sequence conditioning with risk of unnecessary depth
+      on the compact binary surface.
     adequacy_knobs:
-      - tficl_n_heads
-      - tficl_n_layers
-      - tficl_ff_expansion
+    - tficl_n_heads
+    - tficl_n_layers
+    - tficl_ff_expansion
     parameter_adequacy_policy:
       default_plan:
-        - Distinguish context-value from pure added-depth effects in the result card.
+      - Distinguish context-value from pure added-depth effects in the result card.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: qass_context
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5045,28 +5724,31 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run after simpler model deltas so the interpretation has cleaner context.
+    default_next_action: Run after simpler model deltas so the interpretation has
+      cleaner context.
     applicability_guards: []
-
   delta_global_rmsnorm:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Keep the anchor structure fixed but switch the staged/global LayerNorm family to RMSNorm, including the row-pool norm override for completeness.
+    description: Keep the anchor structure fixed but switch the staged/global LayerNorm
+      family to RMSNorm, including the row-pool norm override for completeness.
     upstream_delta: Upstream nanoTabPFN uses LayerNorm in its exact transformer blocks.
-    expected_effect: Potentially smoother optimization or lower gradient spikes, with the risk that RMSNorm only shifts calibration or late-curve behavior.
+    expected_effect: Potentially smoother optimization or lower gradient spikes, with
+      the risk that RMSNorm only shifts calibration or late-curve behavior.
     adequacy_knobs:
-      - model.norm_type
-      - model.tfrow_norm
+    - model.norm_type
+    - model.tfrow_norm
     parameter_adequacy_policy:
       default_plan:
-        - Compare best/final ROC AUC and training stability against the constant anchor surface.
-        - Distinguish early-step stabilization from true end-of-run quality improvements.
+      - Compare best/final ROC AUC and training stability against the constant anchor
+        surface.
+      - Distinguish early-step stabilization from true end-of-run quality improvements.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5079,29 +5761,33 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run after the other model rows so the norm-family change is separated from structural deltas.
+    default_next_action: Run after the other model rows so the norm-family change
+      is separated from structural deltas.
     applicability_guards: []
-
   delta_training_linear_decay:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but replace the exact-prior constant LR with single-stage linear decay.
-    upstream_delta: Not applicable; this is a repo-local exact-prior training recipe change.
-    expected_effect: Better late-curve retention or stability if the constant exact-prior LR is too aggressive for the anchored surface.
+    description: Keep the anchor model, data, and preprocessing surfaces but replace
+      the exact-prior constant LR with single-stage linear decay.
+    upstream_delta: Not applicable; this is a repo-local exact-prior training recipe
+      change.
+    expected_effect: Better late-curve retention or stability if the constant exact-prior
+      LR is too aggressive for the anchored surface.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Interpret against the constant-LR anchor on both ROC and post-warmup stability diagnostics.
-        - Keep optimizer, model, data, and preprocessing fixed for the first pass.
+      - Interpret against the constant-LR anchor on both ROC and post-warmup stability
+        diagnostics.
+      - Keep optimizer, model, data, and preprocessing fixed for the first pass.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5120,34 +5806,39 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.0
-    default_next_action: Run after the model rows so schedule evidence is not mixed with structure changes.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.0
+    default_next_action: Run after the model rows so schedule evidence is not mixed
+      with structure changes.
     applicability_guards: []
-
   delta_training_linear_warmup_decay:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup.
-    upstream_delta: Not applicable; this is a repo-local exact-prior training recipe change.
-    expected_effect: Reduced early instability versus constant LR or plain linear decay, with uncertain final quality impact.
+    description: Keep the anchor model, data, and preprocessing surfaces but use single-stage
+      linear decay with a short warmup.
+    upstream_delta: Not applicable; this is a repo-local exact-prior training recipe
+      change.
+    expected_effect: Reduced early instability versus constant LR or plain linear
+      decay, with uncertain final quality impact.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare against both the constant-LR anchor and the no-warmup linear-decay row.
-        - Treat best/final ROC, post-warmup train-loss variance, and gradient norms as the primary interpretation surface.
+      - Compare against both the constant-LR anchor and the no-warmup linear-decay
+        row.
+      - Treat best/final ROC, post-warmup train-loss variance, and gradient norms
+        as the primary interpretation surface.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5166,32 +5857,38 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the no-warmup linear-decay row so warmup is isolated from pure decay.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the no-warmup linear-decay row so warmup is isolated
+      from pure decay.
     applicability_guards: []
-
   delta_training_linear_warmup_decay_lr3e3:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but lower the peak LR while keeping the carried warmup-decay floor fixed.
-    upstream_delta: Not applicable; this is a repo-local LR-shape follow-up on the settled warmup-decay surface.
-    expected_effect: Lower peak LR may reduce clipping and improve final retention if the carried `0.004` ceiling is still too aggressive on the inherited harder surface.
+    description: Keep the anchor model, data, and preprocessing surfaces but lower
+      the peak LR while keeping the carried warmup-decay floor fixed.
+    upstream_delta: Not applicable; this is a repo-local LR-shape follow-up on the
+      settled warmup-decay surface.
+    expected_effect: Lower peak LR may reduce clipping and improve final retention
+      if the carried `0.004` ceiling is still too aggressive on the inherited harder
+      surface.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
+    - schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the carried warmup-decay baseline while keeping optimizer family, data surface, and runtime fixed.
-        - Prefer it only if final quality improves without relying on guardrail metrics alone.
+      - Compare locally against the carried warmup-decay baseline while keeping optimizer
+        family, data surface, and runtime fixed.
+      - Prefer it only if final quality improves without relying on guardrail metrics
+        alone.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5210,32 +5907,36 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.003
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the carried warmup-decay baseline as the lower-ceiling LR probe.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.003
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the carried warmup-decay baseline as the lower-ceiling
+      LR probe.
     applicability_guards: []
-
   delta_training_linear_warmup_decay_minlr1e4:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but lower the LR floor while keeping the carried peak LR and warmup fixed.
-    upstream_delta: Not applicable; this is a repo-local LR-floor follow-up on the settled warmup-decay surface.
-    expected_effect: A lower floor may preserve later plasticity if the carried `0.0004` floor is decaying too conservatively on the inherited harder surface.
+    description: Keep the anchor model, data, and preprocessing surfaces but lower
+      the LR floor while keeping the carried peak LR and warmup fixed.
+    upstream_delta: Not applicable; this is a repo-local LR-floor follow-up on the
+      settled warmup-decay surface.
+    expected_effect: A lower floor may preserve later plasticity if the carried `0.0004`
+      floor is decaying too conservatively on the inherited harder surface.
     adequacy_knobs:
-      - optimizer.min_lr
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the carried warmup-decay baseline while keeping the peak LR, warmup, and optimizer family fixed.
-        - Prefer it only if final quality improves without a material stability regression.
+      - Compare locally against the carried warmup-decay baseline while keeping the
+        peak LR, warmup, and optimizer family fixed.
+      - Prefer it only if final quality improves without a material stability regression.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5254,32 +5955,36 @@ deltas:
             min_lr: 0.0001
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the carried warmup-decay baseline as the lower-floor LR probe.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the carried warmup-decay baseline as the lower-floor
+      LR probe.
     applicability_guards: []
-
   delta_training_linear_warmup_decay_warm10:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but lengthen warmup on the carried warmup-decay schedule.
-    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on the settled warmup-decay surface.
-    expected_effect: Longer warmup may reduce early clipping further, though it risks underusing the fixed-step budget.
+    description: Keep the anchor model, data, and preprocessing surfaces but lengthen
+      warmup on the carried warmup-decay schedule.
+    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on
+      the settled warmup-decay surface.
+    expected_effect: Longer warmup may reduce early clipping further, though it risks
+      underusing the fixed-step budget.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the carried warmup-decay baseline while keeping peak LR, floor, and optimizer family fixed.
-        - Prefer it only if benchmark quality and early stability improve together.
+      - Compare locally against the carried warmup-decay baseline while keeping peak
+        LR, floor, and optimizer family fixed.
+      - Prefer it only if benchmark quality and early stability improve together.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5298,32 +6003,36 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run after the carried warmup-decay baseline as the longer-warmup probe.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run after the carried warmup-decay baseline as the longer-warmup
+      probe.
     applicability_guards: []
-
   delta_training_linear_warmup_decay_warm20:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the carried short-run warmup-decay surface but lengthen warmup materially.
-    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on the corrected short-run warmup-decay surface.
-    expected_effect: A `0.20` warmup may reduce early clipping further on the corrected `400`-step runtime, though it risks underusing the fixed-step budget.
+    description: Keep the carried short-run warmup-decay surface but lengthen warmup
+      materially.
+    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on
+      the corrected short-run warmup-decay surface.
+    expected_effect: A `0.20` warmup may reduce early clipping further on the corrected
+      `400`-step runtime, though it risks underusing the fixed-step budget.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the corrected short-run warmup-decay baseline while keeping peak LR, floor, and optimizer family fixed.
-        - Prefer it only if benchmark quality and early stability improve together.
+      - Compare locally against the corrected short-run warmup-decay baseline while
+        keeping peak LR, floor, and optimizer family fixed.
+      - Prefer it only if benchmark quality and early stability improve together.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5342,34 +6051,39 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.20
-    default_next_action: Run after the corrected short-run baseline as the materially longer-warmup probe.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.2
+    default_next_action: Run after the corrected short-run baseline as the materially
+      longer-warmup probe.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but use single-stage linear decay with a short warmup.
-    upstream_delta: Not applicable; this is a repo-local corrected short-run warmup-decay baseline on the inherited harder surface.
-    expected_effect: Reduced early instability versus constant LR or plain linear decay, with uncertain final quality impact.
+    description: Keep the anchor model, data, and preprocessing surfaces but use single-stage
+      linear decay with a short warmup.
+    upstream_delta: Not applicable; this is a repo-local corrected short-run warmup-decay
+      baseline on the inherited harder surface.
+    expected_effect: Reduced early instability versus constant LR or plain linear
+      decay, with uncertain final quality impact.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Use this as the explicit local reference for TF-RD-018 warmup and LR-shape follow-ups while still comparing against the locked anchor.
-        - Rank final log loss first, final Brier score second, and final ROC AUC third; treat drift and clipped-step behavior as guardrails.
+      - Use this as the explicit local reference for TF-RD-018 warmup and LR-shape
+        follow-ups while still comparing against the locked anchor.
+      - Rank final log loss first, final Brier score second, and final ROC AUC third;
+        treat drift and clipped-step behavior as guardrails.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5388,32 +6102,37 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run first as the corrected short-run LR/warmup baseline replay, then compare the four bounded variants against it and the locked anchor.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run first as the corrected short-run LR/warmup baseline replay,
+      then compare the four bounded variants against it and the locked anchor.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay_warm0:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the carried short-run warmup-decay surface but remove warmup entirely.
-    upstream_delta: Not applicable; this is a repo-local warmup-zero follow-up on the corrected short-run warmup-decay surface.
-    expected_effect: No warmup may preserve quality if the corrected `400`-step runtime is already stable enough without early protection.
+    description: Keep the carried short-run warmup-decay surface but remove warmup
+      entirely.
+    upstream_delta: Not applicable; this is a repo-local warmup-zero follow-up on
+      the corrected short-run warmup-decay surface.
+    expected_effect: No warmup may preserve quality if the corrected `400`-step runtime
+      is already stable enough without early protection.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the corrected short-run warmup-decay baseline while keeping LR ceiling, LR floor, optimizer family, and runtime fixed.
-        - Prefer it only if benchmark quality stays competitive without reopening obvious early instability.
+      - Compare locally against the corrected short-run warmup-decay baseline while
+        keeping LR ceiling, LR floor, optimizer family, and runtime fixed.
+      - Prefer it only if benchmark quality stays competitive without reopening obvious
+        early instability.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5432,32 +6151,38 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.0
-    default_next_action: Run after the corrected short-run baseline as the warmup-zero discriminator.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.0
+    default_next_action: Run after the corrected short-run baseline as the warmup-zero
+      discriminator.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay_lr3e3:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but lower the peak LR while keeping the carried warmup-decay floor fixed.
-    upstream_delta: Not applicable; this is a repo-local LR-shape follow-up on the settled warmup-decay surface.
-    expected_effect: Lower peak LR may reduce clipping and improve final retention if the carried `0.004` ceiling is still too aggressive on the inherited harder surface.
+    description: Keep the anchor model, data, and preprocessing surfaces but lower
+      the peak LR while keeping the carried warmup-decay floor fixed.
+    upstream_delta: Not applicable; this is a repo-local LR-shape follow-up on the
+      settled warmup-decay surface.
+    expected_effect: Lower peak LR may reduce clipping and improve final retention
+      if the carried `0.004` ceiling is still too aggressive on the inherited harder
+      surface.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
+    - schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the carried warmup-decay baseline while keeping optimizer family, data surface, and runtime fixed.
-        - Prefer it only if final quality improves without relying on guardrail metrics alone.
+      - Compare locally against the carried warmup-decay baseline while keeping optimizer
+        family, data surface, and runtime fixed.
+      - Prefer it only if final quality improves without relying on guardrail metrics
+        alone.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5476,32 +6201,36 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.003
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the carried warmup-decay baseline as the lower-ceiling LR probe.
+            - name: stage1
+              steps: 400
+              lr_max: 0.003
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the carried warmup-decay baseline as the lower-ceiling
+      LR probe.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay_minlr1e4:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces but lower the LR floor while keeping the carried peak LR and warmup fixed.
-    upstream_delta: Not applicable; this is a repo-local LR-floor follow-up on the settled warmup-decay surface.
-    expected_effect: A lower floor may preserve later plasticity if the carried `0.0004` floor is decaying too conservatively on the inherited harder surface.
+    description: Keep the anchor model, data, and preprocessing surfaces but lower
+      the LR floor while keeping the carried peak LR and warmup fixed.
+    upstream_delta: Not applicable; this is a repo-local LR-floor follow-up on the
+      settled warmup-decay surface.
+    expected_effect: A lower floor may preserve later plasticity if the carried `0.0004`
+      floor is decaying too conservatively on the inherited harder surface.
     adequacy_knobs:
-      - optimizer.min_lr
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the carried warmup-decay baseline while keeping the peak LR, warmup, and optimizer family fixed.
-        - Prefer it only if final quality improves without a material stability regression.
+      - Compare locally against the carried warmup-decay baseline while keeping the
+        peak LR, warmup, and optimizer family fixed.
+      - Prefer it only if final quality improves without a material stability regression.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5520,32 +6249,36 @@ deltas:
             min_lr: 0.0001
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the carried warmup-decay baseline as the lower-floor LR probe.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the carried warmup-decay baseline as the lower-floor
+      LR probe.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay_warm10:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the carried short-run warmup-decay surface but lengthen warmup modestly.
-    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on the corrected short-run warmup-decay surface.
-    expected_effect: A `0.10` warmup may reduce early clipping further on the corrected `400`-step runtime, though it risks underusing the fixed-step budget.
+    description: Keep the carried short-run warmup-decay surface but lengthen warmup
+      modestly.
+    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on
+      the corrected short-run warmup-decay surface.
+    expected_effect: A `0.10` warmup may reduce early clipping further on the corrected
+      `400`-step runtime, though it risks underusing the fixed-step budget.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the corrected short-run warmup-decay baseline while keeping peak LR, floor, and optimizer family fixed.
-        - Prefer it only if benchmark quality and early stability improve together.
+      - Compare locally against the corrected short-run warmup-decay baseline while
+        keeping peak LR, floor, and optimizer family fixed.
+      - Prefer it only if benchmark quality and early stability improve together.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5564,32 +6297,36 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run after the corrected short-run baseline as the modestly longer-warmup probe.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run after the corrected short-run baseline as the modestly
+      longer-warmup probe.
     applicability_guards: []
-
   delta_training_tf_rd_018_linear_warmup_decay_warm20:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Keep the carried short-run warmup-decay surface but lengthen warmup materially.
-    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on the corrected short-run warmup-decay surface.
-    expected_effect: A `0.20` warmup may reduce early clipping further on the corrected `400`-step runtime, though it risks underusing the fixed-step budget.
+    description: Keep the carried short-run warmup-decay surface but lengthen warmup
+      materially.
+    upstream_delta: Not applicable; this is a repo-local warmup-length follow-up on
+      the corrected short-run warmup-decay surface.
+    expected_effect: A `0.20` warmup may reduce early clipping further on the corrected
+      `400`-step runtime, though it risks underusing the fixed-step budget.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare locally against the corrected short-run warmup-decay baseline while keeping peak LR, floor, and optimizer family fixed.
-        - Prefer it only if benchmark quality and early stability improve together.
+      - Compare locally against the corrected short-run warmup-decay baseline while
+        keeping peak LR, floor, and optimizer family fixed.
+      - Prefer it only if benchmark quality and early stability improve together.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5608,35 +6345,40 @@ deltas:
             min_lr: 0.0004
           schedule:
             stages:
-              - name: stage1
-                steps: 400
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.20
-    default_next_action: Run after the corrected short-run baseline as the materially longer-warmup probe.
+            - name: stage1
+              steps: 400
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.2
+    default_next_action: Run after the corrected short-run baseline as the materially
+      longer-warmup probe.
     applicability_guards: []
-
   delta_training_adamw:
     dimension_family: training
     family: optimizer
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces fixed but replace schedulefree AdamW with plain AdamW on the same linear-warmup-decay schedule.
-    upstream_delta: Not applicable; this is a repo-local optimizer-family comparison on the settled row-first anchor.
-    expected_effect: AdamW may provide a cleaner or more stable optimization path if schedulefree dynamics are masking the anchor's real quality ceiling.
+    description: Keep the anchor model, data, and preprocessing surfaces fixed but
+      replace schedulefree AdamW with plain AdamW on the same linear-warmup-decay
+      schedule.
+    upstream_delta: Not applicable; this is a repo-local optimizer-family comparison
+      on the settled row-first anchor.
+    expected_effect: AdamW may provide a cleaner or more stable optimization path
+      if schedulefree dynamics are masking the anchor's real quality ceiling.
     adequacy_knobs:
-      - optimizer.name
-      - optimizer.weight_decay
-      - optimizer.betas
-      - optimizer.min_lr
+    - optimizer.name
+    - optimizer.weight_decay
+    - optimizer.betas
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as a bounded optimizer-family comparison on the settled warmup-decay surface.
-        - Compare final log loss first, then supporting calibration and stability diagnostics.
+      - Treat this as a bounded optimizer-family comparison on the settled warmup-decay
+        surface.
+      - Compare final log loss first, then supporting calibration and stability diagnostics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5657,8 +6399,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -5668,36 +6410,40 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the schedule-family comparison so optimizer-family effects are read on the settled warmup-decay surface.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the schedule-family comparison so optimizer-family
+      effects are read on the settled warmup-decay surface.
     applicability_guards: []
-
   delta_training_muon:
     dimension_family: training
     family: optimizer
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces fixed but replace schedulefree AdamW with Muon on the same linear-warmup-decay schedule.
-    upstream_delta: Not applicable; this is a repo-local optimizer-family comparison on the settled row-first anchor.
-    expected_effect: Muon may improve convergence or late retention on the settled row-first surface, but any read must stay separate from model-surface expansion.
+    description: Keep the anchor model, data, and preprocessing surfaces fixed but
+      replace schedulefree AdamW with Muon on the same linear-warmup-decay schedule.
+    upstream_delta: Not applicable; this is a repo-local optimizer-family comparison
+      on the settled row-first anchor.
+    expected_effect: Muon may improve convergence or late retention on the settled
+      row-first surface, but any read must stay separate from model-surface expansion.
     adequacy_knobs:
-      - optimizer.name
-      - optimizer.weight_decay
-      - optimizer.betas
-      - optimizer.min_lr
-      - optimizer.muon_per_parameter_lr
+    - optimizer.name
+    - optimizer.weight_decay
+    - optimizer.betas
+    - optimizer.min_lr
+    - optimizer.muon_per_parameter_lr
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as a bounded optimizer-family comparison only.
-        - If weak, defer rather than reject until the optimizer-default surface itself has had one clean read on the locked anchor.
+      - Treat this as a bounded optimizer-family comparison only.
+      - If weak, defer rather than reject until the optimizer-default surface itself
+        has had one clean read on the locked anchor.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5718,9 +6464,9 @@ deltas:
             require_requested: true
             weight_decay: 0.01
             betas:
-              - 0.9
-              - 0.95
-            min_lr: 1.0e-6
+            - 0.9
+            - 0.95
+            min_lr: 1.0e-06
             muon_per_parameter_lr: true
             muon_lr_scale_base: 0.2
             muon_partition_non2d: true
@@ -5731,36 +6477,42 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the AdamW comparator so the two non-schedulefree families can be read against the same settled schedule.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the AdamW comparator so the two non-schedulefree
+      families can be read against the same settled schedule.
     applicability_guards: []
-
   delta_training_batch64_sqrt:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces fixed but raise prior-dump batch size to 64 with sqrt LR scaling on the same warmup-decay family.
-    upstream_delta: Not applicable; this is a repo-local batch-size and LR-coupling comparison on the settled row-first anchor.
-    expected_effect: A larger scaled batch may improve stability or runtime efficiency if the settled anchor is not already on its preferred batch surface.
+    description: Keep the anchor model, data, and preprocessing surfaces fixed but
+      raise prior-dump batch size to 64 with sqrt LR scaling on the same warmup-decay
+      family.
+    upstream_delta: Not applicable; this is a repo-local batch-size and LR-coupling
+      comparison on the settled row-first anchor.
+    expected_effect: A larger scaled batch may improve stability or runtime efficiency
+      if the settled anchor is not already on its preferred batch surface.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - training.prior_dump_batch_reference_size
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - training.prior_dump_batch_reference_size
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Keep the model, bundle, and optimizer family fixed so the row isolates batch-size coupling only.
-        - Compare final log loss first, then clipped-step fraction and training-time change.
+      - Keep the model, bundle, and optimizer family fixed so the row isolates batch-size
+        coupling only.
+      - Compare final log loss first, then clipped-step fraction and training-time
+        change.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5784,8 +6536,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -5795,35 +6547,41 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the schedule and optimizer-family rows so batch-size coupling is read on the preferred training family.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the schedule and optimizer-family rows so batch-size
+      coupling is read on the preferred training family.
     applicability_guards: []
-
   delta_training_task_batch4:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to four at a time on the TF-RD-013 medium corpus surface.
-    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy rung on the settled row-first anchor.
-    expected_effect: A four-task manifest batch should improve dataset-throughput efficiency with lower packing and memory risk than the larger rungs.
+    description: Keep the settled row-first model, preprocessing, and warmup-decay
+      family fixed, but batch exact-shape manifest tasks up to four at a time on the
+      TF-RD-013 medium corpus surface.
+    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy
+      rung on the settled row-first anchor.
+    expected_effect: A four-task manifest batch should improve dataset-throughput
+      efficiency with lower packing and memory risk than the larger rungs.
     adequacy_knobs:
-      - training.task_batch_size
-      - task_batch_singleton_fallback_fraction
-      - batched_update_count
-      - train_elapsed_seconds
+    - training.task_batch_size
+    - task_batch_singleton_fallback_fraction
+    - batched_update_count
+    - train_elapsed_seconds
     parameter_adequacy_policy:
       default_plan:
-        - Keep the model, data surface, preprocessing, optimizer family, schedule shape, and step budget fixed so this row isolates manifest task batching only.
-        - Compare wall-clock, singleton-fallback fraction, and the primary final metrics jointly before preferring a larger rung.
+      - Keep the model, data surface, preprocessing, optimizer family, schedule shape,
+        and step budget fixed so this row isolates manifest task batching only.
+      - Compare wall-clock, singleton-fallback fraction, and the primary final metrics
+        jointly before preferring a larger rung.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5850,8 +6608,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -5864,35 +6622,41 @@ deltas:
             val_batches: 0
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run first as the opening manifest task-batch rung on the settled TF-RD-013 medium surface.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run first as the opening manifest task-batch rung on the
+      settled TF-RD-013 medium surface.
     applicability_guards: []
-
   delta_training_task_batch8:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to eight at a time on the TF-RD-013 medium corpus surface.
-    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy rung on the settled row-first anchor.
-    expected_effect: An eight-task manifest batch may improve wall-clock efficiency further if the medium corpus still spends too much time on singleton task dispatch.
+    description: Keep the settled row-first model, preprocessing, and warmup-decay
+      family fixed, but batch exact-shape manifest tasks up to eight at a time on
+      the TF-RD-013 medium corpus surface.
+    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy
+      rung on the settled row-first anchor.
+    expected_effect: An eight-task manifest batch may improve wall-clock efficiency
+      further if the medium corpus still spends too much time on singleton task dispatch.
     adequacy_knobs:
-      - training.task_batch_size
-      - task_batch_singleton_fallback_fraction
-      - batched_update_count
-      - train_elapsed_seconds
+    - training.task_batch_size
+    - task_batch_singleton_fallback_fraction
+    - batched_update_count
+    - train_elapsed_seconds
     parameter_adequacy_policy:
       default_plan:
-        - Keep the model, data surface, preprocessing, optimizer family, schedule shape, and step budget fixed so this row isolates manifest task batching only.
-        - Compare wall-clock, singleton-fallback fraction, and the primary final metrics jointly before unblocking larger rungs.
+      - Keep the model, data surface, preprocessing, optimizer family, schedule shape,
+        and step budget fixed so this row isolates manifest task batching only.
+      - Compare wall-clock, singleton-fallback fraction, and the primary final metrics
+        jointly before unblocking larger rungs.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -5919,8 +6683,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -5933,35 +6697,42 @@ deltas:
             val_batches: 0
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run second as the highest unconditional manifest task-batch rung on the settled TF-RD-013 medium surface.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run second as the highest unconditional manifest task-batch
+      rung on the settled TF-RD-013 medium surface.
     applicability_guards: []
-
   delta_training_task_batch16:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to sixteen at a time on the TF-RD-013 medium corpus surface.
-    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy rung on the settled row-first anchor.
-    expected_effect: A sixteen-task manifest batch may improve throughput further, but it carries materially higher singleton-fallback and memory-pressure risk than the opening rungs.
+    description: Keep the settled row-first model, preprocessing, and warmup-decay
+      family fixed, but batch exact-shape manifest tasks up to sixteen at a time on
+      the TF-RD-013 medium corpus surface.
+    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy
+      rung on the settled row-first anchor.
+    expected_effect: A sixteen-task manifest batch may improve throughput further,
+      but it carries materially higher singleton-fallback and memory-pressure risk
+      than the opening rungs.
     adequacy_knobs:
-      - training.task_batch_size
-      - task_batch_singleton_fallback_fraction
-      - batched_update_count
-      - train_elapsed_seconds
+    - training.task_batch_size
+    - task_batch_singleton_fallback_fraction
+    - batched_update_count
+    - train_elapsed_seconds
     parameter_adequacy_policy:
       default_plan:
-        - Keep the model, data surface, preprocessing, optimizer family, schedule shape, and step budget fixed so this row isolates manifest task batching only.
-        - Unblock this rung only if the `task_batch_size=8` row finishes in <=900s, avoids OOM, and keeps singleton fallback at <=10 percent of updates.
+      - Keep the model, data surface, preprocessing, optimizer family, schedule shape,
+        and step budget fixed so this row isolates manifest task batching only.
+      - Unblock this rung only if the `task_batch_size=8` row finishes in <=900s,
+        avoids OOM, and keeps singleton fallback at <=10 percent of updates.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked
     default_initial_interpretation_status: blocked
@@ -5988,8 +6759,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -6002,35 +6773,42 @@ deltas:
             val_batches: 0
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Leave blocked until the `task_batch_size=8` rung clears the runtime, OOM, and singleton-fallback gate.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Leave blocked until the `task_batch_size=8` rung clears the
+      runtime, OOM, and singleton-fallback gate.
     applicability_guards: []
-
   delta_training_task_batch32:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Keep the settled row-first model, preprocessing, and warmup-decay family fixed, but batch exact-shape manifest tasks up to thirty-two at a time on the TF-RD-013 medium corpus surface.
-    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy rung on the settled row-first anchor.
-    expected_effect: A thirty-two-task manifest batch would maximize batching pressure on this medium corpus, but it is most likely to trip OOM or singleton-fallback gates before quality can be read cleanly.
+    description: Keep the settled row-first model, preprocessing, and warmup-decay
+      family fixed, but batch exact-shape manifest tasks up to thirty-two at a time
+      on the TF-RD-013 medium corpus surface.
+    upstream_delta: Not applicable; this is a repo-local manifest task-batching adequacy
+      rung on the settled row-first anchor.
+    expected_effect: A thirty-two-task manifest batch would maximize batching pressure
+      on this medium corpus, but it is most likely to trip OOM or singleton-fallback
+      gates before quality can be read cleanly.
     adequacy_knobs:
-      - training.task_batch_size
-      - task_batch_singleton_fallback_fraction
-      - batched_update_count
-      - train_elapsed_seconds
+    - training.task_batch_size
+    - task_batch_singleton_fallback_fraction
+    - batched_update_count
+    - train_elapsed_seconds
     parameter_adequacy_policy:
       default_plan:
-        - Keep the model, data surface, preprocessing, optimizer family, schedule shape, and step budget fixed so this row isolates manifest task batching only.
-        - Unblock this rung only if the `task_batch_size=16` row finishes in <=900s, avoids OOM, and keeps singleton fallback at <=10 percent of updates.
+      - Keep the model, data surface, preprocessing, optimizer family, schedule shape,
+        and step budget fixed so this row isolates manifest task batching only.
+      - Unblock this rung only if the `task_batch_size=16` row finishes in <=900s,
+        avoids OOM, and keeps singleton fallback at <=10 percent of updates.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked
     default_initial_interpretation_status: blocked
@@ -6057,8 +6835,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -6071,32 +6849,36 @@ deltas:
             val_batches: 0
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Leave blocked until the `task_batch_size=16` rung clears the runtime, OOM, and singleton-fallback gate.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Leave blocked until the `task_batch_size=16` rung clears
+      the runtime, OOM, and singleton-fallback gate.
     applicability_guards: []
-
   delta_training_clip05:
     dimension_family: training
     family: regularization
     binary_applicable: true
-    description: Keep the anchor model, data, and preprocessing surfaces fixed but tighten gradient clipping from 1.0 to 0.5 on the same warmup-decay family.
-    upstream_delta: Not applicable; this is a repo-local clip-policy adequacy probe on the settled row-first anchor.
-    expected_effect: A tighter clip may reduce rare update spikes, though it can also overconstrain useful row-first updates.
+    description: Keep the anchor model, data, and preprocessing surfaces fixed but
+      tighten gradient clipping from 1.0 to 0.5 on the same warmup-decay family.
+    upstream_delta: Not applicable; this is a repo-local clip-policy adequacy probe
+      on the settled row-first anchor.
+    expected_effect: A tighter clip may reduce rare update spikes, though it can also
+      overconstrain useful row-first updates.
     adequacy_knobs:
-      - runtime.grad_clip
+    - runtime.grad_clip
     parameter_adequacy_policy:
       default_plan:
-        - Read this row only as a clip-policy probe on the settled training family.
-        - Prefer it only if quality remains competitive while clipping or gradient spikes improve materially.
+      - Read this row only as a clip-policy probe on the settled training family.
+      - Prefer it only if quality remains competitive while clipping or gradient spikes
+        improve materially.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6117,8 +6899,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -6129,33 +6911,38 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the preferred schedule and optimizer rows so clip-policy changes are not read against the wrong baseline family.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the preferred schedule and optimizer rows so clip-policy
+      changes are not read against the wrong baseline family.
     applicability_guards: []
-
   delta_training_budget_5k:
     dimension_family: training
     family: budget
     binary_applicable: true
-    description: Keep the settled row-first anchor family fixed but double the training budget to 5000 steps under the same warmup-decay schedule.
-    upstream_delta: Not applicable; this is a repo-local training-budget adequacy probe on the settled row-first anchor.
-    expected_effect: If the anchor is still compute-limited after the earlier schedule, optimizer, batch, and clip reads, a 5000-step budget should improve the primary final metric without changing the mechanism family.
+    description: Keep the settled row-first anchor family fixed but double the training
+      budget to 5000 steps under the same warmup-decay schedule.
+    upstream_delta: Not applicable; this is a repo-local training-budget adequacy
+      probe on the settled row-first anchor.
+    expected_effect: If the anchor is still compute-limited after the earlier schedule,
+      optimizer, batch, and clip reads, a 5000-step budget should improve the primary
+      final metric without changing the mechanism family.
     adequacy_knobs:
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Run only after the shorter-budget schedule and optimizer family reads are understood well enough to justify more compute on one fixed recipe.
-        - Interpret any gain as budget adequacy evidence only, not as architecture evidence.
+      - Run only after the shorter-budget schedule and optimizer family reads are
+        understood well enough to justify more compute on one fixed recipe.
+      - Interpret any gain as budget adequacy evidence only, not as architecture evidence.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6176,8 +6963,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -6187,34 +6974,37 @@ deltas:
             trace_activations: false
           schedule:
             stages:
-              - name: stage1
-                steps: 5000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the shorter-budget adequacy rows pick one preferred 2500-step recipe worth extending.
+            - name: stage1
+              steps: 5000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the shorter-budget adequacy rows pick one preferred
+      2500-step recipe worth extending.
     applicability_guards: []
-
   dpnb_baseline_cosine_warmup_2500:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Re-anchor stability_followup on the `delta_prenorm_block` bridge surface with the 2500-step cosine-warmup baseline.
+    description: Re-anchor stability_followup on the `delta_prenorm_block` bridge
+      surface with the 2500-step cosine-warmup baseline.
     upstream_delta: Not applicable; this is a repo-local exact-prior bridge baseline.
-    expected_effect: Establish the baseline comparator for all later prenorm calibration rows.
+    expected_effect: Establish the baseline comparator for all later prenorm calibration
+      rows.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - schedule.stages[0].warmup_ratio
-      - runtime.grad_clip
+    - schedule.stages[0].lr_max
+    - schedule.stages[0].warmup_ratio
+    - runtime.grad_clip
     parameter_adequacy_policy:
       default_plan:
-        - Treat this row as the calibration baseline for the bridge surface.
-        - Report benchmark ROC, drift, clipped-step fraction, module balance, and activation windows.
+      - Treat this row as the calibration baseline for the bridge surface.
+      - Report benchmark ROC, drift, clipped-step fraction, module balance, and activation
+        windows.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6240,14 +7030,14 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: cosine
-                warmup_ratio: 0.05
-    default_next_action: Run the bridge baseline first and compare all later rows against it.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: cosine
+              warmup_ratio: 0.05
+    default_next_action: Run the bridge baseline first and compare all later rows
+      against it.
     applicability_guards: []
-
   dpnb_linear_decay_lr4e3:
     dimension_family: training
     family: schedule
@@ -6256,18 +7046,19 @@ deltas:
     upstream_delta: Not applicable; this is a repo-local exact-prior schedule change.
     expected_effect: Potentially lower drift, with risk of reopening early instability.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the bridge baseline and the warmup-decay row.
-        - Use benchmark ROC as primary and clipped-step/module-balance telemetry as diagnostics.
+      - Compare against the bridge baseline and the warmup-decay row.
+      - Use benchmark ROC as primary and clipped-step/module-balance telemetry as
+        diagnostics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6295,34 +7086,34 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.0
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.0
     default_next_action: Run after the bridge baseline to isolate decay without warmup.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm5:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Canonical linear warmup decay row for the `delta_prenorm_block` bridge surface.
+    description: Canonical linear warmup decay row for the `delta_prenorm_block` bridge
+      surface.
     upstream_delta: Not applicable; this is a repo-local exact-prior schedule change.
     expected_effect: Best chance to retain warmup stability while reducing drift.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Treat this row as the center of the local calibration neighborhood.
-        - Compare rows 4-10 directly against this row before promoting any variant.
+      - Treat this row as the center of the local calibration neighborhood.
+      - Compare rows 4-10 directly against this row before promoting any variant.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6350,33 +7141,34 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Use as the center row for LR, warmup, clip, weight-decay, and optimizer calibration.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Use as the center row for LR, warmup, clip, weight-decay,
+      and optimizer calibration.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr3e3_warm5:
     dimension_family: training
     family: schedule
     binary_applicable: true
     description: Low-LR neighbor of the canonical prenorm warmup-decay row.
     upstream_delta: Not applicable; repo-local exact-prior LR calibration.
-    expected_effect: Lower peak LR may reduce clipping and improve final retention if 0.004 is still too aggressive.
+    expected_effect: Lower peak LR may reduce clipping and improve final retention
+      if 0.004 is still too aggressive.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare only locally against the canonical warmup-decay row.
-        - Prefer it only if benchmark quality is competitive and telemetry is cleaner.
+      - Compare only locally against the canonical warmup-decay row.
+      - Prefer it only if benchmark quality is competitive and telemetry is cleaner.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6404,33 +7196,33 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.003
-                lr_schedule: linear
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.003
+              lr_schedule: linear
+              warmup_ratio: 0.05
     default_next_action: Run after the canonical warmup-decay row as the low-LR probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr5e3_warm5:
     dimension_family: training
     family: schedule
     binary_applicable: true
     description: High-LR neighbor of the canonical prenorm warmup-decay row.
     upstream_delta: Not applicable; repo-local exact-prior LR calibration.
-    expected_effect: Higher peak LR may recover quality if the bridge surface is under-driven, but can also increase clipping.
+    expected_effect: Higher peak LR may recover quality if the bridge surface is under-driven,
+      but can also increase clipping.
     adequacy_knobs:
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare only locally against the canonical warmup-decay row.
-        - Prefer it only if the quality win is not just a clipped-step regression.
+      - Compare only locally against the canonical warmup-decay row.
+      - Prefer it only if the quality win is not just a clipped-step regression.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6458,14 +7250,13 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.005
-                lr_schedule: linear
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.005
+              lr_schedule: linear
+              warmup_ratio: 0.05
     default_next_action: Run after the canonical warmup-decay row as the high-LR probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm2:
     dimension_family: training
     family: schedule
@@ -6474,16 +7265,16 @@ deltas:
     upstream_delta: Not applicable; repo-local exact-prior warmup calibration.
     expected_effect: Shorter warmup may preserve quality while trimming excess protection.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare rows 6, 3, and 7 jointly as the warmup bracket.
-        - Prefer the shortest warmup that does not materially reopen early instability.
+      - Compare rows 6, 3, and 7 jointly as the warmup bracket.
+      - Prefer the shortest warmup that does not materially reopen early instability.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6511,32 +7302,33 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.02
-    default_next_action: Run after the canonical warmup-decay row as the short-warmup probe.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.02
+    default_next_action: Run after the canonical warmup-decay row as the short-warmup
+      probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm10:
     dimension_family: training
     family: schedule
     binary_applicable: true
     description: Long-warmup neighbor of the canonical prenorm warmup-decay row.
     upstream_delta: Not applicable; repo-local exact-prior warmup calibration.
-    expected_effect: Longer warmup may reduce clipping further, but can underuse the fixed 2500-step budget.
+    expected_effect: Longer warmup may reduce clipping further, but can underuse the
+      fixed 2500-step budget.
     adequacy_knobs:
-      - schedule.stages[0].warmup_ratio
+    - schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare rows 6, 3, and 7 jointly as the warmup bracket.
-        - Prefer this row only if it wins on benchmark quality as well as early stability.
+      - Compare rows 6, 3, and 7 jointly as the warmup bracket.
+      - Prefer this row only if it wins on benchmark quality as well as early stability.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6564,32 +7356,34 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run after the canonical warmup-decay row as the long-warmup probe.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run after the canonical warmup-decay row as the long-warmup
+      probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm5_clip05:
     dimension_family: training
     family: regularization
     binary_applicable: true
     description: Tight clip probe around the canonical prenorm warmup-decay row.
     upstream_delta: Not applicable; repo-local exact-prior clip calibration.
-    expected_effect: Lower clip may reduce residual spikes, though it can also overconstrain useful updates.
+    expected_effect: Lower clip may reduce residual spikes, though it can also overconstrain
+      useful updates.
     adequacy_knobs:
-      - runtime.grad_clip
+    - runtime.grad_clip
     parameter_adequacy_policy:
       default_plan:
-        - Interpret only locally against the canonical warmup-decay row.
-        - Prefer it only if benchmark quality remains competitive and clipping drops materially.
+      - Interpret only locally against the canonical warmup-decay row.
+      - Prefer it only if benchmark quality remains competitive and clipping drops
+        materially.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6617,32 +7411,35 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the canonical warmup-decay row as the tight-clip probe.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the canonical warmup-decay row as the tight-clip
+      probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm5_wd5e4:
     dimension_family: training
     family: regularization
     binary_applicable: true
-    description: Small weight-decay probe around the canonical prenorm warmup-decay row.
+    description: Small weight-decay probe around the canonical prenorm warmup-decay
+      row.
     upstream_delta: Not applicable; repo-local exact-prior regularization calibration.
-    expected_effect: Mild damping may improve late retention or activation scale without harming quality.
+    expected_effect: Mild damping may improve late retention or activation scale without
+      harming quality.
     adequacy_knobs:
-      - optimizer.weight_decay
+    - optimizer.weight_decay
     parameter_adequacy_policy:
       default_plan:
-        - Interpret only locally against the canonical warmup-decay row.
-        - Prefer it only if it helps benchmark quality or drift without clear optimization tax.
+      - Interpret only locally against the canonical warmup-decay row.
+      - Prefer it only if it helps benchmark quality or drift without clear optimization
+        tax.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6671,32 +7468,33 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the canonical warmup-decay row as the small-weight-decay probe.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the canonical warmup-decay row as the small-weight-decay
+      probe.
     applicability_guards: []
-
   dpnb_linear_warmup_decay_lr4e3_warm5_adamw:
     dimension_family: training
     family: optimizer
     binary_applicable: true
     description: Plain AdamW comparator for the canonical prenorm warmup-decay row.
     upstream_delta: Not applicable; repo-local optimizer-family comparator.
-    expected_effect: AdamW may offer a cleaner or easier-to-interpret optimization path even if quality is similar.
+    expected_effect: AdamW may offer a cleaner or easier-to-interpret optimization
+      path even if quality is similar.
     adequacy_knobs:
-      - optimizer.name
+    - optimizer.name
     parameter_adequacy_policy:
       default_plan:
-        - Treat as a narrow optimizer-family comparison only.
-        - Prefer it only if it is benchmark-competitive and materially cleaner.
+      - Treat as a narrow optimizer-family comparison only.
+      - Prefer it only if it is benchmark-competitive and materially cleaner.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: prenorm_block
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6726,34 +7524,36 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the canonical warmup-decay row as the optimizer-family comparator.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the canonical warmup-decay row as the optimizer-family
+      comparator.
     applicability_guards: []
-
   dpnb_row_cls_cls2_linear_warmup_decay:
     dimension_family: model
     family: row_pool
     binary_applicable: true
-    description: Bounded row-cls revisit on the calibrated `delta_prenorm_block` bridge surface.
+    description: Bounded row-cls revisit on the calibrated `delta_prenorm_block` bridge
+      surface.
     upstream_delta: Upstream nanoTabPFN does not use row-level CLS pooling.
-    expected_effect: If row-cls still misses badly with the clean cls2 seed, it should remain parked on the bridge surface.
+    expected_effect: If row-cls still misses badly with the clean cls2 seed, it should
+      remain parked on the bridge surface.
     adequacy_knobs:
-      - tfrow_n_heads
-      - tfrow_n_layers
-      - tfrow_cls_tokens
+    - tfrow_n_heads
+    - tfrow_n_layers
+    - tfrow_cls_tokens
     parameter_adequacy_policy:
       default_plan:
-        - Rank benchmark quality first, drift second, and stability telemetry third.
-        - Treat this as a bounded row-pool probe only.
+      - Rank benchmark quality first, drift second, and stability telemetry third.
+      - Treat this as a bounded row-pool probe only.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6786,32 +7586,37 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the training rows so row-pool interpretation is not mixed with unsettled schedule evidence.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the training rows so row-pool interpretation is
+      not mixed with unsettled schedule evidence.
     applicability_guards: []
-
   dpnb_row_cls_cls2_linear_warmup_decay_warm10:
     dimension_family: model
     family: row_pool
     binary_applicable: true
-    description: Promotion-gate row-cls confirmation row on the calibrated `delta_prenorm_block` bridge surface.
+    description: Promotion-gate row-cls confirmation row on the calibrated `delta_prenorm_block`
+      bridge surface.
     upstream_delta: Upstream nanoTabPFN does not use row-level CLS pooling.
-    expected_effect: If row-cls is genuinely reopened on the bridge surface, pairing it with the longer warmup should preserve the row-cls gain while keeping drift bounded.
+    expected_effect: If row-cls is genuinely reopened on the bridge surface, pairing
+      it with the longer warmup should preserve the row-cls gain while keeping drift
+      bounded.
     adequacy_knobs:
-      - warmup_ratio
+    - warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the target-column warm10 winner and the row-cls warm5 row.
-        - Promote only if final ROC stays clearly ahead without reintroducing material drift.
+      - Compare directly against the target-column warm10 winner and the row-cls warm5
+        row.
+      - Promote only if final ROC stays clearly ahead without reintroducing material
+        drift.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: row_cls_pool
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6844,34 +7649,40 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.10
-    default_next_action: Run after the bounded row-cls reopen as the single promotion-gate confirmation row.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.1
+    default_next_action: Run after the bounded row-cls reopen as the single promotion-gate
+      confirmation row.
     applicability_guards: []
-
   delta_training_current_corpus_uncapped:
     dimension_family: training
     family: baseline_replay
     binary_applicable: true
-    description: Run the settled row-first anchor against a TF-RD-008-scale fresh current-corpus manifest from current dagzoo output with the inherited time cap cleared so the 2500-step contract is actually reached.
-    upstream_delta: Not applicable; this is a repo-local TF-RD-008-scale fresh current-corpus control row for TF-RD-013.
-    expected_effect: Establish the canonical TF-RD-008-scale fresh current-corpus control before reading any dagzoo size-rung comparison.
+    description: Run the settled row-first anchor against a TF-RD-008-scale fresh
+      current-corpus manifest from current dagzoo output with the inherited time cap
+      cleared so the 2500-step contract is actually reached.
+    upstream_delta: Not applicable; this is a repo-local TF-RD-008-scale fresh current-corpus
+      control row for TF-RD-013.
+    expected_effect: Establish the canonical TF-RD-008-scale fresh current-corpus
+      control before reading any dagzoo size-rung comparison.
     adequacy_knobs:
-      - training.overrides.runtime.target_train_seconds
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - training.overrides.runtime.target_train_seconds
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the resolved backend is manifest and `target_train_seconds` is null before reading any benchmark output.
-        - Use this row only as the TF-RD-008-scale fresh current-corpus control for the dagzoo size ladder, not as a new training-optimization claim.
+      - Confirm the resolved backend is manifest and `target_train_seconds` is null
+        before reading any benchmark output.
+      - Use this row only as the TF-RD-008-scale fresh current-corpus control for
+        the dagzoo size ladder, not as a new training-optimization claim.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6898,8 +7709,8 @@ deltas:
             require_requested: true
             weight_decay: 0.0
             betas:
-              - 0.9
-              - 0.999
+            - 0.9
+            - 0.999
             min_lr: 0.0004
             muon_per_parameter_lr: false
           runtime:
@@ -6911,34 +7722,40 @@ deltas:
             val_batches: 0
           schedule:
             stages:
-              - name: stage1
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run first after bootstrapping the TF-RD-008-scale fresh current-corpus manifest from current dagzoo output, before comparing any broader dagzoo support surface.
+            - name: stage1
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run first after bootstrapping the TF-RD-008-scale fresh current-corpus
+      manifest from current dagzoo output, before comparing any broader dagzoo support
+      surface.
     applicability_guards: []
-
   delta_data_manifest_root_dagzoo_generated_source:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at the unfiltered dagzoo generated-source manifest with explicit dagzoo generate provenance.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data generation axis.
-    expected_effect: Higher-throughput synthetic training data with no post-generation filtering and explicit provenance.
+    description: Point training at the unfiltered dagzoo generated-source manifest
+      with explicit dagzoo generate provenance.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data generation
+      axis.
+    expected_effect: Higher-throughput synthetic training data with no post-generation
+      filtering and explicit provenance.
     adequacy_knobs:
-      - dagzoo generate command lineage
-      - dataset count and split distribution deltas
-      - filter-status distribution versus the anchor manifest
+    - dagzoo generate command lineage
+    - dataset count and split distribution deltas
+    - filter-status distribution versus the anchor manifest
     parameter_adequacy_policy:
       default_plan:
-        - Compare manifest characteristics before training and record that the initial TF-RD-013 read is intentionally unfiltered.
-        - If weaker, discuss whether corpus breadth or absent filtering is the likely cause.
+      - Compare manifest characteristics before training and record that the initial
+        TF-RD-013 read is intentionally unfiltered.
+      - If weaker, discuss whether corpus breadth or absent filtering is the likely
+        cause.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6956,29 +7773,34 @@ deltas:
             curated_root_lineage: []
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run the current-versus-generated-source comparison before any later filtering-policy follow-up.
+    default_next_action: Run the current-versus-generated-source comparison before
+      any later filtering-policy follow-up.
     applicability_guards: []
-
   delta_data_manifest_root_dagzoo_shape_aware_multi_invocation:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at the multi-invocation, shape-aware dagzoo manifest with explicit per-invocation provenance.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data generation axis.
-    expected_effect: Broader synthetic training coverage across small, anchor-scale, and large-shape dagzoo regimes while keeping provenance reviewable.
+    description: Point training at the multi-invocation, shape-aware dagzoo manifest
+      with explicit per-invocation provenance.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data generation
+      axis.
+    expected_effect: Broader synthetic training coverage across small, anchor-scale,
+      and large-shape dagzoo regimes while keeping provenance reviewable.
     adequacy_knobs:
-      - explicit config ladder coverage across the selected dagzoo shape regimes
-      - per-invocation dataset counts and combined split distribution
-      - manifest-contract deltas versus the anchor and curated comparator
+    - explicit config ladder coverage across the selected dagzoo shape regimes
+    - per-invocation dataset counts and combined split distribution
+    - manifest-contract deltas versus the anchor and curated comparator
     parameter_adequacy_policy:
       default_plan:
-        - Compare manifest characteristics before training and name which config-backed regimes are represented in the combined surface.
-        - If weaker, discuss whether the broader surface still fails to match intended representative data rather than jumping straight to filtering policy.
+      - Compare manifest characteristics before training and name which config-backed
+        regimes are represented in the combined surface.
+      - If weaker, discuss whether the broader surface still fails to match intended
+        representative data rather than jumping straight to filtering policy.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -6997,29 +7819,37 @@ deltas:
             invocations: []
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Materialize the broader multi-invocation dagzoo surface, rerun TF-RD-013, and decide whether dagzoo now changes the representative post-008 training-data read.
+    default_next_action: Materialize the broader multi-invocation dagzoo surface,
+      rerun TF-RD-013, and decide whether dagzoo now changes the representative post-008
+      training-data read.
     applicability_guards: []
-
   delta_data_manifest_root_dagzoo_shape_aware_size_small:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at the 20-dataset shape-aware dagzoo support manifest while keeping the three-regime config mix explicit.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size axis.
-    expected_effect: A 20-dataset synthetic support corpus should let the uncapped 2500-step manifest run revisit each sampled regime many times while staying close to the TF-RD-008-scale control.
+    description: Point training at the 20-dataset shape-aware dagzoo support manifest
+      while keeping the three-regime config mix explicit.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size
+      axis.
+    expected_effect: A 20-dataset synthetic support corpus should let the uncapped
+      2500-step manifest run revisit each sampled regime many times while staying
+      close to the TF-RD-008-scale control.
     adequacy_knobs:
-      - explicit config ladder coverage across the selected dagzoo shape regimes
-      - per-invocation dataset counts and combined split distribution
-      - manifest-contract deltas versus the fresh current-corpus control
+    - explicit config ladder coverage across the selected dagzoo shape regimes
+    - per-invocation dataset counts and combined split distribution
+    - manifest-contract deltas versus the fresh current-corpus control
     parameter_adequacy_policy:
       default_plan:
-        - Compare manifest characteristics against the anchor before training and confirm the intended `small` ladder counts (`4` benchmark, `14` default, `2` large-shape) landed in the merged surface.
-        - If weak, interpret it as size-rung evidence first rather than jumping to filtering or multiclass follow-up.
+      - Compare manifest characteristics against the anchor before training and confirm
+        the intended `small` ladder counts (`4` benchmark, `14` default, `2` large-shape)
+        landed in the merged surface.
+      - If weak, interpret it as size-rung evidence first rather than jumping to filtering
+        or multiclass follow-up.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7033,29 +7863,37 @@ deltas:
           corpus_ref: tf_rd_013_dagzoo_shape_aware_size_small_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run after the TF-RD-008-scale fresh current-corpus control to determine whether the 20-dataset dagzoo support corpus improves the promoted-anchor read.
+    default_next_action: Run after the TF-RD-008-scale fresh current-corpus control
+      to determine whether the 20-dataset dagzoo support corpus improves the promoted-anchor
+      read.
     applicability_guards: []
-
   delta_data_manifest_root_dagzoo_shape_aware_size_medium:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at the 40-dataset shape-aware dagzoo support manifest so TF-RD-013 can test a middle rung between the 20-dataset and 80-dataset ladders.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size axis.
-    expected_effect: A 40-dataset support corpus should preserve broader regime diversity than the smallest rung while still giving the uncapped 2500-step run substantial reuse relative to the prior oversized surface.
+    description: Point training at the 40-dataset shape-aware dagzoo support manifest
+      so TF-RD-013 can test a middle rung between the 20-dataset and 80-dataset ladders.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size
+      axis.
+    expected_effect: A 40-dataset support corpus should preserve broader regime diversity
+      than the smallest rung while still giving the uncapped 2500-step run substantial
+      reuse relative to the prior oversized surface.
     adequacy_knobs:
-      - explicit config ladder coverage across the selected dagzoo shape regimes
-      - per-invocation dataset counts and combined split distribution
-      - manifest-contract deltas versus the fresh current-corpus control
+    - explicit config ladder coverage across the selected dagzoo shape regimes
+    - per-invocation dataset counts and combined split distribution
+    - manifest-contract deltas versus the fresh current-corpus control
     parameter_adequacy_policy:
       default_plan:
-        - Compare manifest characteristics against the anchor before training and confirm the intended `medium` ladder counts (`8` benchmark, `28` default, `4` large-shape) landed in the merged surface.
-        - Use this rung to decide whether any benefit appears only after the smallest corpus is relaxed rather than treating size as a binary keep/defer switch.
+      - Compare manifest characteristics against the anchor before training and confirm
+        the intended `medium` ladder counts (`8` benchmark, `28` default, `4` large-shape)
+        landed in the merged surface.
+      - Use this rung to decide whether any benefit appears only after the smallest
+        corpus is relaxed rather than treating size as a binary keep/defer switch.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7069,29 +7907,36 @@ deltas:
           corpus_ref: tf_rd_013_dagzoo_shape_aware_size_medium_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run after the 20-dataset rung so TF-RD-013 can read whether dagzoo quality is size-sensitive rather than uniformly weak.
+    default_next_action: Run after the 20-dataset rung so TF-RD-013 can read whether
+      dagzoo quality is size-sensitive rather than uniformly weak.
     applicability_guards: []
-
   delta_data_manifest_root_dagzoo_shape_aware_size_large:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at the 80-dataset shape-aware dagzoo support manifest as the upper rung of the TF-RD-013 size ladder.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size axis.
-    expected_effect: The 80-dataset rung should retain the broadest synthetic coverage in this ladder while still staying close enough to the TF-RD-008-scale control for repeated exposure.
+    description: Point training at the 80-dataset shape-aware dagzoo support manifest
+      as the upper rung of the TF-RD-013 size ladder.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data corpus-size
+      axis.
+    expected_effect: The 80-dataset rung should retain the broadest synthetic coverage
+      in this ladder while still staying close enough to the TF-RD-008-scale control
+      for repeated exposure.
     adequacy_knobs:
-      - explicit config ladder coverage across the selected dagzoo shape regimes
-      - per-invocation dataset counts and combined split distribution
-      - manifest-contract deltas versus the fresh current-corpus control
+    - explicit config ladder coverage across the selected dagzoo shape regimes
+    - per-invocation dataset counts and combined split distribution
+    - manifest-contract deltas versus the fresh current-corpus control
     parameter_adequacy_policy:
       default_plan:
-        - Compare manifest characteristics against the anchor before training and confirm the intended `large` ladder counts (`16` benchmark, `56` default, `8` large-shape) landed in the merged surface.
-        - Read this rung as the upper boundary of the size ladder before reopening any broader synthetic-data exploration.
+      - Compare manifest characteristics against the anchor before training and confirm
+        the intended `large` ladder counts (`16` benchmark, `56` default, `8` large-shape)
+        landed in the merged surface.
+      - Read this rung as the upper boundary of the size ladder before reopening any
+        broader synthetic-data exploration.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7105,30 +7950,38 @@ deltas:
           corpus_ref: tf_rd_013_dagzoo_shape_aware_size_large_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run last as the 80-dataset upper size rung before deciding whether TF-RD-013 needs any broader synthetic-data exploration beyond this ladder.
+    default_next_action: Run last as the 80-dataset upper size rung before deciding
+      whether TF-RD-013 needs any broader synthetic-data exploration beyond this ladder.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_missingness_mcar:
     dimension_family: data
     family: missingness
     binary_applicable: true
-    description: Point training at the TF-RD-020 MCAR harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Moderate MCAR may make the synthetic training surface harder without introducing mechanism-linked missingness structure.
+    description: Point training at the TF-RD-020 MCAR harder-front manifest while
+      keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Moderate MCAR may make the synthetic training surface harder
+      without introducing mechanism-linked missingness structure.
     adequacy_knobs:
-      - explicit `missing_rate` and `missing_mechanism` resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit `missing_rate` and `missing_mechanism` resolution across the carried
+      `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix before reading benchmark output.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other missingness rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix before reading benchmark output.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        missingness rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7142,30 +7995,37 @@ deltas:
           corpus_ref: tf_rd_020_missingness_mcar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first under issue `#148`, then compare directly against the MAR and MNAR rows before nominating one missingness winner.
+    default_next_action: Run first under issue `#148`, then compare directly against
+      the MAR and MNAR rows before nominating one missingness winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_missingness_mar:
     dimension_family: data
     family: missingness
     binary_applicable: true
-    description: Point training at the TF-RD-020 MAR harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Structured MAR missingness may create a clearer harder front than MCAR without the stronger self-masking bias of MNAR.
+    description: Point training at the TF-RD-020 MAR harder-front manifest while keeping
+      the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Structured MAR missingness may create a clearer harder front
+      than MCAR without the stronger self-masking bias of MNAR.
     adequacy_knobs:
-      - explicit MAR override resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit MAR override resolution across the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the MAR override fields in provenance.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other missingness rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the MAR override fields in provenance.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        missingness rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7179,30 +8039,38 @@ deltas:
           corpus_ref: tf_rd_020_missingness_mar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second under issue `#148`, then compare directly against the MCAR and MNAR rows before nominating one missingness winner.
+    default_next_action: Run second under issue `#148`, then compare directly against
+      the MCAR and MNAR rows before nominating one missingness winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_missingness_mnar:
     dimension_family: data
     family: missingness
     binary_applicable: true
-    description: Point training at the TF-RD-020 MNAR harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Structured MNAR missingness may be the strongest missingness harder front, but it risks a less interpretable synthetic lane than MCAR or MAR.
+    description: Point training at the TF-RD-020 MNAR harder-front manifest while
+      keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Structured MNAR missingness may be the strongest missingness
+      harder front, but it risks a less interpretable synthetic lane than MCAR or
+      MAR.
     adequacy_knobs:
-      - explicit MNAR override resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit MNAR override resolution across the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the MNAR override fields in provenance.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other missingness rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the MNAR override fields in provenance.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        missingness rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7216,30 +8084,39 @@ deltas:
           corpus_ref: tf_rd_020_missingness_mnar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run third under issue `#148`, then select exactly one missingness nominee for cross-front comparison.
+    default_next_action: Run third under issue `#148`, then select exactly one missingness
+      nominee for cross-front comparison.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_010_dagzoo_medium_control:
     dimension_family: data
     family: provenance
     binary_applicable: false
-    description: Point training at the TF-RD-010 dagzoo classification control corpus (`n_classes_min=2`, `n_classes_max=10`) while the evolved sandwich benchmark contract is defined against hub-owned validation manifests.
-    upstream_delta: Not applicable; this is a repo-local synthetic training-front contract tied to the first benchmark-evolution lane.
-    expected_effect: Establish the TF-RD-010 classification control corpus that both the medium and large validation rungs will compare against.
+    description: Point training at the TF-RD-010 dagzoo classification control corpus
+      (`n_classes_min=2`, `n_classes_max=10`) while the evolved sandwich benchmark
+      contract is defined against hub-owned validation manifests.
+    upstream_delta: Not applicable; this is a repo-local synthetic training-front
+      contract tied to the first benchmark-evolution lane.
+    expected_effect: Establish the TF-RD-010 classification control corpus that both
+      the medium and large validation rungs will compare against.
     adequacy_knobs:
-      - explicit dagzoo provenance for the classification control corpus
-      - medium and large real-data validation separation via `tab-realdata-hub` manifests
-      - class-count coverage, feature-count coverage, missingness policy, and minority-class floor on the validation side
+    - explicit dagzoo provenance for the classification control corpus
+    - medium and large real-data validation separation via `tab-realdata-hub` manifests
+    - class-count coverage, feature-count coverage, missingness policy, and minority-class
+      floor on the validation side
     parameter_adequacy_policy:
       default_plan:
-        - Keep the evolved sandwich architecture fixed at FiLM plus `sandwich_summary_tokens_per_axis=3` with the direct multiclass head.
-        - Treat `dagzoo` as the synthetic training owner and `tab-realdata-hub` as the validation-manifest owner.
-        - Rank rows by `final_log_loss_at_matched_regime_budget`, with calibration, runtime, stability, and any retained legacy cell-likelihood diagnostics reported as guardrails.
+      - Keep the evolved sandwich architecture fixed at FiLM plus `sandwich_summary_tokens_per_axis=3`
+        with the direct multiclass head.
+      - Treat `dagzoo` as the synthetic training owner and `tab-realdata-hub` as the
+        validation-manifest owner.
+      - Rank rows by `final_log_loss_at_matched_regime_budget`, with calibration,
+        runtime, stability, and any retained legacy cell-likelihood diagnostics reported
+        as guardrails.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_validation_manifests_and_control_baselines
     default_initial_interpretation_status: pending
@@ -7252,30 +8129,37 @@ deltas:
           corpus_ref: tf_rd_010_dagzoo_medium_control_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Wait for `tab-realdata-hub#1` plus the frozen legacy TF-RD-010 control baselines before executing the first TF-RD-010 benchmark rung.
+    default_next_action: Wait for `tab-realdata-hub#1` plus the frozen legacy TF-RD-010
+      control baselines before executing the first TF-RD-010 benchmark rung.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_010_missingness_mcar:
     dimension_family: data
     family: missingness
     binary_applicable: false
-    description: Point training at the TF-RD-010 MCAR classification corpus (`n_classes_min=2`, `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
-    expected_effect: Moderate MCAR should test whether the evolved sandwich target benefits from missingness exposure before any larger benchmark-front escalation.
+    description: Point training at the TF-RD-010 MCAR classification corpus (`n_classes_min=2`,
+      `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed
+      validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front
+      for the benchmark-evolution lane.
+    expected_effect: Moderate MCAR should test whether the evolved sandwich target
+      benefits from missingness exposure before any larger benchmark-front escalation.
     adequacy_knobs:
-      - explicit MCAR provenance in the dagzoo training front
-      - fixed medium and large hub-owned validation manifests
-      - natural-log CE/log-loss ranking under the direct multiclass head contract
+    - explicit MCAR provenance in the dagzoo training front
+    - fixed medium and large hub-owned validation manifests
+    - natural-log CE/log-loss ranking under the direct multiclass head contract
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the TF-RD-010 control corpus before preferring any missingness variant.
-        - Treat the medium and large hub validation bundles as fixed broader-classification reference surfaces, with the large rung providing the larger task set.
-        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      - Compare against the TF-RD-010 control corpus before preferring any missingness
+        variant.
+      - Treat the medium and large hub validation bundles as fixed broader-classification
+        reference surfaces, with the large rung providing the larger task set.
+      - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder
+        to TF-RD-017.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_validation_manifests_and_control_baselines
     default_initial_interpretation_status: pending
@@ -7288,30 +8172,37 @@ deltas:
           corpus_ref: tf_rd_010_missingness_mcar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze, then compare directly against the control, MAR, and MNAR rows.
+    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze,
+      then compare directly against the control, MAR, and MNAR rows.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_010_missingness_mar:
     dimension_family: data
     family: missingness
     binary_applicable: false
-    description: Point training at the TF-RD-010 MAR classification corpus (`n_classes_min=2`, `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
-    expected_effect: Structured MAR may provide a harder but still interpretable missingness front for the first TF-RD-010 classification benchmark program.
+    description: Point training at the TF-RD-010 MAR classification corpus (`n_classes_min=2`,
+      `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed
+      validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front
+      for the benchmark-evolution lane.
+    expected_effect: Structured MAR may provide a harder but still interpretable missingness
+      front for the first TF-RD-010 classification benchmark program.
     adequacy_knobs:
-      - explicit MAR provenance in the dagzoo training front
-      - fixed medium and large hub-owned validation manifests
-      - natural-log CE/log-loss ranking under the direct multiclass head contract
+    - explicit MAR provenance in the dagzoo training front
+    - fixed medium and large hub-owned validation manifests
+    - natural-log CE/log-loss ranking under the direct multiclass head contract
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the TF-RD-010 control corpus plus the MCAR and MNAR rows before preferring structured missingness.
-        - Treat the medium and large hub validation bundles as fixed broader-classification reference surfaces, with the large rung providing the larger task set.
-        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      - Compare against the TF-RD-010 control corpus plus the MCAR and MNAR rows before
+        preferring structured missingness.
+      - Treat the medium and large hub validation bundles as fixed broader-classification
+        reference surfaces, with the large rung providing the larger task set.
+      - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder
+        to TF-RD-017.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_validation_manifests_and_control_baselines
     default_initial_interpretation_status: pending
@@ -7324,30 +8215,38 @@ deltas:
           corpus_ref: tf_rd_010_missingness_mar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze, then compare directly against the control, MCAR, and MNAR rows.
+    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze,
+      then compare directly against the control, MCAR, and MNAR rows.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_010_missingness_mnar:
     dimension_family: data
     family: missingness
     binary_applicable: false
-    description: Point training at the TF-RD-010 MNAR classification corpus (`n_classes_min=2`, `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed validation contract fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic missingness front for the benchmark-evolution lane.
-    expected_effect: Structured MNAR may be the strongest synthetic missingness perturbation, but it risks a less interpretable first benchmark-evolution read than MCAR or MAR.
+    description: Point training at the TF-RD-010 MNAR classification corpus (`n_classes_min=2`,
+      `n_classes_max=10`) while keeping the evolved sandwich architecture and hub-backed
+      validation contract fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic missingness front
+      for the benchmark-evolution lane.
+    expected_effect: Structured MNAR may be the strongest synthetic missingness perturbation,
+      but it risks a less interpretable first benchmark-evolution read than MCAR or
+      MAR.
     adequacy_knobs:
-      - explicit MNAR provenance in the dagzoo training front
-      - fixed medium and large hub-owned validation manifests
-      - natural-log CE/log-loss ranking under the direct multiclass head contract
+    - explicit MNAR provenance in the dagzoo training front
+    - fixed medium and large hub-owned validation manifests
+    - natural-log CE/log-loss ranking under the direct multiclass head contract
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the TF-RD-010 control corpus plus the MCAR and MAR rows before preferring the strongest self-masking option.
-        - Treat the medium and large hub validation bundles as fixed broader-classification reference surfaces, with the large rung providing the larger task set.
-        - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder to TF-RD-017.
+      - Compare against the TF-RD-010 control corpus plus the MCAR and MAR rows before
+        preferring the strongest self-masking option.
+      - Treat the medium and large hub validation bundles as fixed broader-classification
+        reference surfaces, with the large rung providing the larger task set.
+      - Keep class-imbalance reporting explicit, but defer any dedicated skew ladder
+        to TF-RD-017.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_validation_manifests_and_control_baselines
     default_initial_interpretation_status: pending
@@ -7360,30 +8259,38 @@ deltas:
           corpus_ref: tf_rd_010_missingness_mnar_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze, then compare directly against the control, MCAR, and MAR rows.
+    default_next_action: Wait for `tab-realdata-hub#1` and the legacy baseline freeze,
+      then compare directly against the control, MCAR, and MAR rows.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_shift_graph_drift:
     dimension_family: data
     family: shift
     binary_applicable: true
-    description: Point training at the TF-RD-020 graph-drift harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Moderate graph drift may create a harder synthetic front without simultaneously changing mechanism or noise structure.
+    description: Point training at the TF-RD-020 graph-drift harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Moderate graph drift may create a harder synthetic front without
+      simultaneously changing mechanism or noise structure.
     adequacy_knobs:
-      - explicit `shift.mode=graph_drift` resolution with `graph_scale=0.5` across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit `shift.mode=graph_drift` resolution with `graph_scale=0.5` across the
+      carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the graph-drift effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other shift rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the graph-drift effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        shift rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7397,30 +8304,39 @@ deltas:
           corpus_ref: tf_rd_020_shift_graph_drift_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first under issue `#149`, then compare directly against the mechanism-drift, noise-drift, and mixed rows before nominating one shift winner.
+    default_next_action: Run first under issue `#149`, then compare directly against
+      the mechanism-drift, noise-drift, and mixed rows before nominating one shift
+      winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_shift_mechanism_drift:
     dimension_family: data
     family: shift
     binary_applicable: true
-    description: Point training at the TF-RD-020 mechanism-drift harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Moderate mechanism drift may create a clearer harder front than pure graph drift by changing function-family mass between train and test.
+    description: Point training at the TF-RD-020 mechanism-drift harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Moderate mechanism drift may create a clearer harder front than
+      pure graph drift by changing function-family mass between train and test.
     adequacy_knobs:
-      - explicit `shift.mode=mechanism_drift` resolution with `mechanism_scale=0.5` across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit `shift.mode=mechanism_drift` resolution with `mechanism_scale=0.5`
+      across the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the mechanism-drift effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other shift rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the mechanism-drift effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        shift rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7434,30 +8350,38 @@ deltas:
           corpus_ref: tf_rd_020_shift_mechanism_drift_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second under issue `#149`, then compare directly against the graph-drift, noise-drift, and mixed rows before nominating one shift winner.
+    default_next_action: Run second under issue `#149`, then compare directly against
+      the graph-drift, noise-drift, and mixed rows before nominating one shift winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_shift_noise_drift:
     dimension_family: data
     family: shift
     binary_applicable: true
-    description: Point training at the TF-RD-020 noise-drift harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Moderate variance drift may create a harder front if the current overfitting problem is partly a mismatch in stochasticity rather than structure.
+    description: Point training at the TF-RD-020 noise-drift harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Moderate variance drift may create a harder front if the current
+      overfitting problem is partly a mismatch in stochasticity rather than structure.
     adequacy_knobs:
-      - explicit `shift.mode=noise_drift` resolution with `variance_scale=0.5` across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit `shift.mode=noise_drift` resolution with `variance_scale=0.5` across
+      the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the noise-drift effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other shift rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the noise-drift effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        shift rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7471,30 +8395,39 @@ deltas:
           corpus_ref: tf_rd_020_shift_noise_drift_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run third under issue `#149`, then compare directly against the graph-drift, mechanism-drift, and mixed rows before nominating one shift winner.
+    default_next_action: Run third under issue `#149`, then compare directly against
+      the graph-drift, mechanism-drift, and mixed rows before nominating one shift
+      winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_shift_mixed:
     dimension_family: data
     family: shift
     binary_applicable: true
-    description: Point training at the TF-RD-020 mixed-drift harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Mixed drift may be the strongest shift candidate, but it also risks becoming less interpretable than the single-axis rows.
+    description: Point training at the TF-RD-020 mixed-drift harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Mixed drift may be the strongest shift candidate, but it also
+      risks becoming less interpretable than the single-axis rows.
     adequacy_knobs:
-      - explicit `shift.mode=mixed` resolution with all three `0.5` scales across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit `shift.mode=mixed` resolution with all three `0.5` scales across the
+      carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the mixed-drift effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other shift rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the mixed-drift effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        shift rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7508,30 +8441,38 @@ deltas:
           corpus_ref: tf_rd_020_shift_mixed_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run fourth under issue `#149`, then select exactly one shift or drift nominee for cross-front comparison.
+    default_next_action: Run fourth under issue `#149`, then select exactly one shift
+      or drift nominee for cross-front comparison.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_mechanism_piecewise:
     dimension_family: data
     family: mechanism_diversity
     binary_applicable: true
-    description: Point training at the TF-RD-020 piecewise-mechanism harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: The shipped piecewise-plus-linear family mix may create a more data-hungry synthetic front without introducing explicit train-test shift.
+    description: Point training at the TF-RD-020 piecewise-mechanism harder-front
+      manifest while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: The shipped piecewise-plus-linear family mix may create a more
+      data-hungry synthetic front without introducing explicit train-test shift.
     adequacy_knobs:
-      - explicit mechanism family-mix resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit mechanism family-mix resolution across the carried `8/28/4` invocation
+      mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the piecewise effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other mechanism or noise rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the piecewise effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        mechanism or noise rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7545,30 +8486,39 @@ deltas:
           corpus_ref: tf_rd_020_mechanism_piecewise_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run first under issue `#150`, then compare directly against the GP-only and heavier-tail noise rows before nominating one mechanism or noise winner.
+    default_next_action: Run first under issue `#150`, then compare directly against
+      the GP-only and heavier-tail noise rows before nominating one mechanism or noise
+      winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_mechanism_gp:
     dimension_family: data
     family: mechanism_diversity
     binary_applicable: true
-    description: Point training at the TF-RD-020 GP-only mechanism harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: The widened GP family may create a more sample-hungry but still interpretable harder front if the current corpus is too easy.
+    description: Point training at the TF-RD-020 GP-only mechanism harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: The widened GP family may create a more sample-hungry but still
+      interpretable harder front if the current corpus is too easy.
     adequacy_knobs:
-      - explicit GP-only family-mix resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit GP-only family-mix resolution across the carried `8/28/4` invocation
+      mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the GP-only effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other mechanism or noise rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the GP-only effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        mechanism or noise rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7582,30 +8532,38 @@ deltas:
           corpus_ref: tf_rd_020_mechanism_gp_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run second under issue `#150`, then compare directly against the piecewise and heavier-tail noise rows before nominating one mechanism or noise winner.
+    default_next_action: Run second under issue `#150`, then compare directly against
+      the piecewise and heavier-tail noise rows before nominating one mechanism or
+      noise winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_noise_laplace:
     dimension_family: data
     family: noise
     binary_applicable: true
-    description: Point training at the TF-RD-020 Laplace-noise harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Laplace noise may create a harder front through heavier tails without the broader ambiguity of the mixture-noise row.
+    description: Point training at the TF-RD-020 Laplace-noise harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Laplace noise may create a harder front through heavier tails
+      without the broader ambiguity of the mixture-noise row.
     adequacy_knobs:
-      - explicit Laplace-noise resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit Laplace-noise resolution across the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the Laplace effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other mechanism or noise rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the Laplace effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        mechanism or noise rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7619,30 +8577,39 @@ deltas:
           corpus_ref: tf_rd_020_noise_laplace_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run third under issue `#150`, then compare directly against the mechanism rows and mixture noise row before nominating one mechanism or noise winner.
+    default_next_action: Run third under issue `#150`, then compare directly against
+      the mechanism rows and mixture noise row before nominating one mechanism or
+      noise winner.
     applicability_guards: []
-
   delta_data_manifest_root_tf_rd_020_noise_mixture:
     dimension_family: data
     family: noise
     binary_applicable: true
-    description: Point training at the TF-RD-020 mixture-noise harder-front manifest while keeping the settled four-task row-first recipe fixed.
-    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front axis.
-    expected_effect: Mixture noise may be the strongest heavier-tail noise candidate, but it also risks becoming noisier and less interpretable than the mechanism rows.
+    description: Point training at the TF-RD-020 mixture-noise harder-front manifest
+      while keeping the settled four-task row-first recipe fixed.
+    upstream_delta: Not applicable; this is a repo-local synthetic-data harder-front
+      axis.
+    expected_effect: Mixture noise may be the strongest heavier-tail noise candidate,
+      but it also risks becoming noisier and less interpretable than the mechanism
+      rows.
     adequacy_knobs:
-      - explicit mixture-noise resolution across the carried `8/28/4` invocation mix
-      - manifest-contract deltas versus the kept TF-RD-013 medium control
-      - benchmark-facing generalization under the settled four-task row-first recipe
+    - explicit mixture-noise resolution across the carried `8/28/4` invocation mix
+    - manifest-contract deltas versus the kept TF-RD-013 medium control
+    - benchmark-facing generalization under the settled four-task row-first recipe
     parameter_adequacy_policy:
       default_plan:
-        - Confirm the materialized corpus preserves the carried `8/28/4` invocation mix and resolves the mixture-noise effective config artifacts.
-        - Compare final log loss first, final Brier score second, final ROC AUC third, and best-to-final ROC delta fourth against the medium control and the other mechanism or noise rows.
-        - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior as guardrails rather than primary selection metrics.
+      - Confirm the materialized corpus preserves the carried `8/28/4` invocation
+        mix and resolves the mixture-noise effective config artifacts.
+      - Compare final log loss first, final Brier score second, final ROC AUC third,
+        and best-to-final ROC delta fourth against the medium control and the other
+        mechanism or noise rows.
+      - Treat runtime, clipped-step fraction, fallback, NaNs, and OOM or retry behavior
+        as guardrails rather than primary selection metrics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7656,61 +8623,68 @@ deltas:
           corpus_ref: tf_rd_020_noise_mixture_v1
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run fourth under issue `#150`, then select exactly one mechanism-diversity or noise nominee for cross-front comparison.
+    default_next_action: Run fourth under issue `#150`, then select exactly one mechanism-diversity
+      or noise nominee for cross-front comparison.
     applicability_guards: []
-
   delta_data_filter_policy_accepted_only:
-      dimension_family: data
-      family: provenance
-      binary_applicable: true
-      description: Rebuild the training manifest with accepted-only dagzoo filtering while holding model and preprocessing at the anchor.
-      upstream_delta: Not applicable; this is a repo-local manifest/provenance decision.
-      expected_effect: Cleaner data quality with a possible diversity-versus-quality tradeoff.
-      adequacy_knobs:
-        - Must report dataset-count and feature/class distribution shifts versus the anchor manifest.
-      parameter_adequacy_policy:
-        default_plan:
-          - Rebuild the manifest and compare manifest characteristics before training.
-          - If weaker, discuss whether coverage loss or provenance tightening is the likely cause.
-        default_negative_decision: defer
-        reject_requires:
-          - isolated_change
-          - adequacy_plan_complete
-          - clearly_worse_without_offsetting_benefit
-      legacy_stage_alias: none
-      default_initial_status: blocked_on_artifacts
-      default_initial_interpretation_status: pending
-      default_effective_surface:
-        model:
-          stage_label: anchor_model
-        data:
-          surface_label: accepted_only_manifest
-          surface_overrides:
-            filter_policy: accepted_only
-        preprocessing:
-          surface_label: runtime_default
-      default_next_action: Materialize the accepted-only manifest and attach its provenance before scheduling training.
-      applicability_guards: []
-
+    dimension_family: data
+    family: provenance
+    binary_applicable: true
+    description: Rebuild the training manifest with accepted-only dagzoo filtering
+      while holding model and preprocessing at the anchor.
+    upstream_delta: Not applicable; this is a repo-local manifest/provenance decision.
+    expected_effect: Cleaner data quality with a possible diversity-versus-quality
+      tradeoff.
+    adequacy_knobs:
+    - Must report dataset-count and feature/class distribution shifts versus the anchor
+      manifest.
+    parameter_adequacy_policy:
+      default_plan:
+      - Rebuild the manifest and compare manifest characteristics before training.
+      - If weaker, discuss whether coverage loss or provenance tightening is the likely
+        cause.
+      default_negative_decision: defer
+      reject_requires:
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
+    legacy_stage_alias: none
+    default_initial_status: blocked_on_artifacts
+    default_initial_interpretation_status: pending
+    default_effective_surface:
+      model:
+        stage_label: anchor_model
+      data:
+        surface_label: accepted_only_manifest
+        surface_overrides:
+          filter_policy: accepted_only
+      preprocessing:
+        surface_label: runtime_default
+    default_next_action: Materialize the accepted-only manifest and attach its provenance
+      before scheduling training.
+    applicability_guards: []
   delta_data_manifest_root_curated_dagzoo:
     dimension_family: data
     family: provenance
     binary_applicable: true
-    description: Point training at a curated dagzoo manifest root with explicit dagzoo command provenance.
+    description: Point training at a curated dagzoo manifest root with explicit dagzoo
+      command provenance.
     upstream_delta: Not applicable; this is a repo-local dataset-generation axis.
-    expected_effect: Potentially cleaner training data with a materially different corpus composition.
+    expected_effect: Potentially cleaner training data with a materially different
+      corpus composition.
     adequacy_knobs:
-      - dagzoo generate/filter commands
-      - curated root lineage
-      - dataset count and split distribution deltas
+    - dagzoo generate/filter commands
+    - curated root lineage
+    - dataset count and split distribution deltas
     parameter_adequacy_policy:
       default_plan:
-        - Do not run until the dagzoo provenance payload is filled in and the manifest characteristics are attached.
+      - Do not run until the dagzoo provenance payload is filled in and the manifest
+        characteristics are attached.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_artifacts
     default_initial_interpretation_status: pending
@@ -7730,24 +8704,26 @@ deltas:
         surface_label: runtime_default
     default_next_action: Capture the dagzoo generation/filter lineage first.
     applicability_guards: []
-
   delta_data_manifest_source_binary_iris:
     dimension_family: data
     family: source
     binary_applicable: true
-    description: Swap the training manifest to the small binary iris support surface while keeping the model and preprocessing anchored.
-    upstream_delta: Not applicable; upstream nanoTabPFN does not share this repo-local prior-training manifest contract.
+    description: Swap the training manifest to the small binary iris support surface
+      while keeping the model and preprocessing anchored.
+    upstream_delta: Not applicable; upstream nanoTabPFN does not share this repo-local
+      prior-training manifest contract.
     expected_effect: Faster, cleaner, but much lower-diversity training data.
     adequacy_knobs:
-      - Compare manifest row/feature/class distributions to the anchor before training.
+    - Compare manifest row/feature/class distributions to the anchor before training.
     parameter_adequacy_policy:
       default_plan:
-        - Treat any weakness primarily as evidence about training-surface coverage unless metrics collapse unambiguously.
+      - Treat any weakness primarily as evidence about training-surface coverage unless
+        metrics collapse unambiguously.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7761,29 +8737,36 @@ deltas:
           manifest_path: outputs/staged_ladder_support/binary_iris_manifest/manifest.parquet
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run only after the matrix explicitly records the anchor-versus-iris manifest characteristics.
+    default_next_action: Run only after the matrix explicitly records the anchor-versus-iris
+      manifest characteristics.
     applicability_guards: []
-
   delta_data_manifest_curated_realdata_comparator:
     dimension_family: data
     family: source
     binary_applicable: true
-    description: Define the curated real-data comparator manifest contract as one OpenML baseline plus any approved manifest-backed augmentations.
-    upstream_delta: Not applicable; this is a repo-local comparator contract layered on top of the benchmark-native OpenML baseline.
-    expected_effect: A real-data comparator lane that is explicit enough to compare against current-corpus and dagzoo candidates without reopening loader boundaries.
+    description: Define the curated real-data comparator manifest contract as one
+      OpenML baseline plus any approved manifest-backed augmentations.
+    upstream_delta: Not applicable; this is a repo-local comparator contract layered
+      on top of the benchmark-native OpenML baseline.
+    expected_effect: A real-data comparator lane that is explicit enough to compare
+      against current-corpus and dagzoo candidates without reopening loader boundaries.
     adequacy_knobs:
-      - Approved ledger rows for every dataset referenced by the comparator manifest family.
-      - OpenML baseline versus approved external augmentation coverage notes.
-      - Manifest lineage and regime-coverage notes attached before any benchmark read is interpreted.
+    - Approved ledger rows for every dataset referenced by the comparator manifest
+      family.
+    - OpenML baseline versus approved external augmentation coverage notes.
+    - Manifest lineage and regime-coverage notes attached before any benchmark read
+      is interpreted.
     parameter_adequacy_policy:
       default_plan:
-        - Keep the OpenML baseline canonical and treat manifest-backed external datasets as approved augmentations rather than a replacement path.
-        - Do not schedule the comparator until the referenced datasets are approved in the review ledger and the manifest lineage is attached.
+      - Keep the OpenML baseline canonical and treat manifest-backed external datasets
+        as approved augmentations rather than a replacement path.
+      - Do not schedule the comparator until the referenced datasets are approved
+        in the review ledger and the manifest lineage is attached.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_artifacts
     default_initial_interpretation_status: pending
@@ -7798,26 +8781,30 @@ deltas:
         allow_missing_values: true
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Materialize the approved OpenML-baseline comparator manifest and cite any approved external augmentations before scheduling this row.
+    default_next_action: Materialize the approved OpenML-baseline comparator manifest
+      and cite any approved external augmentations before scheduling this row.
     applicability_guards: []
-
   delta_preproc_impute_missing_off:
     dimension_family: preprocessing
     family: missing_values
     binary_applicable: true
-    description: Disable runtime mean imputation while keeping the fitted label-remap path intact.
-    upstream_delta: Upstream notebook preprocessing imputes as part of its benchmark helper path.
-    expected_effect: Cleaner attribution around imputation usefulness, but possibly brittle feature tensors on some datasets.
+    description: Disable runtime mean imputation while keeping the fitted label-remap
+      path intact.
+    upstream_delta: Upstream notebook preprocessing imputes as part of its benchmark
+      helper path.
+    expected_effect: Cleaner attribution around imputation usefulness, but possibly
+      brittle feature tensors on some datasets.
     adequacy_knobs:
-      - Interpret against manifest missingness prevalence where available.
+    - Interpret against manifest missingness prevalence where available.
     parameter_adequacy_policy:
       default_plan:
-        - If the result is weak, note whether the benchmark tasks actually contain meaningful missingness on the support side.
+      - If the result is weak, note whether the benchmark tasks actually contain meaningful
+        missingness on the support side.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: deferred_separate_workstream
     default_initial_interpretation_status: blocked
@@ -7830,26 +8817,31 @@ deltas:
         surface_label: runtime_no_impute
         overrides:
           impute_missing: false
-    default_next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
+    default_next_action: Do not run on the main no-missing campaign; revisit only
+      in a dedicated missingness workstream with explicit missing-valued training
+      and evaluation inputs.
     applicability_guards: []
-
   delta_preproc_all_nan_fill_nonzero:
     dimension_family: preprocessing
     family: missing_values
     binary_applicable: true
-    description: Keep imputation on but change the all-NaN fallback fill value from 0.0 to 1.0.
-    upstream_delta: Upstream helper logic does not expose this repo-local fill-value contract as a first-class surface.
-    expected_effect: Usually small, but important for understanding whether hidden fill defaults matter on this corpus.
+    description: Keep imputation on but change the all-NaN fallback fill value from
+      0.0 to 1.0.
+    upstream_delta: Upstream helper logic does not expose this repo-local fill-value
+      contract as a first-class surface.
+    expected_effect: Usually small, but important for understanding whether hidden
+      fill defaults matter on this corpus.
     adequacy_knobs:
-      - Report whether all-NaN columns are actually present in the compared manifests.
+    - Report whether all-NaN columns are actually present in the compared manifests.
     parameter_adequacy_policy:
       default_plan:
-        - Interpret near-zero movement as expected if the surface rarely exercises this branch.
+      - Interpret near-zero movement as expected if the surface rarely exercises this
+        branch.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: deferred_separate_workstream
     default_initial_interpretation_status: blocked
@@ -7862,31 +8854,30 @@ deltas:
         surface_label: runtime_all_nan_fill_one
         overrides:
           all_nan_fill: 1.0
-    default_next_action: Do not run on the main no-missing campaign; revisit only in a dedicated missingness workstream with explicit missing-valued training and evaluation inputs.
+    default_next_action: Do not run on the main no-missing campaign; revisit only
+      in a dedicated missingness workstream with explicit missing-valued training
+      and evaluation inputs.
     applicability_guards: []
-
   delta_preproc_norm_zscore:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: >-
-      Apply train-only z-score normalization (no clipping) to input features
+    description: Apply train-only z-score normalization (no clipping) to input features
       before encoding, changing model.input_normalization from none to train_zscore.
     upstream_delta: Upstream nanoTabPFN applies z-score+clip inside the feature encoder.
-    expected_effect: >-
-      May reduce feature-scale sensitivity; the anchor sees raw features, so any
-      improvement indicates the model benefits from pre-normalized inputs.
+    expected_effect: May reduce feature-scale sensitivity; the anchor sees raw features,
+      so any improvement indicates the model benefits from pre-normalized inputs.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare ROC AUC and loss curves against the anchor (no normalization).
-        - Check whether normalization helps more on high-variance-feature tasks.
+      - Compare ROC AUC and loss curves against the anchor (no normalization).
+      - Check whether normalization helps more on high-variance-feature tasks.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7898,32 +8889,30 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run and compare against the anchor and other normalization rows.
+    default_next_action: Run and compare against the anchor and other normalization
+      rows.
     applicability_guards: []
-
   delta_preproc_norm_rankgauss:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: >-
-      Apply train-only rank-Gauss (quantile-to-normal via erfinv) normalization
-      to input features before encoding, changing model.input_normalization from
-      none to train_rankgauss.
+    description: Apply train-only rank-Gauss (quantile-to-normal via erfinv) normalization
+      to input features before encoding, changing model.input_normalization from none
+      to train_rankgauss.
     upstream_delta: Upstream nanoTabPFN applies z-score+clip inside the feature encoder.
-    expected_effect: >-
-      Rank-Gauss is robust to outliers and heavy tails; may help on skewed-feature
-      tasks where z-score under- or over-corrects.
+    expected_effect: Rank-Gauss is robust to outliers and heavy tails; may help on
+      skewed-feature tasks where z-score under- or over-corrects.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare ROC AUC and loss curves against the anchor (no normalization).
-        - Look for per-task lift on skewed or heavy-tailed feature distributions.
+      - Compare ROC AUC and loss curves against the anchor (no normalization).
+      - Look for per-task lift on skewed or heavy-tailed feature distributions.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7935,31 +8924,30 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run and compare against the anchor and other normalization rows.
+    default_next_action: Run and compare against the anchor and other normalization
+      rows.
     applicability_guards: []
-
   delta_preproc_norm_robust:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: >-
-      Apply train-only robust (median / IQR) normalization to input features
+    description: Apply train-only robust (median / IQR) normalization to input features
       before encoding, changing model.input_normalization from none to train_robust.
     upstream_delta: Upstream nanoTabPFN applies z-score+clip inside the feature encoder.
-    expected_effect: >-
-      Median/IQR scaling is less sensitive to outliers than z-score; may improve
-      stability on tasks with extreme values without discarding ordinal information.
+    expected_effect: Median/IQR scaling is less sensitive to outliers than z-score;
+      may improve stability on tasks with extreme values without discarding ordinal
+      information.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare ROC AUC and loss curves against the anchor (no normalization).
-        - Check whether robust scaling helps on tasks with outlier-heavy columns.
+      - Compare ROC AUC and loss curves against the anchor (no normalization).
+      - Check whether robust scaling helps on tasks with outlier-heavy columns.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -7971,33 +8959,30 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run and compare against the anchor and other normalization rows.
+    default_next_action: Run and compare against the anchor and other normalization
+      rows.
     applicability_guards: []
-
   delta_preproc_norm_winsorize_zscore:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: >-
-      Clip input features at the 1st/99th train percentiles, then apply z-score
-      normalization, changing model.input_normalization from none to
-      train_winsorize_zscore.
+    description: Clip input features at the 1st/99th train percentiles, then apply
+      z-score normalization, changing model.input_normalization from none to train_winsorize_zscore.
     upstream_delta: Upstream nanoTabPFN applies z-score+clip inside the feature encoder.
-    expected_effect: >-
-      Winsorization removes extreme outliers before z-scoring, giving a tighter
-      effective range than plain z-score while preserving more ordinal detail than
-      rank-Gauss.
+    expected_effect: Winsorization removes extreme outliers before z-scoring, giving
+      a tighter effective range than plain z-score while preserving more ordinal detail
+      than rank-Gauss.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare ROC AUC and loss curves against the anchor (no normalization).
-        - Verify that winsorization bounds match expected 1st/99th percentile range.
+      - Compare ROC AUC and loss curves against the anchor (no normalization).
+      - Verify that winsorization bounds match expected 1st/99th percentile range.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8009,29 +8994,32 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Run and compare against the anchor and other normalization rows.
+    default_next_action: Run and compare against the anchor and other normalization
+      rows.
     applicability_guards: []
-
   dpnb_input_norm_anchor_replay:
     dimension_family: training
     family: baseline_replay
     binary_applicable: true
-    description: Replay the locked hybrid-diagnostic baseline exactly on this machine before comparing normalization or batch-size variants.
-    upstream_delta: Not applicable; this is a repo-local metadata-only hybrid-diagnostic anchor replay.
-    expected_effect: Establish a local comparator for all later rows while the canonical winning artifacts remain on another machine.
+    description: Replay the locked hybrid-diagnostic baseline exactly on this machine
+      before comparing normalization or batch-size variants.
+    upstream_delta: Not applicable; this is a repo-local metadata-only hybrid-diagnostic
+      anchor replay.
+    expected_effect: Establish a local comparator for all later rows while the canonical
+      winning artifacts remain on another machine.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - optimizer.min_lr
-      - schedule.stages[0].lr_max
+    - training.prior_dump_batch_size
+    - optimizer.min_lr
+    - schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Run this row first so every later row has a local same-machine comparator.
-        - Treat benchmark ROC as primary and use drift/clipped-step telemetry as diagnostics.
+      - Run this row first so every later row has a local same-machine comparator.
+      - Treat benchmark ROC as primary and use drift/clipped-step telemetry as diagnostics.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8068,32 +9056,37 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run this row first and keep it as the local comparator for the rest of the sweep.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run this row first and keep it as the local comparator for
+      the rest of the sweep.
     applicability_guards: []
-
   dpnb_input_norm_zscore:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: Remove external clipping and use plain train-only z-score normalization on the locked hybrid-diagnostic baseline.
-    upstream_delta: Upstream nanoTabPFN keeps internal z-score-plus-clip behavior on the exact path.
-    expected_effect: Clarifies whether clipping is still helping on the stabilized row-cls bridge surface.
+    description: Remove external clipping and use plain train-only z-score normalization
+      on the locked hybrid-diagnostic baseline.
+    upstream_delta: Upstream nanoTabPFN keeps internal z-score-plus-clip behavior
+      on the exact path.
+    expected_effect: Clarifies whether clipping is still helping on the stabilized
+      row-cls bridge surface.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the anchor replay before trying smoother tails or batch-size interactions.
-        - Use drift and clipped-step telemetry only as diagnostics for the benchmark outcome.
+      - Compare directly against the anchor replay before trying smoother tails or
+        batch-size interactions.
+      - Use drift and clipped-step telemetry only as diagnostics for the benchmark
+        outcome.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8106,27 +9099,31 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Compare directly against the anchor replay to decide whether clipping should remain default.
+    default_next_action: Compare directly against the anchor replay to decide whether
+      clipping should remain default.
     applicability_guards: []
-
   dpnb_input_norm_winsorize_zscore:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: Winsorize at the 1st and 99th train percentiles before z-scoring on the locked hybrid-diagnostic baseline.
-    upstream_delta: Upstream nanoTabPFN does not expose percentile winsorization as a first-class normalization mode.
-    expected_effect: May preserve outlier robustness while relaxing the hard post-z-score clip.
+    description: Winsorize at the 1st and 99th train percentiles before z-scoring
+      on the locked hybrid-diagnostic baseline.
+    upstream_delta: Upstream nanoTabPFN does not expose percentile winsorization as
+      a first-class normalization mode.
+    expected_effect: May preserve outlier robustness while relaxing the hard post-z-score
+      clip.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Interpret this row as a bounded outlier-defense alternative, not as a smooth-tail mechanism.
-        - Compare against both the anchor replay and plain z-score before drawing conclusions.
+      - Interpret this row as a bounded outlier-defense alternative, not as a smooth-tail
+        mechanism.
+      - Compare against both the anchor replay and plain z-score before drawing conclusions.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8139,27 +9136,31 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Compare against the anchor replay and plain z-score to decide whether percentile clipping is worth keeping around.
+    default_next_action: Compare against the anchor replay and plain z-score to decide
+      whether percentile clipping is worth keeping around.
     applicability_guards: []
-
   dpnb_input_norm_zscore_tanh:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: Apply train-only z-score normalization followed by a smooth tanh tail squash on the locked hybrid-diagnostic baseline.
-    upstream_delta: Upstream nanoTabPFN does not expose a smooth-tail normalization family.
-    expected_effect: Preserves near-linear scale around zero while soft-bounding outliers without hard clipping.
+    description: Apply train-only z-score normalization followed by a smooth tanh
+      tail squash on the locked hybrid-diagnostic baseline.
+    upstream_delta: Upstream nanoTabPFN does not expose a smooth-tail normalization
+      family.
+    expected_effect: Preserves near-linear scale around zero while soft-bounding outliers
+      without hard clipping.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Treat this as the primary smooth-tail row for the sweep.
-        - If it wins locally, use it for the batch-size interaction sidecars before reopening any other preprocessing family.
+      - Treat this as the primary smooth-tail row for the sweep.
+      - If it wins locally, use it for the batch-size interaction sidecars before
+        reopening any other preprocessing family.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8172,27 +9173,31 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Use this as the favored smooth-tail row before any batch-size interaction checks.
+    default_next_action: Use this as the favored smooth-tail row before any batch-size
+      interaction checks.
     applicability_guards: []
-
   dpnb_input_norm_robust_tanh:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: Apply robust median/IQR scaling followed by a smooth tanh tail squash on the locked hybrid-diagnostic baseline.
-    upstream_delta: Upstream nanoTabPFN does not expose this robust smooth-tail normalization family.
-    expected_effect: Tests whether a more outlier-resistant center/scale estimate helps more than plain z-score plus smooth tails.
+    description: Apply robust median/IQR scaling followed by a smooth tanh tail squash
+      on the locked hybrid-diagnostic baseline.
+    upstream_delta: Upstream nanoTabPFN does not expose this robust smooth-tail normalization
+      family.
+    expected_effect: Tests whether a more outlier-resistant center/scale estimate
+      helps more than plain z-score plus smooth tails.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Compare this against zscore_tanh rather than against the anchor alone so the smooth-tail family is properly separated.
-        - Prefer the simpler z-score family unless this row shows clear benchmark upside.
+      - Compare this against zscore_tanh rather than against the anchor alone so the
+        smooth-tail family is properly separated.
+      - Prefer the simpler z-score family unless this row shows clear benchmark upside.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8205,30 +9210,33 @@ deltas:
         surface_label: anchor_manifest_default
       preprocessing:
         surface_label: runtime_default
-    default_next_action: Compare against zscore_tanh before investing more budget in robust-tail preprocessing.
+    default_next_action: Compare against zscore_tanh before investing more budget
+      in robust-tail preprocessing.
     applicability_guards: []
-
   dpnb_input_norm_anchor_replay_batch16_sqrt:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Replay the locked hybrid-diagnostic baseline at prior-dump batch size 16 with sqrt LR scaling.
+    description: Replay the locked hybrid-diagnostic baseline at prior-dump batch
+      size 16 with sqrt LR scaling.
     upstream_delta: Not applicable; this is a repo-local exact-prior systems probe.
-    expected_effect: Tests whether smaller batches improve the bridge baseline once LR is scaled conservatively.
+    expected_effect: Tests whether smaller batches improve the bridge baseline once
+      LR is scaled conservatively.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare this row against the batch-32 anchor replay before combining batch changes with normalization changes.
-        - Use benchmark quality first and telemetry second.
+      - Compare this row against the batch-32 anchor replay before combining batch
+        changes with normalization changes.
+      - Use benchmark quality first and telemetry second.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8247,30 +9255,33 @@ deltas:
         prior_dump_batch_size: 16
         prior_dump_lr_scale_rule: sqrt
         prior_dump_batch_reference_size: 32
-    default_next_action: Compare against the batch-32 anchor replay before attributing any gain to normalization.
+    default_next_action: Compare against the batch-32 anchor replay before attributing
+      any gain to normalization.
     applicability_guards: []
-
   dpnb_input_norm_anchor_replay_batch64_sqrt:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Replay the locked hybrid-diagnostic baseline at prior-dump batch size 64 with sqrt LR scaling.
+    description: Replay the locked hybrid-diagnostic baseline at prior-dump batch
+      size 64 with sqrt LR scaling.
     upstream_delta: Not applicable; this is a repo-local exact-prior systems probe.
-    expected_effect: Tests whether the stabilized bridge surface prefers a larger effective batch when LR is scaled up conservatively.
+    expected_effect: Tests whether the stabilized bridge surface prefers a larger
+      effective batch when LR is scaled up conservatively.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - schedule.stages[0].lr_max
-      - optimizer.min_lr
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - schedule.stages[0].lr_max
+    - optimizer.min_lr
     parameter_adequacy_policy:
       default_plan:
-        - Compare this row against the batch-32 anchor replay before combining batch changes with normalization changes.
-        - Use benchmark quality first and telemetry second.
+      - Compare this row against the batch-32 anchor replay before combining batch
+        changes with normalization changes.
+      - Use benchmark quality first and telemetry second.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8289,29 +9300,34 @@ deltas:
         prior_dump_batch_size: 64
         prior_dump_lr_scale_rule: sqrt
         prior_dump_batch_reference_size: 32
-    default_next_action: Compare against the batch-32 anchor replay before attributing any gain to normalization.
+    default_next_action: Compare against the batch-32 anchor replay before attributing
+      any gain to normalization.
     applicability_guards: []
-
   dpnb_input_norm_zscore_tanh_batch16_sqrt:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Combine the favored smooth-tail zscore_tanh normalization with prior-dump batch size 16 and sqrt LR scaling.
-    upstream_delta: Not applicable; this is a repo-local interaction probe between smooth-tail preprocessing and smaller batch size.
-    expected_effect: Checks whether any zscore_tanh gains survive or improve at a smaller, scaled batch.
+    description: Combine the favored smooth-tail zscore_tanh normalization with prior-dump
+      batch size 16 and sqrt LR scaling.
+    upstream_delta: Not applicable; this is a repo-local interaction probe between
+      smooth-tail preprocessing and smaller batch size.
+    expected_effect: Checks whether any zscore_tanh gains survive or improve at a
+      smaller, scaled batch.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - model.input_normalization
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Only interpret this row after comparing zscore_tanh itself against the anchor replay.
-        - Use it to decide whether batch size changes interact constructively with the smooth-tail row.
+      - Only interpret this row after comparing zscore_tanh itself against the anchor
+        replay.
+      - Use it to decide whether batch size changes interact constructively with the
+        smooth-tail row.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8330,29 +9346,34 @@ deltas:
         prior_dump_batch_size: 16
         prior_dump_lr_scale_rule: sqrt
         prior_dump_batch_reference_size: 32
-    default_next_action: Compare against the plain zscore_tanh row before concluding that batch size is part of the mechanism.
+    default_next_action: Compare against the plain zscore_tanh row before concluding
+      that batch size is part of the mechanism.
     applicability_guards: []
-
   dpnb_input_norm_zscore_tanh_batch64_sqrt:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Combine the favored smooth-tail zscore_tanh normalization with prior-dump batch size 64 and sqrt LR scaling.
-    upstream_delta: Not applicable; this is a repo-local interaction probe between smooth-tail preprocessing and larger batch size.
-    expected_effect: Checks whether any zscore_tanh gains survive or improve at a larger, scaled batch.
+    description: Combine the favored smooth-tail zscore_tanh normalization with prior-dump
+      batch size 64 and sqrt LR scaling.
+    upstream_delta: Not applicable; this is a repo-local interaction probe between
+      smooth-tail preprocessing and larger batch size.
+    expected_effect: Checks whether any zscore_tanh gains survive or improve at a
+      larger, scaled batch.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - model.input_normalization
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Only interpret this row after comparing zscore_tanh itself against the anchor replay.
-        - Use it to decide whether batch size changes interact constructively with the smooth-tail row.
+      - Only interpret this row after comparing zscore_tanh itself against the anchor
+        replay.
+      - Use it to decide whether batch size changes interact constructively with the
+        smooth-tail row.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8371,27 +9392,33 @@ deltas:
         prior_dump_batch_size: 64
         prior_dump_lr_scale_rule: sqrt
         prior_dump_batch_reference_size: 32
-    default_next_action: Compare against the plain zscore_tanh row before concluding that batch size is part of the mechanism.
+    default_next_action: Compare against the plain zscore_tanh row before concluding
+      that batch size is part of the mechanism.
     applicability_guards: []
-
   dpnb_input_norm_none_batch64_sqrt:
     dimension_family: preprocessing
     family: input_normalization
     binary_applicable: true
-    description: Remove explicit input normalization on the batch64 sqrt-scaled bridge winner and keep the larger-batch surface fixed.
-    upstream_delta: Upstream nanoTabPFN keeps internal z-score-plus-clip handling on the exact path; this repo-local surface can disable explicit pre-encoder normalization entirely.
-    expected_effect: Tests whether batch size was the real driver of the gain and whether the batch64 winner can stay competitive without any explicit normalization.
+    description: Remove explicit input normalization on the batch64 sqrt-scaled bridge
+      winner and keep the larger-batch surface fixed.
+    upstream_delta: Upstream nanoTabPFN keeps internal z-score-plus-clip handling
+      on the exact path; this repo-local surface can disable explicit pre-encoder
+      normalization entirely.
+    expected_effect: Tests whether batch size was the real driver of the gain and
+      whether the batch64 winner can stay competitive without any explicit normalization.
     adequacy_knobs:
-      - model.input_normalization
+    - model.input_normalization
     parameter_adequacy_policy:
       default_plan:
-        - Keep the batch64 sqrt-scaled training surface identical to the clipped batch64 anchor.
-        - Compare final ROC AUC and drift directly against the batch64 clipped winner before simplifying the default preprocessing surface.
+      - Keep the batch64 sqrt-scaled training surface identical to the clipped batch64
+        anchor.
+      - Compare final ROC AUC and drift directly against the batch64 clipped winner
+        before simplifying the default preprocessing surface.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8428,35 +9455,41 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.005656854249492381
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Compare directly against the batch64 clipped winner and only keep `none` if it matches the benchmark surface closely enough to justify the simpler preprocessing.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.005656854249492381
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Compare directly against the batch64 clipped winner and only
+      keep `none` if it matches the benchmark surface closely enough to justify the
+      simpler preprocessing.
     applicability_guards: []
-
   dpnb_cuda_large_anchor:
     dimension_family: model
     family: size_scaling
     binary_applicable: true
-    description: Establish the large CUDA-sized bridge baseline on the stabilized prenorm plus row-cls recipe.
-    upstream_delta: Not applicable; this is a repo-local capacity expansion relative to the locked batch64 sqrt-scaled hybrid-diagnostic anchor.
-    expected_effect: A larger exact-prior trunk may improve quality if the hybrid-diagnostic surface is still capacity-limited at the current budget.
+    description: Establish the large CUDA-sized bridge baseline on the stabilized
+      prenorm plus row-cls recipe.
+    upstream_delta: Not applicable; this is a repo-local capacity expansion relative
+      to the locked batch64 sqrt-scaled hybrid-diagnostic anchor.
+    expected_effect: A larger exact-prior trunk may improve quality if the hybrid-diagnostic
+      surface is still capacity-limited at the current budget.
     adequacy_knobs:
-      - model.d_icl
-      - model.tficl_n_heads
-      - model.tficl_n_layers
-      - model.head_hidden_dim
+    - model.d_icl
+    - model.tficl_n_heads
+    - model.tficl_n_layers
+    - model.head_hidden_dim
     parameter_adequacy_policy:
       default_plan:
-        - Run this row first and treat it as the large-model comparator for the rest of the capacity pilot.
-        - Compare against the promoted batch64 sqrt-scaled anchor on the task-family primary metric first, then supporting diagnostics and training-time delta.
+      - Run this row first and treat it as the large-model comparator for the rest
+        of the capacity pilot.
+      - Compare against the promoted batch64 sqrt-scaled anchor on the task-family
+        primary metric first, then supporting diagnostics and training-time delta.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8498,34 +9531,36 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
     default_next_action: Run this row first to establish the large CUDA bridge baseline.
     applicability_guards: []
-
   dpnb_cuda_large_width_x2:
     dimension_family: model
     family: size_scaling
     binary_applicable: true
-    description: Double the large-anchor width-related capacity while keeping bridge modules and depth fixed.
-    upstream_delta: Not applicable; this is a repo-local width probe on the large bridge baseline.
-    expected_effect: More width may improve representation quality if the large anchor remains bottlenecked on hidden size rather than depth.
+    description: Double the large-anchor width-related capacity while keeping bridge
+      modules and depth fixed.
+    upstream_delta: Not applicable; this is a repo-local width probe on the large
+      bridge baseline.
+    expected_effect: More width may improve representation quality if the large anchor
+      remains bottlenecked on hidden size rather than depth.
     adequacy_knobs:
-      - model.d_col
-      - model.d_icl
-      - model.head_hidden_dim
+    - model.d_col
+    - model.d_icl
+    - model.head_hidden_dim
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the large-anchor row before reading the depth probe.
-        - Prefer width only if its benchmark gain survives the training-time cost.
+      - Compare directly against the large-anchor row before reading the depth probe.
+      - Prefer width only if its benchmark gain survives the training-time cost.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8567,32 +9602,35 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Compare against the large anchor before opening any width-only follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Compare against the large anchor before opening any width-only
+      follow-up.
     applicability_guards: []
-
   dpnb_cuda_large_depth_plus4:
     dimension_family: model
     family: size_scaling
     binary_applicable: true
-    description: Add four ICL transformer layers on top of the large CUDA bridge anchor while keeping width fixed.
-    upstream_delta: Not applicable; this is a repo-local depth probe on the large bridge baseline.
-    expected_effect: More depth may improve benchmark quality if the large anchor needs extra iterative processing more than extra width.
+    description: Add four ICL transformer layers on top of the large CUDA bridge anchor
+      while keeping width fixed.
+    upstream_delta: Not applicable; this is a repo-local depth probe on the large
+      bridge baseline.
+    expected_effect: More depth may improve benchmark quality if the large anchor
+      needs extra iterative processing more than extra width.
     adequacy_knobs:
-      - model.tficl_n_layers
+    - model.tficl_n_layers
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the large-anchor row after the width probe is available.
-        - Treat this as the depth sibling of the width row rather than a budget change.
+      - Compare directly against the large-anchor row after the width probe is available.
+      - Treat this as the depth sibling of the width row rather than a budget change.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8634,36 +9672,40 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Compare against the large anchor before deciding whether depth deserves a dedicated follow-up.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Compare against the large anchor before deciding whether
+      depth deserves a dedicated follow-up.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch64_noscale:
     dimension_family: training
     family: schedule
     binary_applicable: true
     description: Re-run the large CUDA bridge anchor at batch64 without sqrt LR scaling.
-    upstream_delta: Not applicable; this is a repo-local training-surface stabilization probe on the large CUDA anchor.
-    expected_effect: Lower effective LR should reduce activation drift if the copied batch64-sqrt surface is the main trigger.
+    upstream_delta: Not applicable; this is a repo-local training-surface stabilization
+      probe on the large CUDA anchor.
+    expected_effect: Lower effective LR should reduce activation drift if the copied
+      batch64-sqrt surface is the main trigger.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - training.prior_dump_batch_reference_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - training.prior_dump_batch_reference_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the stopped batch64-sqrt large-anchor diagnostic before reopening architecture.
-        - Use activation boundedness and clipping telemetry first, then benchmark quality only after the row looks trainable.
+      - Compare directly against the stopped batch64-sqrt large-anchor diagnostic
+        before reopening architecture.
+      - Use activation boundedness and clipping telemetry first, then benchmark quality
+        only after the row looks trainable.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8705,36 +9747,41 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Leave deferred unless the batch32 ladder settles cleanly and a non-fallback batch64 surface becomes worth revisiting.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Leave deferred unless the batch32 ladder settles cleanly
+      and a non-fallback batch64 surface becomes worth revisiting.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch64_noscale_lr3e3:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Re-run the large CUDA bridge anchor at batch64 without sqrt LR scaling and with a lower 3e-3 LR ceiling.
-    upstream_delta: Not applicable; this is a repo-local lower-LR neighbor for the large-anchor stability probe.
-    expected_effect: Further reducing the LR surface should help if the no-scale row is still too aggressive for the 12-layer CUDA anchor.
+    description: Re-run the large CUDA bridge anchor at batch64 without sqrt LR scaling
+      and with a lower 3e-3 LR ceiling.
+    upstream_delta: Not applicable; this is a repo-local lower-LR neighbor for the
+      large-anchor stability probe.
+    expected_effect: Further reducing the LR surface should help if the no-scale row
+      is still too aggressive for the 12-layer CUDA anchor.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - training.prior_dump_batch_reference_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - training.prior_dump_batch_reference_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the no-scale batch64 row before attributing any gain to architecture rather than LR.
-        - Prefer this row only if it improves boundedness without paying an obvious quality penalty.
+      - Compare against the no-scale batch64 row before attributing any gain to architecture
+        rather than LR.
+      - Prefer this row only if it improves boundedness without paying an obvious
+        quality penalty.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: deferred_separate_workstream
     default_initial_interpretation_status: blocked
@@ -8776,36 +9823,41 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.003
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Keep as deferred backlog evidence until the batch32 ladder resolves and batch64 is worth revisiting without first-attempt OOM fallback.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.003
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Keep as deferred backlog evidence until the batch32 ladder
+      resolves and batch64 is worth revisiting without first-attempt OOM fallback.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch32_replay:
     dimension_family: training
     family: batch_size
     binary_applicable: true
-    description: Re-run the large CUDA bridge anchor on the compact batch32 replay surface.
-    upstream_delta: Not applicable; this is a repo-local batch/LR-coupling probe on the large CUDA anchor.
-    expected_effect: Reverting to the batch32 replay surface should show whether the large CUDA anchor can train on the pre-batch64 baseline without reopening architecture.
+    description: Re-run the large CUDA bridge anchor on the compact batch32 replay
+      surface.
+    upstream_delta: Not applicable; this is a repo-local batch/LR-coupling probe on
+      the large CUDA anchor.
+    expected_effect: Reverting to the batch32 replay surface should show whether the
+      large CUDA anchor can train on the pre-batch64 baseline without reopening architecture.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - training.prior_dump_batch_reference_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - training.prior_dump_batch_reference_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the batch64 no-scale row to separate pure LR-surface effects from batch-size coupling.
-        - Treat this as the compact-surface replay for the large anchor, not as a new canonical system unless it is both stable and competitive.
+      - Compare against the batch64 no-scale row to separate pure LR-surface effects
+        from batch-size coupling.
+      - Treat this as the compact-surface replay for the large anchor, not as a new
+        canonical system unless it is both stable and competitive.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8847,36 +9899,41 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run this row first as the clean batch32 discriminator before spending more cycles on batch64 or architecture changes.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run this row first as the clean batch32 discriminator before
+      spending more cycles on batch64 or architecture changes.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch32_lr3e3:
     dimension_family: training
     family: schedule
     binary_applicable: true
-    description: Re-run the large CUDA bridge anchor on the compact batch32 replay surface with a lower 3e-3 LR ceiling.
-    upstream_delta: Not applicable; this is a repo-local lower-LR neighbor on the batch32 replay surface for the large CUDA anchor.
-    expected_effect: If the baseline batch32 replay still drifts, a milder LR surface may flatten upper-block norms without reopening architecture.
+    description: Re-run the large CUDA bridge anchor on the compact batch32 replay
+      surface with a lower 3e-3 LR ceiling.
+    upstream_delta: Not applicable; this is a repo-local lower-LR neighbor on the
+      batch32 replay surface for the large CUDA anchor.
+    expected_effect: If the baseline batch32 replay still drifts, a milder LR surface
+      may flatten upper-block norms without reopening architecture.
     adequacy_knobs:
-      - training.prior_dump_batch_size
-      - training.prior_dump_lr_scale_rule
-      - training.prior_dump_batch_reference_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - training.prior_dump_batch_size
+    - training.prior_dump_lr_scale_rule
+    - training.prior_dump_batch_reference_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare against the plain batch32 replay before attributing any stabilization gain to architecture rather than LR.
-        - Keep the large CUDA anchor architecture fixed so this row isolates LR-surface softness only.
+      - Compare against the plain batch32 replay before attributing any stabilization
+        gain to architecture rather than LR.
+      - Keep the large CUDA anchor architecture fixed so this row isolates LR-surface
+        softness only.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8918,35 +9975,40 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.003
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the plain batch32 replay if the clean batch32 surface still shows activation drift.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.003
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the plain batch32 replay if the clean batch32 surface
+      still shows activation drift.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch32_postrms:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Keep the large CUDA bridge anchor on the batch32 replay surface and add explicit post-encoder RMSNorm before the transformer blocks.
-    upstream_delta: Upstream nanoTabPFN does not expose this exact staged post-encoder normalization surface on the large CUDA bridge path.
-    expected_effect: RMSNorm may bound transformer-input scale on the large prenorm stack if the schedule-only batch32 rows still drift.
+    description: Keep the large CUDA bridge anchor on the batch32 replay surface and
+      add explicit post-encoder RMSNorm before the transformer blocks.
+    upstream_delta: Upstream nanoTabPFN does not expose this exact staged post-encoder
+      normalization surface on the large CUDA bridge path.
+    expected_effect: RMSNorm may bound transformer-input scale on the large prenorm
+      stack if the schedule-only batch32 rows still drift.
     adequacy_knobs:
-      - model.module_overrides.post_encoder_norm
-      - training.prior_dump_batch_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - model.module_overrides.post_encoder_norm
+    - training.prior_dump_batch_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare against both batch32 schedule rows before attributing any gain to architecture rather than LR softness.
-        - Keep the batch32 replay surface fixed so this row isolates post-encoder normalization family effects.
+      - Compare against both batch32 schedule rows before attributing any gain to
+        architecture rather than LR softness.
+      - Keep the batch32 replay surface fixed so this row isolates post-encoder normalization
+        family effects.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -8989,35 +10051,40 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the batch32 LR ladder if schedule-only changes still leave upward activation drift.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the batch32 LR ladder if schedule-only changes
+      still leave upward activation drift.
     applicability_guards: []
-
   dpnb_cuda_large_anchor_batch32_postln:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Keep the large CUDA bridge anchor on the batch32 replay surface and add explicit post-encoder LayerNorm before the transformer blocks.
-    upstream_delta: Upstream nanoTabPFN does not expose this exact staged post-encoder normalization surface on the large CUDA bridge path.
-    expected_effect: LayerNorm is the direct norm-family comparator to the RMSNorm probe if the first architecture-level stabilization row is mixed or still drifts.
+    description: Keep the large CUDA bridge anchor on the batch32 replay surface and
+      add explicit post-encoder LayerNorm before the transformer blocks.
+    upstream_delta: Upstream nanoTabPFN does not expose this exact staged post-encoder
+      normalization surface on the large CUDA bridge path.
+    expected_effect: LayerNorm is the direct norm-family comparator to the RMSNorm
+      probe if the first architecture-level stabilization row is mixed or still drifts.
     adequacy_knobs:
-      - model.module_overrides.post_encoder_norm
-      - training.prior_dump_batch_size
-      - training.overrides.optimizer.min_lr
-      - training.overrides.schedule.stages[0].lr_max
+    - model.module_overrides.post_encoder_norm
+    - training.prior_dump_batch_size
+    - training.overrides.optimizer.min_lr
+    - training.overrides.schedule.stages[0].lr_max
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the RMSNorm row on the same batch32 replay surface before preferring one normalization family.
-        - Keep the batch32 replay surface fixed so any change is attributable to the post-encoder norm choice.
+      - Compare directly against the RMSNorm row on the same batch32 replay surface
+        before preferring one normalization family.
+      - Keep the batch32 replay surface fixed so any change is attributable to the
+        post-encoder norm choice.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9060,34 +10127,39 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the RMSNorm row if you still need the direct post-encoder norm-family comparison on the batch32 surface.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the RMSNorm row if you still need the direct post-encoder
+      norm-family comparison on the batch32 surface.
     applicability_guards: []
-
   dpnb_cuda_stack_scale_control:
     dimension_family: training
     family: screening
     binary_applicable: true
-    description: Re-screen the large-anchor batch32 replay surface with a short activation-first diagnostic run.
-    upstream_delta: Not applicable; this is a repo-local control screen for the stack-scale follow-up.
-    expected_effect: Reconfirm the control upper-block activation drift on the short screen budget before reading any new stabilization change.
+    description: Re-screen the large-anchor batch32 replay surface with a short activation-first
+      diagnostic run.
+    upstream_delta: Not applicable; this is a repo-local control screen for the stack-scale
+      follow-up.
+    expected_effect: Reconfirm the control upper-block activation drift on the short
+      screen budget before reading any new stabilization change.
     adequacy_knobs:
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
-      - training.overrides.schedule.stages[0].warmup_ratio
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
+    - training.overrides.schedule.stages[0].warmup_ratio
     parameter_adequacy_policy:
       default_plan:
-        - Treat this row as the short-screen control, not as a benchmark-facing replacement for the registered anchor.
-        - Compare the same upper-block screen diagnostics against rows 2-4 before choosing any combined full-budget row.
+      - Treat this row as the short-screen control, not as a benchmark-facing replacement
+        for the registered anchor.
+      - Compare the same upper-block screen diagnostics against rows 2-4 before choosing
+        any combined full-budget row.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9129,34 +10201,39 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 1000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run this short-screen control first, then compare the two post-stack norm candidates before deciding on the combined benchmark row.
+            - name: prior_dump
+              steps: 1000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run this short-screen control first, then compare the two
+      post-stack norm candidates before deciding on the combined benchmark row.
     applicability_guards: []
-
   dpnb_cuda_stack_scale_poststack_rms:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Add post-stack RMSNorm after the prenorm table-block stack on the batch32 replay control screen.
-    upstream_delta: Upstream nanoTabPFN does not expose this staged post-stack normalization probe on the large-anchor bridge surface.
-    expected_effect: A post-stack RMSNorm may bound the exported residual stream even if internal prenorm blocks still grow.
+    description: Add post-stack RMSNorm after the prenorm table-block stack on the
+      batch32 replay control screen.
+    upstream_delta: Upstream nanoTabPFN does not expose this staged post-stack normalization
+      probe on the large-anchor bridge surface.
+    expected_effect: A post-stack RMSNorm may bound the exported residual stream even
+      if internal prenorm blocks still grow.
     adequacy_knobs:
-      - model.module_overrides.post_stack_norm
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - model.module_overrides.post_stack_norm
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the matching LayerNorm row on the same short-screen surface.
-        - Use the short-screen upper-block diagnostics to decide whether post-stack normalization is enough on its own.
+      - Compare directly against the matching LayerNorm row on the same short-screen
+        surface.
+      - Use the short-screen upper-block diagnostics to decide whether post-stack
+        normalization is enough on its own.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9199,34 +10276,39 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 1000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the short-screen control and compare directly against the LayerNorm variant before carrying one norm into a full benchmark row.
+            - name: prior_dump
+              steps: 1000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the short-screen control and compare directly against
+      the LayerNorm variant before carrying one norm into a full benchmark row.
     applicability_guards: []
-
   dpnb_cuda_stack_scale_poststack_ln:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Add post-stack LayerNorm after the prenorm table-block stack on the batch32 replay control screen.
-    upstream_delta: Upstream nanoTabPFN does not expose this staged post-stack normalization probe on the large-anchor bridge surface.
-    expected_effect: A post-stack LayerNorm is the direct norm-family comparator to the RMSNorm probe on the same short-screen surface.
+    description: Add post-stack LayerNorm after the prenorm table-block stack on the
+      batch32 replay control screen.
+    upstream_delta: Upstream nanoTabPFN does not expose this staged post-stack normalization
+      probe on the large-anchor bridge surface.
+    expected_effect: A post-stack LayerNorm is the direct norm-family comparator to
+      the RMSNorm probe on the same short-screen surface.
     adequacy_knobs:
-      - model.module_overrides.post_stack_norm
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - model.module_overrides.post_stack_norm
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the matching RMSNorm row on the same short-screen surface.
-        - Prefer the lower upper-block scale winner and only use training loss as a late tie-breaker.
+      - Compare directly against the matching RMSNorm row on the same short-screen
+        surface.
+      - Prefer the lower upper-block scale winner and only use training loss as a
+        late tie-breaker.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9269,34 +10351,39 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 1000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the RMSNorm short screen so the post-stack norm family comparison is available for a winner-take-forward decision.
+            - name: prior_dump
+              steps: 1000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the RMSNorm short screen so the post-stack norm
+      family comparison is available for a winner-take-forward decision.
     applicability_guards: []
-
   dpnb_cuda_stack_scale_depth_scaled:
     dimension_family: model
     family: residual_scaling
     binary_applicable: true
-    description: Keep the batch32 replay control screen fixed and depth-scale each prenorm residual branch by stack depth.
-    upstream_delta: Upstream nanoTabPFN does not expose this staged depth-scaled prenorm residual probe on the large-anchor bridge surface.
-    expected_effect: Depth-scaled residual branches should target the source of the in-stack activation ratchet more directly than a final normalization alone.
+    description: Keep the batch32 replay control screen fixed and depth-scale each
+      prenorm residual branch by stack depth.
+    upstream_delta: Upstream nanoTabPFN does not expose this staged depth-scaled prenorm
+      residual probe on the large-anchor bridge surface.
+    expected_effect: Depth-scaled residual branches should target the source of the
+      in-stack activation ratchet more directly than a final normalization alone.
     adequacy_knobs:
-      - model.module_overrides.table_block_residual_scale
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - model.module_overrides.table_block_residual_scale
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Compare directly against the control and post-stack norm rows on the same short-screen surface.
-        - Use this row to test root-cause stabilization before spending a full benchmark row on a combined intervention.
+      - Compare directly against the control and post-stack norm rows on the same
+        short-screen surface.
+      - Use this row to test root-cause stabilization before spending a full benchmark
+        row on a combined intervention.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9339,35 +10426,42 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 1000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Run after the norm-family screens so the final full-budget row can combine depth scaling with the winning post-stack norm if needed.
+            - name: prior_dump
+              steps: 1000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Run after the norm-family screens so the final full-budget
+      row can combine depth scaling with the winning post-stack norm if needed.
     applicability_guards: []
-
   dpnb_cuda_stack_scale_depth_scaled_plus_norm_winner:
     dimension_family: model
     family: normalization
     binary_applicable: true
-    description: Run the full batch32 replay benchmark with depth-scaled prenorm residuals plus whichever post-stack norm wins the short-screen comparison.
-    upstream_delta: Not applicable; this is the combined full-budget follow-up row derived from the repo-local stack-scale screens.
-    expected_effect: The combined row should test whether root-cause residual scaling plus the better downstream stack export norm is enough to produce a benchmarkable large-anchor candidate.
+    description: Run the full batch32 replay benchmark with depth-scaled prenorm residuals
+      plus whichever post-stack norm wins the short-screen comparison.
+    upstream_delta: Not applicable; this is the combined full-budget follow-up row
+      derived from the repo-local stack-scale screens.
+    expected_effect: The combined row should test whether root-cause residual scaling
+      plus the better downstream stack export norm is enough to produce a benchmarkable
+      large-anchor candidate.
     adequacy_knobs:
-      - model.module_overrides.table_block_residual_scale
-      - model.module_overrides.post_stack_norm
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - model.module_overrides.table_block_residual_scale
+    - model.module_overrides.post_stack_norm
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Resolve the winning post-stack norm from rows 2-3 using upper-block final-window scale first, then post-warmup slope, then clip rate, then loss EMA, with RMSNorm as the final tie-breaker.
-        - Benchmark only this combined row at full budget after the short-screen control and component rows complete.
+      - Resolve the winning post-stack norm from rows 2-3 using upper-block final-window
+        scale first, then post-warmup slope, then clip rate, then loss EMA, with RMSNorm
+        as the final tie-breaker.
+      - Benchmark only this combined row at full budget after the short-screen control
+        and component rows complete.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: ready
     default_initial_interpretation_status: pending
@@ -9410,33 +10504,38 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 2500
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Wait for the short-screen norm comparison to resolve, then benchmark the combined depth-scaled row with the winning post-stack norm.
+            - name: prior_dump
+              steps: 2500
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Wait for the short-screen norm comparison to resolve, then
+      benchmark the combined depth-scaled row with the winning post-stack norm.
     applicability_guards: []
-
   dpnb_cuda_budget_5k:
     dimension_family: training
     family: budget
     binary_applicable: true
-    description: Re-run the chosen large-capacity bridge row for 5000 steps under the same optimizer and schedule family.
-    upstream_delta: Not applicable; this is a repo-local training-budget adequacy probe.
-    expected_effect: If the chosen capacity row is compute-limited at 2500 steps, doubling the budget should improve the task-family primary final metric without changing the mechanism family.
+    description: Re-run the chosen large-capacity bridge row for 5000 steps under
+      the same optimizer and schedule family.
+    upstream_delta: Not applicable; this is a repo-local training-budget adequacy
+      probe.
+    expected_effect: If the chosen capacity row is compute-limited at 2500 steps,
+      doubling the budget should improve the task-family primary final metric without
+      changing the mechanism family.
     adequacy_knobs:
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Re-anchor this row to the winning capacity architecture before execution.
-        - Compare against the chosen 2500-step capacity row and treat any gain as budget adequacy evidence only.
+      - Re-anchor this row to the winning capacity architecture before execution.
+      - Compare against the chosen 2500-step capacity row and treat any gain as budget
+        adequacy evidence only.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_anchor_selection
     default_initial_interpretation_status: blocked
@@ -9478,33 +10577,36 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 5000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Wait for the capacity pilot winner, then bind this row to that architecture before running it.
+            - name: prior_dump
+              steps: 5000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Wait for the capacity pilot winner, then bind this row to
+      that architecture before running it.
     applicability_guards: []
-
   dpnb_cuda_budget_10k:
     dimension_family: training
     family: budget
     binary_applicable: true
-    description: Re-run the chosen large-capacity bridge row for 10000 steps under the same optimizer and schedule family.
-    upstream_delta: Not applicable; this is a repo-local training-budget adequacy probe.
-    expected_effect: Further budget may help only if the chosen capacity row still looks compute-limited after the 5000-step rerun.
+    description: Re-run the chosen large-capacity bridge row for 10000 steps under
+      the same optimizer and schedule family.
+    upstream_delta: Not applicable; this is a repo-local training-budget adequacy
+      probe.
+    expected_effect: Further budget may help only if the chosen capacity row still
+      looks compute-limited after the 5000-step rerun.
     adequacy_knobs:
-      - training.overrides.runtime.max_steps
-      - training.overrides.schedule.stages[0].steps
+    - training.overrides.runtime.max_steps
+    - training.overrides.schedule.stages[0].steps
     parameter_adequacy_policy:
       default_plan:
-        - Re-anchor this row to the winning capacity architecture before execution.
-        - Use it only after the 5000-step row still shows headroom.
+      - Re-anchor this row to the winning capacity architecture before execution.
+      - Use it only after the 5000-step row still shows headroom.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_anchor_selection
     default_initial_interpretation_status: blocked
@@ -9546,31 +10648,34 @@ deltas:
             trace_activations: true
           schedule:
             stages:
-              - name: prior_dump
-                steps: 10000
-                lr_max: 0.004
-                lr_schedule: linear
-                warmup_ratio: 0.05
-    default_next_action: Keep this row blocked unless the 5000-step rerun still looks compute-limited.
+            - name: prior_dump
+              steps: 10000
+              lr_max: 0.004
+              lr_schedule: linear
+              warmup_ratio: 0.05
+    default_next_action: Keep this row blocked unless the 5000-step rerun still looks
+      compute-limited.
     applicability_guards: []
-
   delta_preproc_label_mapping_surface:
     dimension_family: preprocessing
     family: label_mapping
     binary_applicable: true
-    description: Compare the current train-only remap/filter label policy against an alternate surfaced label-mapping policy.
-    upstream_delta: Upstream notebook code does not expose this repo-local label-policy contract as a benchmarkable axis.
+    description: Compare the current train-only remap/filter label policy against
+      an alternate surfaced label-mapping policy.
+    upstream_delta: Upstream notebook code does not expose this repo-local label-policy
+      contract as a benchmarkable axis.
     expected_effect: Unknown until an alternate policy is implemented.
     adequacy_knobs:
-      - Must record how unseen test labels are handled and whether the effective task definition changes.
+    - Must record how unseen test labels are handled and whether the effective task
+      definition changes.
     parameter_adequacy_policy:
       default_plan:
-        - Do not run until a real alternative policy exists.
+      - Do not run until a real alternative policy exists.
       default_negative_decision: defer
       reject_requires:
-        - isolated_change
-        - adequacy_plan_complete
-        - clearly_worse_without_offsetting_benefit
+      - isolated_change
+      - adequacy_plan_complete
+      - clearly_worse_without_offsetting_benefit
     legacy_stage_alias: none
     default_initial_status: blocked_on_policy_impl
     default_initial_interpretation_status: blocked
@@ -9584,5 +10689,210 @@ deltas:
         overrides:
           label_mapping: train_only_remap
           unseen_test_label_policy: filter
-    default_next_action: Add a second supported label policy before activating this row.
+    default_next_action: Add a second supported label policy before activating this
+      row.
+    applicability_guards: []
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+      batch fixed while transferring Muon momentum and lr with budget.
+    upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+    expected_effect: If the paper fixed-batch transfer law is the better inductive
+      bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local
+      retuning.
+    adequacy_knobs:
+    - paper-derived budget transfer law
+    - corrected openml_classification_medium_v1 anchor benchmark
+    - 144x4 geometry held fixed
+    default_effective_surface:
+      model:
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        many_class_base: 10
+        head_hidden_dim: 96
+        sandwich_latents: 24
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        d_icl: 144
+        sandwich_layers: 4
+      data:
+        surface_label: tf_rd_010_dagzoo_medium_control
+        source: manifest
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      preprocessing:
+        surface_label: runtime_default
+      training:
+        surface_label: prior_cosine_warmup
+        task_batch_size: 16
+        prior_dump_batch_size: 64
+        overrides:
+          optimizer:
+            name: muon
+            require_requested: true
+            weight_decay: 0.01
+            betas:
+            - 0.9
+            - 0.95
+            min_lr: 1.0e-06
+            muon_per_parameter_lr: true
+            muon_lr_scale_base: 0.2
+            muon_partition_non2d: true
+          runtime:
+            mixed_precision: bf16
+            grad_clip: 0.0
+            trace_activations: false
+            activation_checkpointing: true
+            eval_every: 25
+            checkpoint_every: 25
+            val_batches: 0
+            loader_task_batch_cache: false
+            loader_task_batch_cache_mode: bounded_streaming
+            num_workers: auto
+            loader_pin_memory: true
+            loader_persistent_workers: false
+            loader_prefetch_factor: auto
+            non_blocking_device_transfer: true
+            compile_model: true
+            compile_backend: eager
+            compile_dynamic: true
+            compile_shape_dispatch_mode: signature_family
+            compile_shape_dispatch_max_families: 16
+            signature_family_run_length: 4
+            grad_accum_steps: 4
+            max_steps: 5000
+          schedule:
+            stages:
+            - name: prior_dump
+              steps: 5000
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+        one_epoch_contract:
+          enabled: true
+          scope: train_manifest_unique_tasks
+          required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+          corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+          largest_required_train_tasks: 1280000
+          expected_train_records_available: 1344081
+    parameter_adequacy_policy:
+      default_plan: []
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Screen the faithful transfer candidates for regime B on T0,
+      then carry only the winning anchor into tf_rd_009_muon_training_dynamics_transfer_medium_v1.
+    applicability_guards: []
+  delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1:
+    dimension_family: training
+    family: classification_scaling_law
+    binary_applicable: false
+    description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+      effective batch, Muon momentum, and lr with budget.
+    upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+    expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+      bias, the screened T0 anchor should beat both carried baselines on corrected
+      benchmark log loss.
+    adequacy_knobs:
+    - paper-derived budget transfer law
+    - corrected openml_classification_medium_v1 anchor benchmark
+    - 144x4 geometry held fixed
+    default_effective_surface:
+      model:
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        many_class_base: 10
+        head_hidden_dim: 96
+        sandwich_latents: 24
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        d_icl: 144
+        sandwich_layers: 4
+      data:
+        surface_label: tf_rd_010_dagzoo_medium_control
+        source: manifest
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        surface_overrides:
+          source: manifest
+          corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      preprocessing:
+        surface_label: runtime_default
+      training:
+        surface_label: prior_cosine_warmup
+        task_batch_size: 16
+        prior_dump_batch_size: 64
+        overrides:
+          optimizer:
+            name: muon
+            require_requested: true
+            weight_decay: 0.01
+            betas:
+            - 0.9
+            - 0.95
+            min_lr: 1.0e-06
+            muon_per_parameter_lr: true
+            muon_lr_scale_base: 0.2
+            muon_partition_non2d: true
+          runtime:
+            mixed_precision: bf16
+            grad_clip: 0.0
+            trace_activations: false
+            activation_checkpointing: true
+            eval_every: 25
+            checkpoint_every: 25
+            val_batches: 0
+            loader_task_batch_cache: false
+            loader_task_batch_cache_mode: bounded_streaming
+            num_workers: auto
+            loader_pin_memory: true
+            loader_persistent_workers: false
+            loader_prefetch_factor: auto
+            non_blocking_device_transfer: true
+            compile_model: true
+            compile_backend: eager
+            compile_dynamic: true
+            compile_shape_dispatch_mode: signature_family
+            compile_shape_dispatch_max_families: 16
+            signature_family_run_length: 4
+            grad_accum_steps: 4
+            max_steps: 5000
+          schedule:
+            stages:
+            - name: prior_dump
+              steps: 5000
+              lr_max: 0.001
+              lr_schedule: linear
+              warmup_ratio: 0.1
+        one_epoch_contract:
+          enabled: true
+          scope: train_manifest_unique_tasks
+          required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+          corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+          largest_required_train_tasks: 1280000
+          expected_train_records_available: 1344081
+    parameter_adequacy_policy:
+      default_plan: []
+    default_initial_status: ready
+    default_initial_interpretation_status: pending
+    default_next_action: Screen the faithful transfer candidates for regime D on T0,
+      then carry only the winning anchor into tf_rd_009_muon_training_dynamics_transfer_medium_v1.
     applicability_guards: []

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -501,7 +501,7 @@ sweeps:
     external_benchmarks: []
   tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1:
     parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-    status: draft
+    status: superseded
     anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -509,6 +509,14 @@ sweeps:
     external_benchmarks: []
   tf_rd_009_muon_training_dynamics_transfer_medium_v1:
     parent_sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    status: superseded
+    anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+    complexity_level: classification_md
+    benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+    external_benchmarks: []
+  tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1:
+    parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
     status: draft
     anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
     complexity_level: classification_md

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -477,7 +477,7 @@ sweeps:
     external_benchmarks: []
   tf_rd_009_muon_training_dynamics_endpoint_medium_v1:
     parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-    status: draft
+    status: superseded
     anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -495,6 +495,22 @@ sweeps:
     parent_sweep_id: tf_rd_009_muon_width_depth_upper_extension_one_epoch_medium_v1
     status: draft
     anchor_run_id: null
+    complexity_level: classification_md
+    benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+    external_benchmarks: []
+  tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1:
+    parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+    status: draft
+    anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+    complexity_level: classification_md
+    benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+    control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+    external_benchmarks: []
+  tf_rd_009_muon_training_dynamics_transfer_medium_v1:
+    parent_sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    status: draft
+    anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
     control_baseline_id: cls_benchmark_linear_multiclass_medium_v1

--- a/reference/system_delta_sweeps/index.yaml
+++ b/reference/system_delta_sweeps/index.yaml
@@ -517,7 +517,7 @@ sweeps:
     external_benchmarks: []
   tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1:
     parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-    status: draft
+    status: completed
     anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
     complexity_level: classification_md
     benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/matrix.md
@@ -9,7 +9,7 @@ This file is rendered from `reference/system_delta_sweeps/tf_rd_009_muon_trainin
 - Parent sweep id: `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
 - Complexity level: `classification_md`
 - Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml`
-- Resolved queue inputs fingerprint: `93c50ed09ab4c89cb673c50762262e5b366354859f8aa06adcf06de34e53982d`
+- Resolved queue inputs fingerprint: `3e5b84a48c28a5249692d97cceabdd9e830d83d9698a12925b983bded803d5e4`
 
 ## Locked Surface
 
@@ -37,13 +37,13 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 | 1 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
 | 2 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
 | 3 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
-| 4 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
-| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
-| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
-| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
-| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
-| 9 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
-| 10 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 4 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | completed | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | completed | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | completed | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | completed | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | completed | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 9 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | completed | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 10 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | completed | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
 
 ## Detailed Rows
 
@@ -60,7 +60,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
 - Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved surface fingerprint: `de7f9bcc50164afee6aecb2ab285aa3712199e2515bc802f34e5d22b9a50fa24`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
 - Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
 - Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
@@ -109,7 +109,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
 - Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `c4930ff2cd45ed5cbe10bc853eb181e43201c6a89c7ee86ae7b608df225e9ccd`
+- Resolved surface fingerprint: `f03fac3f7e2535a3c9453c64156e55cdc99235f322da2785e3f6b87ef0aa7091`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2500}`
 - Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
 - Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
@@ -158,7 +158,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
 - Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d`
+- Resolved surface fingerprint: `65cdcb0232f5484c99af1b832fdea11d501e5d798d79baab89066514107506a4`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
 - Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
 - Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
@@ -197,7 +197,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 ### 4. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
@@ -207,7 +207,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
 - Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `07d38633c5b9e05798095e8fd8a85279f9eb442a88381f66864d11a25d4ab0e9`
+- Resolved surface fingerprint: `883ad6e9806e19ebe246186acb97e5ffd74d00571cc47d9dd68f6ff5ad0e2188`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 156}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 156}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 156, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 40000, 'realized_effective_budget': 39936, 'budget_drift': -0.0016000000000000458, 'batch_drift': 0.0}`
@@ -222,19 +222,21 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - empirical high-batch reference only; no broader optimizer reopen
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1` with final log loss `0.7299`, delta final log loss `+0.3348`, final Brier score `0.4575`, delta final brier score `+0.1990`, final ROC AUC `0.5093`, delta final roc auc `-0.2490`, final BPC (legacy feature-cell diagnostic) `2.1843`, delta final bpc (legacy feature-cell diagnostic) `+0.0460`, final BPF (legacy feature-cell diagnostic) `2.1843`, delta final bpf (legacy feature-cell diagnostic) `+0.0460`, best ROC AUC `0.5093`, delta final training time `-8163.0s`
 
 ### 5. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
@@ -244,7 +246,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
 - Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `8f07b12c8809233dd626a6e00b4fea37644d2bd014798857d85d2443dac4440f`
+- Resolved surface fingerprint: `b3a0260df59fdd126779e4e2c182a40246d1f7c5fbc1f596e1b7720467a451ba`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 160000, 'realized_effective_budget': 160000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
@@ -259,19 +261,21 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - empirical high-batch reference only; no broader optimizer reopen
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1` with final log loss `0.5848`, delta final log loss `+0.1897`, final Brier score `0.3596`, delta final brier score `+0.1011`, final ROC AUC `0.7213`, delta final roc auc `-0.0370`, final BPC (legacy feature-cell diagnostic) `2.2516`, delta final bpc (legacy feature-cell diagnostic) `+0.1134`, final BPF (legacy feature-cell diagnostic) `2.2516`, delta final bpf (legacy feature-cell diagnostic) `+0.1133`, best ROC AUC `0.7213`, delta final training time `-7022.9s`
 
 ### 6. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
@@ -281,7 +285,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
 - Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `05faa2cd610b3208f72916bef78cb0beb436f3a289b4d483370cad05e09b4988`
+- Resolved surface fingerprint: `33f0bf64bd3ff793f33c07ea319ab9088030c4018330e2a1830e92f8bb011a23`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 1250}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 1250}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 1250, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 320000, 'realized_effective_budget': 320000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
@@ -296,19 +300,21 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - empirical high-batch reference only; no broader optimizer reopen
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1` with final log loss `0.5135`, delta final log loss `+0.1185`, final Brier score `0.3129`, delta final brier score `+0.0544`, final ROC AUC `0.7709`, delta final roc auc `+0.0126`, final BPC (legacy feature-cell diagnostic) `2.2867`, delta final bpc (legacy feature-cell diagnostic) `+0.1484`, final BPF (legacy feature-cell diagnostic) `2.2866`, delta final bpf (legacy feature-cell diagnostic) `+0.1484`, best ROC AUC `0.7709`, delta final training time `-5582.6s`
 
 ### 7. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
@@ -318,7 +324,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T1.
 - Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without local retuning.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `52a7a31f13b3d6c11dd9239ded32f13a215da2b8f44d9bb3efec3002ba0d7c12`
+- Resolved surface fingerprint: `e05b59969d4d30ade39ab6c72c6b81af11ae89384b403a4b1bca307839400639`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2500}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 3.5355339059327384e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 2500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2500, 'lr_max': 0.0003535533905932738, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'B', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
@@ -334,20 +340,22 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - 144x4 geometry held fixed
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1` with final log loss `0.5239`, delta final log loss `+0.1288`, final Brier score `0.3182`, delta final brier score `+0.0597`, final ROC AUC `0.7707`, delta final roc auc `+0.0124`, final BPC (legacy feature-cell diagnostic) `2.2886`, delta final bpc (legacy feature-cell diagnostic) `+0.1503`, final BPF (legacy feature-cell diagnostic) `2.2886`, delta final bpf (legacy feature-cell diagnostic) `+0.1503`, best ROC AUC `0.7707`, delta final training time `-6946.0s`
 
 ### 8. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
@@ -357,7 +365,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T2.
 - Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without local retuning.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `90f46b16e7a68ad05bac9b9476347cadc60d270c4cbc8bce67b7e1284939802a`
+- Resolved surface fingerprint: `484026daee134d5be03f54ebcb9f212fdcedc1ddc5410f64151e5b2515df45de`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2.1022410381342863e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9823223304703363}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.00021022410381342862, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'B', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
@@ -373,20 +381,22 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - 144x4 geometry held fixed
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1` with final log loss `0.5143`, delta final log loss `+0.1193`, final Brier score `0.3131`, delta final brier score `+0.0546`, final ROC AUC `0.7760`, delta final roc auc `+0.0177`, final BPC (legacy feature-cell diagnostic) `2.3096`, delta final bpc (legacy feature-cell diagnostic) `+0.1714`, final BPF (legacy feature-cell diagnostic) `2.3096`, delta final bpf (legacy feature-cell diagnostic) `+0.1713`, best ROC AUC `0.7760`, delta final training time `-5345.0s`
 
 ### 9. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
@@ -396,7 +406,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T1.
 - Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the strict shared T0 anchor transfer should beat both carried baselines on corrected benchmark log loss.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `baefd0b2c2c956be40d031eda08bf5f16b7aba46eb935b0b929195aee58be3c7`
+- Resolved surface fingerprint: `16a01b331044af04043584bd443a4c6a8c0456de6b235643783d43bfe6663a79`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2000}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 4.4544935907016965e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9685019737526281}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 2000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2000, 'lr_max': 0.00044544935907016964, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'D', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
@@ -412,20 +422,22 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - 144x4 geometry held fixed
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1` with final log loss `0.5269`, delta final log loss `+0.1318`, final Brier score `0.3209`, delta final brier score `+0.0624`, final ROC AUC `0.7643`, delta final roc auc `+0.0060`, final BPC (legacy feature-cell diagnostic) `2.2494`, delta final bpc (legacy feature-cell diagnostic) `+0.1112`, final BPF (legacy feature-cell diagnostic) `2.2494`, delta final bpf (legacy feature-cell diagnostic) `+0.1111`, best ROC AUC `0.7643`, delta final training time `-7003.0s`
 
 ### 10. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
 
 - Dimension family: `training`
-- Status: `ready`
+- Status: `completed`
 - Binary applicable: `False`
 - Recipe alias: `none`
 - Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
@@ -435,7 +447,7 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
 - Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T2.
 - Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the strict shared T0 anchor transfer should beat both carried baselines on corrected benchmark log loss.
 - Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
-- Resolved surface fingerprint: `91b360b6bd1ad5ef9e56441aa71787fb618e33a5b3cf59c7dfcb3e31091f1c7e`
+- Resolved surface fingerprint: `2c8099dab822992c163bc055c351d4386b1ebf6753b8ee98086c227f7123ede9`
 - Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 3333}`
 - Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2.9730177875068024e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 3333}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 3333, 'lr_max': 0.00029730177875068024, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
 - Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'D', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
@@ -451,12 +463,14 @@ Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimizatio
   - 144x4 geometry held fixed
 - Execution policy: `benchmark_full`
 - Benchmark checkpoint selection: `best_and_final`
-- Interpretation status: `pending`
-- Decision: `None`
+- Interpretation status: `completed`
+- Decision: `defer`
 - Notes:
   - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
 - Follow-up run ids: `[]`
 - Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
-- Benchmark metrics: pending
+- Registered run: `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1` with final log loss `0.5170`, delta final log loss `+0.1219`, final Brier score `0.3144`, delta final brier score `+0.0558`, final ROC AUC `0.7736`, delta final roc auc `+0.0153`, final BPC (legacy feature-cell diagnostic) `2.3645`, delta final bpc (legacy feature-cell diagnostic) `+0.2262`, final BPF (legacy feature-cell diagnostic) `2.3645`, delta final bpf (legacy feature-cell diagnostic) `+0.2262`, best ROC AUC `0.7736`, delta final training time `-5498.1s`

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/matrix.md
@@ -1,0 +1,462 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml` (derived from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml` plus `reference/system_delta_catalog.yaml`) and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`
+- Sweep status: `draft`
+- Parent sweep id: `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
+- Complexity level: `classification_md`
+- Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml`
+- Resolved queue inputs fingerprint: `93c50ed09ab4c89cb673c50762262e5b366354859f8aa06adcf06de34e53982d`
+
+## Locked Surface
+
+- Anchor run id: `sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+- Benchmark manifest: local benchmark-manifest id `openml_classification_medium_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_medium_v1`
+- External benchmarks: `none`
+- Training experiment: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Training config profile: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Surface role: `classification_training_dynamics_transfer`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final BPC `2.1383`, final BPF `2.1383`, final log loss `0.3951`, final Brier score `0.2585`, best ROC AUC `0.7563`, final ROC AUC `0.7583`, final training time `8686.8s`
+
+## Anchor Comparison
+
+Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimization Theory` from `https://arxiv.org/abs/2603.15958`.
+
+| Dimension | Upstream Deriving Hyperparameter Scaling Laws via Modern Optimization Theory | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
+| 2 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
+| 3 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining. |
+| 4 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss. |
+| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 9 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+| 10 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget. |
+
+## Detailed Rows
+
+### 1. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.6461` (step 625)
+  - Final log loss: `0.6461`
+  - Final Brier score: `0.4026`
+  - Final ROC AUC: `0.6658`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `2.1886`
+  - Final BPF (legacy feature-cell diagnostic): `2.1886`
+  - max_grad_norm: `3.595`
+
+### 2. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `c4930ff2cd45ed5cbe10bc853eb181e43201c6a89c7ee86ae7b608df225e9ccd`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2500}`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 160000, 'realized_effective_budget': 160000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 11, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.5079` (step 2500)
+  - Final log loss: `0.5079`
+  - Final Brier score: `0.3095`
+  - Final ROC AUC: `0.7719`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `2.3965`
+  - Final BPF (legacy feature-cell diagnostic): `2.3965`
+  - max_grad_norm: `4.271`
+
+### 3. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 320000, 'realized_effective_budget': 320000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 12, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.4914` (step 5000)
+  - Final log loss: `0.4914`
+  - Final Brier score: `0.2989`
+  - Final ROC AUC: `0.7866`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `3.0328`
+  - Final BPF (legacy feature-cell diagnostic): `3.0327`
+  - max_grad_norm: `2.936`
+
+### 4. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `07d38633c5b9e05798095e8fd8a85279f9eb442a88381f66864d11a25d4ab0e9`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 156}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 156}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 156, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 40000, 'realized_effective_budget': 39936, 'budget_drift': -0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 5. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `8f07b12c8809233dd626a6e00b4fea37644d2bd014798857d85d2443dac4440f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 160000, 'realized_effective_budget': 160000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 6. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `05faa2cd610b3208f72916bef78cb0beb436f3a289b4d483370cad05e09b4988`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 16, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 1250}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 1250}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 1250, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 320000, 'realized_effective_budget': 320000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 7. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
+- Hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T1.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `52a7a31f13b3d6c11dd9239ded32f13a215da2b8f44d9bb3efec3002ba0d7c12`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 3.5355339059327384e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 2500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2500, 'lr_max': 0.0003535533905932738, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'B', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'paper regime B shared-anchor transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'shared_anchor_regime_b', 'target_effective_budget': 160000}`
+- Transfer resolution: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'Theorem 2 fixed-batch transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'shared_anchor_regime_b', 'target_effective_budget': 160000, 'base_effective_budget': 40000, 'realized_effective_budget': 160000, 'base_effective_batch': 64, 'target_effective_batch': 64.0, 'realized_effective_batch': 64, 'base_lr_max': 0.001, 'target_lr_max': 0.0003535533905932738, 'base_momentum': 0.95, 'target_momentum': 0.975, 'base_alpha': 0.050000000000000044, 'target_alpha': 0.025000000000000022, 'grad_accum_steps': 4, 'max_steps': 2500, 'min_lr': 3.5355339059327384e-07, 'budget_drift': 0.0, 'batch_drift': 0.0, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor', 'shared_anchor_provenance': {'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_order': 1, 'anchor_delta_id': 'delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1', 'anchor_run_dir': 'outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train', 'anchor_imported_baseline_provenance': {'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}, 'anchor_candidate_label': 'carry_lowbatch_shared_anchor_t0'}}`
+- Parameter adequacy plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 8. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
+- Hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T2.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `90f46b16e7a68ad05bac9b9476347cadc60d270c4cbc8bce67b7e1284939802a`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 5000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2.1022410381342863e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9823223304703363}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.00021022410381342862, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'B', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'paper regime B shared-anchor transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'shared_anchor_regime_b', 'target_effective_budget': 320000}`
+- Transfer resolution: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'Theorem 2 fixed-batch transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'shared_anchor_regime_b', 'target_effective_budget': 320000, 'base_effective_budget': 40000, 'realized_effective_budget': 320000, 'base_effective_batch': 64, 'target_effective_batch': 64.0, 'realized_effective_batch': 64, 'base_lr_max': 0.001, 'target_lr_max': 0.00021022410381342862, 'base_momentum': 0.95, 'target_momentum': 0.9823223304703363, 'base_alpha': 0.050000000000000044, 'target_alpha': 0.017677669529663705, 'grad_accum_steps': 4, 'max_steps': 5000, 'min_lr': 2.1022410381342863e-07, 'budget_drift': 0.0, 'batch_drift': 0.0, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor', 'shared_anchor_provenance': {'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_order': 1, 'anchor_delta_id': 'delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1', 'anchor_run_dir': 'outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train', 'anchor_imported_baseline_provenance': {'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}, 'anchor_candidate_label': 'carry_lowbatch_shared_anchor_t0'}}`
+- Parameter adequacy plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 9. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
+- Hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T1.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the strict shared T0 anchor transfer should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `baefd0b2c2c956be40d031eda08bf5f16b7aba46eb935b0b929195aee58be3c7`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 2000}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 4.4544935907016965e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9685019737526281}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 2000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2000, 'lr_max': 0.00044544935907016964, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'D', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'paper regime D shared-anchor transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'shared_anchor_regime_d', 'target_effective_budget': 160000}`
+- Transfer resolution: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'Theorem 3 joint-transfer proxy', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'shared_anchor_regime_d', 'target_effective_budget': 160000, 'base_effective_budget': 40000, 'realized_effective_budget': 160000, 'base_effective_batch': 64, 'target_effective_batch': 80.63494719327188, 'realized_effective_batch': 80, 'base_lr_max': 0.001, 'target_lr_max': 0.00044544935907016964, 'base_momentum': 0.95, 'target_momentum': 0.9685019737526281, 'base_alpha': 0.050000000000000044, 'target_alpha': 0.03149802624737186, 'grad_accum_steps': 5, 'max_steps': 2000, 'min_lr': 4.4544935907016965e-07, 'budget_drift': 0.0, 'batch_drift': -0.007874342519875399, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor', 'shared_anchor_provenance': {'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_order': 1, 'anchor_delta_id': 'delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1', 'anchor_run_dir': 'outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train', 'anchor_imported_baseline_provenance': {'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}, 'anchor_candidate_label': 'carry_lowbatch_shared_anchor_t0'}}`
+- Parameter adequacy plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 10. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
+- Hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T2.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the strict shared T0 anchor transfer should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `91b360b6bd1ad5ef9e56441aa71787fb618e33a5b3cf59c7dfcb3e31091f1c7e`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 3333}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2.9730177875068024e-07, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 3333}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 3333, 'lr_max': 0.00029730177875068024, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'shared_anchor_transfer', 'anchor_order': 1, 'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_label': 'carry_lowbatch_shared_anchor_t0', 'regime_label': 'D', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'paper regime D shared-anchor transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'shared_anchor_regime_d', 'target_effective_budget': 320000}`
+- Transfer resolution: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'Theorem 3 joint-transfer proxy', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'shared_anchor_regime_d', 'target_effective_budget': 320000, 'base_effective_budget': 40000, 'realized_effective_budget': 319968, 'base_effective_batch': 64, 'target_effective_batch': 90.50966799187808, 'realized_effective_batch': 96, 'base_lr_max': 0.001, 'target_lr_max': 0.00029730177875068024, 'base_momentum': 0.95, 'target_momentum': 0.975, 'base_alpha': 0.050000000000000044, 'target_alpha': 0.025000000000000022, 'grad_accum_steps': 6, 'max_steps': 3333, 'min_lr': 2.9730177875068024e-07, 'budget_drift': -9.999999999998899e-05, 'batch_drift': 0.060660171779821415, 'resolved_from_order': 1, 'resolved_from_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'resolved_candidate_label': 'carry_lowbatch_shared_anchor_t0', 'resolution_reason': 'shared_anchor', 'shared_anchor_provenance': {'anchor_sweep_id': 'tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1', 'anchor_order': 1, 'anchor_delta_id': 'delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1', 'anchor_run_dir': 'outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train', 'anchor_imported_baseline_provenance': {'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}, 'anchor_candidate_label': 'carry_lowbatch_shared_anchor_t0'}}`
+- Parameter adequacy plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml
@@ -1,0 +1,1402 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+rows:
+- order: 1
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 625
+    max_grad_norm: 3.595210751679737
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 563.5871033887379
+    wall_elapsed_seconds: 572.867870552931
+    peak_vram_allocated: 3068066304
+    peak_vram_reserved: 7589593088
+    end_to_end_wall_seconds: 593.1992791611701
+    loader_setup_seconds: 20.120247365906835
+    throughput_examples_per_second: 70.97394486049788
+    throughput_tokens_per_second: 424133.93522087584
+    non_train_overhead_seconds: 9.431410214398056
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 635
+    tokens_per_step: 382458.2656
+    tokens_seen: 239036416
+    token_budget: 239036416
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.6461466098688694
+    final_log_loss: 0.6461466098688694
+    best_brier_score: 0.4025780370601524
+    final_brier_score: 0.4025780370601524
+    best_roc_auc: 0.6658360736913753
+    final_roc_auc: 0.6658360736913753
+    best_bpc: 2.1886389592728532
+    final_bpc: 2.1886389592728532
+    best_bpf: 2.1886385221739073
+    final_bpf: 2.1886385221739073
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.3674210980534554
+    final_train_loss_ema: 1.2829152672163924
+    final_tail_mean_train_loss: 1.3081061603531006
+    final_tail_mean_train_loss_ema: 1.3118983355389424
+    final_tail_record_count: 63
+    one_family_step_count: 580
+    mixed_family_step_count: 45
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 575
+    family_block_count: 580
+    estimated_family_switch_count: 579
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 9
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 2
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 2500
+    max_grad_norm: 4.271018091022219
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 1961.8925335267559
+    wall_elapsed_seconds: 1980.4997803838924
+    peak_vram_allocated: 3068090368
+    peak_vram_reserved: 7765753856
+    end_to_end_wall_seconds: 2001.2573917103
+    loader_setup_seconds: 20.55282300291583
+    throughput_examples_per_second: 81.55390637650233
+    throughput_tokens_per_second: 487893.3089567956
+    non_train_overhead_seconds: 18.75265457155183
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 2520
+    tokens_per_step: 382877.696
+    tokens_seen: 957194240
+    token_budget: 957194240
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.507891654839319
+    final_log_loss: 0.507891654839319
+    best_brier_score: 0.30953249632666074
+    final_brier_score: 0.30953249632666074
+    best_roc_auc: 0.7718923833213517
+    final_roc_auc: 0.7718923833213517
+    best_bpc: 2.396527912263809
+    final_bpc: 2.396527912263809
+    best_bpf: 2.396453592980478
+    final_bpf: 2.396453592980478
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0272985249757767
+    final_train_loss_ema: 1.095487027726373
+    final_tail_mean_train_loss: 1.1281592704206704
+    final_tail_mean_train_loss_ema: 1.1312624687628345
+    final_tail_record_count: 250
+    one_family_step_count: 147
+    mixed_family_step_count: 2353
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 139
+    family_block_count: 147
+    estimated_family_switch_count: 146
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 11
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 3
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 5000
+    max_grad_norm: 2.936327000965149
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 3780.5150319170207
+    wall_elapsed_seconds: 3812.982417874038
+    peak_vram_allocated: 3068100608
+    peak_vram_reserved: 8241807360
+    end_to_end_wall_seconds: 3833.3359849727713
+    loader_setup_seconds: 20.149004251230508
+    throughput_examples_per_second: 84.64455168102708
+    throughput_tokens_per_second: 506299.0158326164
+    non_train_overhead_seconds: 32.61169299064204
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 5024
+    tokens_per_step: 382814.208
+    tokens_seen: 1914071040
+    token_budget: 1914071040
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.49140312704015116
+    final_log_loss: 0.49140312704015116
+    best_brier_score: 0.29893815856001277
+    final_brier_score: 0.29893815856001277
+    best_roc_auc: 0.78658115657993
+    final_roc_auc: 0.78658115657993
+    best_bpc: 3.032832350861403
+    final_bpc: 3.032832350861403
+    best_bpf: 3.0327029591538555
+    final_bpf: 3.0327029591538555
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0004463642835617
+    final_train_loss_ema: 1.026697086549313
+    final_tail_mean_train_loss: 1.0992620735913514
+    final_tail_mean_train_loss_ema: 1.1018730984280445
+    final_tail_record_count: 500
+    one_family_step_count: 225
+    mixed_family_step_count: 4775
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 217
+    family_block_count: 225
+    estimated_family_switch_count: 224
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 12
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 4
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 156
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 156
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 39936
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 40000
+    realized_effective_budget: 39936
+    budget_drift: -0.0016000000000000458
+    batch_drift: 0.0
+- order: 5
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 6
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 1250
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 1250
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 7
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: B
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 160000
+  dynamic_reuse_train_artifact: null
+- order: 8
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: B
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 320000
+  dynamic_reuse_train_artifact: null
+- order: 9
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: D
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 160000
+  dynamic_reuse_train_artifact: null
+- order: 10
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: D
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 320000
+  dynamic_reuse_train_artifact: null

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml
@@ -4,9 +4,13 @@ rows:
 - order: 1
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
   status: ready
-  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
-  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
-  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -91,8 +95,10 @@ rows:
     run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
     training_surface_fingerprint: 4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a
   parameter_adequacy_plan:
-  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
-  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
   run_id: null
@@ -100,11 +106,15 @@ rows:
   decision: null
   interpretation_status: pending
   confounders: []
-  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
   notes:
-  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
-  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
-  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
   dynamic_model_overrides: null
   screen_metrics: null
   benchmark_metrics:
@@ -182,9 +192,13 @@ rows:
 - order: 2
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
   status: ready
-  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
-  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
-  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -269,8 +283,10 @@ rows:
     run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
     training_surface_fingerprint: a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f
   parameter_adequacy_plan:
-  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
-  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
   run_id: null
@@ -278,11 +294,15 @@ rows:
   decision: null
   interpretation_status: pending
   confounders: []
-  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
   notes:
-  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
-  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
-  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
   dynamic_model_overrides: null
   screen_metrics: null
   benchmark_metrics:
@@ -360,9 +380,13 @@ rows:
 - order: 3
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
   status: ready
-  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
-  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
-  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -447,8 +471,10 @@ rows:
     run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
     training_surface_fingerprint: 7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40
   parameter_adequacy_plan:
-  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
-  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
   run_id: null
@@ -456,11 +482,15 @@ rows:
   decision: null
   interpretation_status: pending
   confounders: []
-  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor LMO transfer study without retraining.
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
   notes:
-  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
-  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
-  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer regimes.
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
   dynamic_model_overrides: null
   screen_metrics: null
   benchmark_metrics:
@@ -537,10 +567,13 @@ rows:
     batch_drift: 0.0
 - order: 4
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
-  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
-  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
-  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  status: completed
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -623,23 +656,55 @@ rows:
       largest_required_train_tasks: 39936
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
-  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
   notes:
-  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
-  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 156.0
+    max_grad_norm: 2.1787555873344653
+    best_bpc: 2.184311092309804
+    best_bpf: 2.1842998934056475
+    best_roc_auc: 0.5093196839499222
+    best_log_loss: 0.7298796508792347
+    best_brier_score: 0.45752949254776754
+    final_bpc: 2.184311092309804
+    final_bpf: 2.1842998934056475
+    final_roc_auc: 0.5093196839499222
+    final_log_loss: 0.7298796508792347
+    final_brier_score: 0.45752949254776754
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.04604897290569854
+    delta_final_bpf: 0.046037774556003885
+    delta_final_log_loss: 0.33480816663937285
+    delta_final_brier_score: 0.199025584377656
+    delta_final_roc_auc: -0.2489757575477024
   parent_delta_ref: null
   transfer_context:
     phase: baseline
@@ -656,10 +721,13 @@ rows:
     batch_drift: 0.0
 - order: 5
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
-  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
-  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
-  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  status: completed
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -742,23 +810,55 @@ rows:
       largest_required_train_tasks: 160000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
-  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
   notes:
-  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
-  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 625.0
+    max_grad_norm: 2.2230412473583567
+    best_bpc: 2.2516136214258657
+    best_bpf: 2.2515761408967765
+    best_roc_auc: 0.721340761172418
+    best_log_loss: 0.5847717688819352
+    best_brier_score: 0.35960961081465354
+    final_bpc: 2.2516136214258657
+    final_bpf: 2.2515761408967765
+    final_roc_auc: 0.721340761172418
+    final_log_loss: 0.5847717688819352
+    final_brier_score: 0.35960961081465354
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.11335150202176036
+    delta_final_bpf: 0.11331402204713292
+    delta_final_log_loss: 0.18970028464207334
+    delta_final_brier_score: 0.101105702644542
+    delta_final_roc_auc: -0.03695468032520666
   parent_delta_ref: null
   transfer_context:
     phase: baseline
@@ -775,10 +875,13 @@ rows:
     batch_drift: 0.0
 - order: 6
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
-  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
-  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
-  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+  status: completed
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -861,23 +964,55 @@ rows:
       largest_required_train_tasks: 320000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
-  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Benchmark this carried high-batch baseline and compare it against the strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
   notes:
-  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
-  - This row remains a carried high-batch baseline; it is not the source of the shared anchor transfer law.
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 1250.0
+    max_grad_norm: 2.2298717852516687
+    best_bpc: 2.28665255111064
+    best_bpf: 2.2866216081921955
+    best_roc_auc: 0.7708654001511831
+    best_log_loss: 0.5135392584680872
+    best_brier_score: 0.31292361206477665
+    final_bpc: 2.28665255111064
+    final_bpf: 2.2866216081921955
+    final_roc_auc: 0.7708654001511831
+    final_log_loss: 0.5135392584680872
+    final_brier_score: 0.31292361206477665
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.14839043170653454
+    delta_final_bpf: 0.14835948934255194
+    delta_final_log_loss: 0.11846777422822541
+    delta_final_brier_score: 0.054419703894665106
+    delta_final_roc_auc: 0.012569958653558477
   parent_delta_ref: null
   transfer_context:
     phase: baseline
@@ -894,10 +1029,12 @@ rows:
     batch_drift: 0.0
 - order: 7
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
-  hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without local retuning.
-  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T1.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T1.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -980,23 +1117,56 @@ rows:
       largest_required_train_tasks: 160000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
-  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
-  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
   notes:
-  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
-  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 2500.0
+    max_grad_norm: 2.899552555527981
+    best_bpc: 2.2885999257123513
+    best_bpf: 2.288567857187156
+    best_roc_auc: 0.770672013686444
+    best_log_loss: 0.5239001271356958
+    best_brier_score: 0.3181910966301987
+    final_bpc: 2.2885999257123513
+    final_bpf: 2.288567857187156
+    final_roc_auc: 0.770672013686444
+    final_log_loss: 0.5239001271356958
+    final_brier_score: 0.3181910966301987
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.1503378063082459
+    delta_final_bpf: 0.15030573833751237
+    delta_final_log_loss: 0.12882864289583396
+    delta_final_brier_score: 0.05968718846008714
+    delta_final_roc_auc: 0.01237657218881938
   parent_delta_ref: null
   dynamic_training_overrides:
     transfer_schedule:
@@ -1021,10 +1191,12 @@ rows:
   dynamic_reuse_train_artifact: null
 - order: 8
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
-  hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without local retuning.
-  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T2.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T2.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -1107,23 +1279,56 @@ rows:
       largest_required_train_tasks: 320000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
-  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
-  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
   notes:
-  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
-  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 5000.0
+    max_grad_norm: 3.7097536343045894
+    best_bpc: 2.3096259918651847
+    best_bpf: 2.309570876889483
+    best_roc_auc: 0.7759643347915962
+    best_log_loss: 0.514343743966672
+    best_brier_score: 0.3131309546446974
+    final_bpc: 2.3096259918651847
+    final_bpf: 2.309570876889483
+    final_roc_auc: 0.7759643347915962
+    final_log_loss: 0.514343743966672
+    final_brier_score: 0.3131309546446974
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.17136387246107931
+    delta_final_bpf: 0.17130875803983958
+    delta_final_log_loss: 0.11927225972681021
+    delta_final_brier_score: 0.05462704647458588
+    delta_final_roc_auc: 0.017668893293971588
   parent_delta_ref: null
   dynamic_training_overrides:
     transfer_schedule:
@@ -1148,10 +1353,12 @@ rows:
   dynamic_reuse_train_artifact: null
 - order: 9
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
-  hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without local retuning.
-  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T1.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T1.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -1234,23 +1441,56 @@ rows:
       largest_required_train_tasks: 160000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
-  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
-  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
   notes:
-  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
-  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 2000.0
+    max_grad_norm: 2.3512524216580015
+    best_bpc: 2.249432306747282
+    best_bpf: 2.2493988999375354
+    best_roc_auc: 0.7642592678458142
+    best_log_loss: 0.5268794041241825
+    best_brier_score: 0.320864474753584
+    final_bpc: 2.249432306747282
+    final_bpf: 2.2493988999375354
+    final_roc_auc: 0.7642592678458142
+    final_log_loss: 0.5268794041241825
+    final_brier_score: 0.320864474753584
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.11117018734317652
+    delta_final_bpf: 0.11113678108789182
+    delta_final_log_loss: 0.13180791988432072
+    delta_final_brier_score: 0.06236056658347244
+    delta_final_roc_auc: 0.005963826348189594
   parent_delta_ref: null
   dynamic_training_overrides:
     transfer_schedule:
@@ -1275,10 +1515,12 @@ rows:
   dynamic_reuse_train_artifact: null
 - order: 10
   delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
-  hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without local retuning.
-  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T2.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T2.
   model:
     arch: tabfoundry_sandwich
     input_normalization: train_zscore_clip
@@ -1361,23 +1603,56 @@ rows:
       largest_required_train_tasks: 320000
       expected_train_records_available: 1344081
   parameter_adequacy_plan:
-  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for LMO transfer.
-  - Apply the paper-derived law directly at the requested budget without any regime-specific T0 search or local retuning.
-  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as a tie-break and stability check.
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
-  next_action: Execute the strict shared-anchor LMO transfer row and compare it against the carried high-batch baseline at the matched budget.
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
   notes:
-  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the carried low-batch T0 anchor with no empirical T0 search.'
-  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break regime winner rule.
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 3333.0
+    max_grad_norm: 3.202575054521003
+    best_bpc: 2.3645095002861245
+    best_bpf: 2.364467995545142
+    best_roc_auc: 0.7736132557327619
+    best_log_loss: 0.5169818589854734
+    best_brier_score: 0.3143521595864829
+    final_bpc: 2.3645095002861245
+    final_bpf: 2.364467995545142
+    final_roc_auc: 0.7736132557327619
+    final_log_loss: 0.5169818589854734
+    final_brier_score: 0.3143521595864829
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.22624738088201912
+    delta_final_bpf: 0.22620587669549863
+    delta_final_log_loss: 0.12191037474561162
+    delta_final_brier_score: 0.05584825141637134
+    delta_final_roc_auc: 0.015317814235137228
   parent_delta_ref: null
   dynamic_training_overrides:
     transfer_schedule:

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
@@ -322,22 +322,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -345,20 +346,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -376,7 +377,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -476,7 +477,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 625
-  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  resolved_surface_fingerprint: de7f9bcc50164afee6aecb2ab285aa3712199e2515bc802f34e5d22b9a50fa24
   transfer_context:
     phase: baseline
     regime_label: carry_lowbatch
@@ -770,22 +771,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -793,20 +795,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -824,7 +826,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -924,7 +926,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 2500
-  resolved_surface_fingerprint: c4930ff2cd45ed5cbe10bc853eb181e43201c6a89c7ee86ae7b608df225e9ccd
+  resolved_surface_fingerprint: f03fac3f7e2535a3c9453c64156e55cdc99235f322da2785e3f6b87ef0aa7091
   transfer_context:
     phase: baseline
     regime_label: carry_lowbatch
@@ -1218,22 +1220,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -1241,20 +1244,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -1272,7 +1275,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -1372,7 +1375,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 5000
-  resolved_surface_fingerprint: ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d
+  resolved_surface_fingerprint: 65cdcb0232f5484c99af1b832fdea11d501e5d798d79baab89066514107506a4
   transfer_context:
     phase: baseline
     regime_label: carry_lowbatch
@@ -1393,7 +1396,7 @@ rows:
     source_kind: carry_lowbatch
 - order: 4
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
+  status: completed
   rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
     transfer study at the requested budget rung.
   hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
@@ -1488,10 +1491,10 @@ rows:
     whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Benchmark this carried high-batch baseline and compare it against the
     strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
@@ -1500,10 +1503,37 @@ rows:
     budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared
     anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 156.0
+    max_grad_norm: 2.1787555873344653
+    best_bpc: 2.184311092309804
+    best_bpf: 2.1842998934056475
+    best_roc_auc: 0.5093196839499222
+    best_log_loss: 0.7298796508792347
+    best_brier_score: 0.45752949254776754
+    final_bpc: 2.184311092309804
+    final_bpf: 2.1842998934056475
+    final_roc_auc: 0.5093196839499222
+    final_log_loss: 0.7298796508792347
+    final_brier_score: 0.45752949254776754
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.04604897290569854
+    delta_final_bpf: 0.046037774556003885
+    delta_final_log_loss: 0.33480816663937285
+    delta_final_brier_score: 0.199025584377656
+    delta_final_roc_auc: -0.2489757575477024
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -1607,22 +1637,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -1630,20 +1661,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -1661,7 +1692,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -1761,7 +1792,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 156
-  resolved_surface_fingerprint: 07d38633c5b9e05798095e8fd8a85279f9eb442a88381f66864d11a25d4ab0e9
+  resolved_surface_fingerprint: 883ad6e9806e19ebe246186acb97e5ffd74d00571cc47d9dd68f6ff5ad0e2188
   transfer_context:
     phase: baseline
     regime_label: carry_highbatch
@@ -1777,7 +1808,7 @@ rows:
     batch_drift: 0.0
 - order: 5
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
+  status: completed
   rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
     transfer study at the requested budget rung.
   hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
@@ -1872,10 +1903,10 @@ rows:
     whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Benchmark this carried high-batch baseline and compare it against the
     strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
@@ -1884,10 +1915,37 @@ rows:
     budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared
     anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_05_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 625.0
+    max_grad_norm: 2.2230412473583567
+    best_bpc: 2.2516136214258657
+    best_bpf: 2.2515761408967765
+    best_roc_auc: 0.721340761172418
+    best_log_loss: 0.5847717688819352
+    best_brier_score: 0.35960961081465354
+    final_bpc: 2.2516136214258657
+    final_bpf: 2.2515761408967765
+    final_roc_auc: 0.721340761172418
+    final_log_loss: 0.5847717688819352
+    final_brier_score: 0.35960961081465354
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.11335150202176036
+    delta_final_bpf: 0.11331402204713292
+    delta_final_log_loss: 0.18970028464207334
+    delta_final_brier_score: 0.101105702644542
+    delta_final_roc_auc: -0.03695468032520666
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -1991,22 +2049,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -2014,20 +2073,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -2045,7 +2104,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -2145,7 +2204,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 625
-  resolved_surface_fingerprint: 8f07b12c8809233dd626a6e00b4fea37644d2bd014798857d85d2443dac4440f
+  resolved_surface_fingerprint: b3a0260df59fdd126779e4e2c182a40246d1f7c5fbc1f596e1b7720467a451ba
   transfer_context:
     phase: baseline
     regime_label: carry_highbatch
@@ -2161,7 +2220,7 @@ rows:
     batch_drift: 0.0
 - order: 6
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
-  status: ready
+  status: completed
   rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
     transfer study at the requested budget rung.
   hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
@@ -2256,10 +2315,10 @@ rows:
     whether this baseline still merits a later Phase-2B rerun.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Benchmark this carried high-batch baseline and compare it against the
     strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
@@ -2268,10 +2327,37 @@ rows:
     budget-faithful carried high-batch baseline for the transfer study.
   - This row remains a carried high-batch baseline; it is not the source of the shared
     anchor transfer law.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_06_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 1250.0
+    max_grad_norm: 2.2298717852516687
+    best_bpc: 2.28665255111064
+    best_bpf: 2.2866216081921955
+    best_roc_auc: 0.7708654001511831
+    best_log_loss: 0.5135392584680872
+    best_brier_score: 0.31292361206477665
+    final_bpc: 2.28665255111064
+    final_bpf: 2.2866216081921955
+    final_roc_auc: 0.7708654001511831
+    final_log_loss: 0.5135392584680872
+    final_brier_score: 0.31292361206477665
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.14839043170653454
+    delta_final_bpf: 0.14835948934255194
+    delta_final_log_loss: 0.11846777422822541
+    delta_final_brier_score: 0.054419703894665106
+    delta_final_roc_auc: 0.012569958653558477
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -2375,22 +2461,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -2398,20 +2485,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -2429,7 +2516,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -2529,7 +2616,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 1250
-  resolved_surface_fingerprint: 05faa2cd610b3208f72916bef78cb0beb436f3a289b4d483370cad05e09b4988
+  resolved_surface_fingerprint: 33f0bf64bd3ff793f33c07ea319ab9088030c4018330e2a1830e92f8bb011a23
   transfer_context:
     phase: baseline
     regime_label: carry_highbatch
@@ -2545,7 +2632,7 @@ rows:
     batch_drift: 0.0
 - order: 7
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
   hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without
     local retuning.
@@ -2641,10 +2728,10 @@ rows:
     a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Execute the strict shared-anchor LMO transfer row and compare it against
     the carried high-batch baseline at the matched budget.
@@ -2653,12 +2740,39 @@ rows:
     carried low-batch T0 anchor with no empirical T0 search.'
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
     regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_07_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row
     `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 2500.0
+    max_grad_norm: 2.899552555527981
+    best_bpc: 2.2885999257123513
+    best_bpf: 2.288567857187156
+    best_roc_auc: 0.770672013686444
+    best_log_loss: 0.5239001271356958
+    best_brier_score: 0.3181910966301987
+    final_bpc: 2.2885999257123513
+    final_bpf: 2.288567857187156
+    final_roc_auc: 0.770672013686444
+    final_log_loss: 0.5239001271356958
+    final_brier_score: 0.3181910966301987
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.1503378063082459
+    delta_final_bpf: 0.15030573833751237
+    delta_final_log_loss: 0.12882864289583396
+    delta_final_brier_score: 0.05968718846008714
+    delta_final_roc_auc: 0.01237657218881938
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -2749,22 +2863,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -2772,20 +2887,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -2803,7 +2918,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -2903,7 +3018,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 2500
-  resolved_surface_fingerprint: 52a7a31f13b3d6c11dd9239ded32f13a215da2b8f44d9bb3efec3002ba0d7c12
+  resolved_surface_fingerprint: e05b59969d4d30ade39ab6c72c6b81af11ae89384b403a4b1bca307839400639
   dynamic_training_overrides:
     transfer_schedule:
       kind: shared_anchor_transfer
@@ -2969,7 +3084,7 @@ rows:
       anchor_candidate_label: carry_lowbatch_shared_anchor_t0
 - order: 8
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
   hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without
     local retuning.
@@ -3065,10 +3180,10 @@ rows:
     a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Execute the strict shared-anchor LMO transfer row and compare it against
     the carried high-batch baseline at the matched budget.
@@ -3077,12 +3192,39 @@ rows:
     carried low-batch T0 anchor with no empirical T0 search.'
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
     regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_08_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row
     `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 5000.0
+    max_grad_norm: 3.7097536343045894
+    best_bpc: 2.3096259918651847
+    best_bpf: 2.309570876889483
+    best_roc_auc: 0.7759643347915962
+    best_log_loss: 0.514343743966672
+    best_brier_score: 0.3131309546446974
+    final_bpc: 2.3096259918651847
+    final_bpf: 2.309570876889483
+    final_roc_auc: 0.7759643347915962
+    final_log_loss: 0.514343743966672
+    final_brier_score: 0.3131309546446974
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.17136387246107931
+    delta_final_bpf: 0.17130875803983958
+    delta_final_log_loss: 0.11927225972681021
+    delta_final_brier_score: 0.05462704647458588
+    delta_final_roc_auc: 0.017668893293971588
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -3173,22 +3315,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -3196,20 +3339,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -3227,7 +3370,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -3327,7 +3470,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 5000
-  resolved_surface_fingerprint: 90f46b16e7a68ad05bac9b9476347cadc60d270c4cbc8bce67b7e1284939802a
+  resolved_surface_fingerprint: 484026daee134d5be03f54ebcb9f212fdcedc1ddc5410f64151e5b2515df45de
   dynamic_training_overrides:
     transfer_schedule:
       kind: shared_anchor_transfer
@@ -3393,7 +3536,7 @@ rows:
       anchor_candidate_label: carry_lowbatch_shared_anchor_t0
 - order: 9
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
   hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without
     local retuning.
@@ -3489,10 +3632,10 @@ rows:
     a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Execute the strict shared-anchor LMO transfer row and compare it against
     the carried high-batch baseline at the matched budget.
@@ -3501,12 +3644,39 @@ rows:
     carried low-batch T0 anchor with no empirical T0 search.'
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
     regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row
     `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 2000.0
+    max_grad_norm: 2.3512524216580015
+    best_bpc: 2.249432306747282
+    best_bpf: 2.2493988999375354
+    best_roc_auc: 0.7642592678458142
+    best_log_loss: 0.5268794041241825
+    best_brier_score: 0.320864474753584
+    final_bpc: 2.249432306747282
+    final_bpf: 2.2493988999375354
+    final_roc_auc: 0.7642592678458142
+    final_log_loss: 0.5268794041241825
+    final_brier_score: 0.320864474753584
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.11117018734317652
+    delta_final_bpf: 0.11113678108789182
+    delta_final_log_loss: 0.13180791988432072
+    delta_final_brier_score: 0.06236056658347244
+    delta_final_roc_auc: 0.005963826348189594
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -3597,22 +3767,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -3620,20 +3791,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -3651,7 +3822,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -3751,7 +3922,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 2000
-  resolved_surface_fingerprint: baefd0b2c2c956be40d031eda08bf5f16b7aba46eb935b0b929195aee58be3c7
+  resolved_surface_fingerprint: 16a01b331044af04043584bd443a4c6a8c0456de6b235643783d43bfe6663a79
   dynamic_training_overrides:
     transfer_schedule:
       kind: shared_anchor_transfer
@@ -3817,7 +3988,7 @@ rows:
       anchor_candidate_label: carry_lowbatch_shared_anchor_t0
 - order: 10
   delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
-  status: ready
+  status: completed
   rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
   hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without
     local retuning.
@@ -3913,10 +4084,10 @@ rows:
     a tie-break and stability check.
   execution_policy: benchmark_full
   benchmark_checkpoint_selection: best_and_final
-  run_id: null
+  run_id: sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1
   followup_run_ids: []
-  decision: null
-  interpretation_status: pending
+  decision: defer
+  interpretation_status: completed
   confounders: []
   next_action: Execute the strict shared-anchor LMO transfer row and compare it against
     the carried high-batch baseline at the matched budget.
@@ -3925,12 +4096,39 @@ rows:
     carried low-batch T0 anchor with no empirical T0 search.'
   - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
     regime winner rule.
+  - Canonical rerun registered as `sd_tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1_10_delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1_v1`.
+  - Canonical benchmark comparison recorded against the locked sweep anchor; interpret
+    this row in the full sweep context.
   - Resolved transfer training overrides `transfer_schedule` from shared anchor row
     `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
   dynamic_model_overrides: null
   reuse_train_artifact: null
   screen_metrics: null
-  benchmark_metrics: null
+  benchmark_metrics:
+    best_step: 3333.0
+    max_grad_norm: 3.202575054521003
+    best_bpc: 2.3645095002861245
+    best_bpf: 2.364467995545142
+    best_roc_auc: 0.7736132557327619
+    best_log_loss: 0.5169818589854734
+    best_brier_score: 0.3143521595864829
+    final_bpc: 2.3645095002861245
+    final_bpf: 2.364467995545142
+    final_roc_auc: 0.7736132557327619
+    final_log_loss: 0.5169818589854734
+    final_brier_score: 0.3143521595864829
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_roc_auc: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    objective_metric: final_log_loss_at_matched_regime_budget
+    drift: 0.0
+    delta_final_bpc: 0.22624738088201912
+    delta_final_bpf: 0.22620587669549863
+    delta_final_log_loss: 0.12191037474561162
+    delta_final_brier_score: 0.05584825141637134
+    delta_final_roc_auc: 0.015317814235137228
   parent_delta_ref: null
   dimension_family: training
   family: classification_scaling_law
@@ -4021,22 +4219,23 @@ rows:
       source: manifest
       filter_policy: null
       allow_missing_values: true
-      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
       requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
       materialization_state: finalized
       recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
-      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5/manifest.parquet
+        manifest_sha256: b54f7409b6d563a08c38e106f23d68f866464fc8914d0cc4119d0d32de130842
       dagzoo_provenance:
-        acceptance_rate: 0.9985836421932587
-        accepted_datasets: 1729454
+        acceptance_rate: 0.9985587580558885
+        accepted_datasets: 1709944
         comparator_role: control
         config_refs:
         - configs/default.yaml
-        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
-        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b54f7409b6d5
         corpus_variant: tf_rd_010_dagzoo_medium_control
         curated_accepted_datasets: 1493424
         filter_policy: accepted_only
@@ -4044,20 +4243,20 @@ rows:
         invocation_count: 144
         manifest_record_count: 1493424
         materialization_timing:
-          cumulative_copy_elapsed_seconds: 11214.598361142067
-          cumulative_filter_elapsed_seconds: 795.7731741687458
-          cumulative_generate_elapsed_seconds: 139096.5615566939
-          cumulative_generated_datasets: 1731907
-          cumulative_invocation_elapsed_seconds: 153944.14504301702
-          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_copy_elapsed_seconds: 9029.037055122666
+          cumulative_filter_elapsed_seconds: 769.7464019064792
+          cumulative_generate_elapsed_seconds: 137186.75154553936
+          cumulative_generated_datasets: 1712412
+          cumulative_invocation_elapsed_seconds: 149788.86008265358
+          cumulative_local_overhead_elapsed_seconds: 2803.32508008508
           cumulative_round_count: 144
-          cumulative_upstream_elapsed_seconds: 139892.33473086264
-          invocation_fanout_elapsed_seconds: 6953.243410833005
-          manifest_build_elapsed_seconds: 1068.3320622059982
-          manifest_workers: 32
-          promotion_elapsed_seconds: 13.678867887007073
-          recipe_elapsed_seconds: 8035.271685323009
-          staged_compaction_elapsed_seconds: 39.46334980899701
+          cumulative_upstream_elapsed_seconds: 137956.49794744584
+          invocation_fanout_elapsed_seconds: 19271.46016815491
+          manifest_build_elapsed_seconds: 772.6144697689451
+          manifest_workers: 22
+          promotion_elapsed_seconds: 14.870547467842698
+          recipe_elapsed_seconds: 20059.05450632004
+          staged_compaction_elapsed_seconds: 19.91831662808545
           staged_compaction_status: completed
           timed_invocation_count: 144
         provenance_labels:
@@ -4075,7 +4274,7 @@ rows:
           task_grid: balanced_rows_features_classes_v1
         recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
         recipe_kind: dagzoo_python_generated
-        rejected_datasets: 2453
+        rejected_datasets: 2468
         review_summary:
           class_counts:
           - 2
@@ -4175,7 +4374,7 @@ rows:
       checkpoint_every: 25
       val_batches: 0
       max_steps: 3333
-  resolved_surface_fingerprint: 91b360b6bd1ad5ef9e56441aa71787fb618e33a5b3cf59c7dfcb3e31091f1c7e
+  resolved_surface_fingerprint: 2c8099dab822992c163bc055c351d4386b1ebf6753b8ee98086c227f7123ede9
   dynamic_training_overrides:
     transfer_schedule:
       kind: shared_anchor_transfer
@@ -4240,4 +4439,4 @@ rows:
         source_kind: carry_lowbatch
       anchor_candidate_label: carry_lowbatch_shared_anchor_t0
 canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
-inputs_fingerprint: 93c50ed09ab4c89cb673c50762262e5b366354859f8aa06adcf06de34e53982d
+inputs_fingerprint: 3e5b84a48c28a5249692d97cceabdd9e830d83d9698a12925b983bded803d5e4

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
@@ -1,0 +1,4243 @@
+schema: tab-foundry-system-delta-resolved-queue-v1
+generated_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+catalog_path: reference/system_delta_catalog.yaml
+canonical_sweep_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/sweep.yaml
+canonical_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/queue.yaml
+canonical_matrix_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/matrix.md
+sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+sweep_status: draft
+complexity_level: classification_md
+anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+surface_role: classification_training_dynamics_transfer
+comparison_policy: anchor_only
+upstream_reference:
+  name: Deriving Hyperparameter Scaling Laws via Modern Optimization Theory
+  model_source: https://arxiv.org/abs/2603.15958
+anchor_surface:
+  notes:
+  - 'This sweep is the active #284 strict shared-anchor LMO transfer study; the earlier
+    screen-based transfer sweeps are superseded context only.'
+  - Keep geometry fixed at 144x4, reuse one carried low-batch Muon T0 artifact as
+    the shared anchor, and derive Regime B and Regime D deterministically from that
+    anchor.
+  - 'Do not perform any T0 hyperparameter search in the canonical #284 path; T0 is
+    the shared carried anchor and the regime comparison happens at T1/T2.'
+  - Primary decision criterion is corrected benchmark log loss on openml_classification_medium_v1
+    with a T2-first, T1 tie-break winner rule; runtime remains diagnostic only.
+  dimension_table: []
+anchor_context:
+  run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup
+rows:
+- order: 1
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
+  dynamic_model_overrides: null
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 625
+    max_grad_norm: 3.595210751679737
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 563.5871033887379
+    wall_elapsed_seconds: 572.867870552931
+    peak_vram_allocated: 3068066304
+    peak_vram_reserved: 7589593088
+    end_to_end_wall_seconds: 593.1992791611701
+    loader_setup_seconds: 20.120247365906835
+    throughput_examples_per_second: 70.97394486049788
+    throughput_tokens_per_second: 424133.93522087584
+    non_train_overhead_seconds: 9.431410214398056
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 635
+    tokens_per_step: 382458.2656
+    tokens_seen: 239036416
+    token_budget: 239036416
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.6461466098688694
+    final_log_loss: 0.6461466098688694
+    best_brier_score: 0.4025780370601524
+    final_brier_score: 0.4025780370601524
+    best_roc_auc: 0.6658360736913753
+    final_roc_auc: 0.6658360736913753
+    best_bpc: 2.1886389592728532
+    final_bpc: 2.1886389592728532
+    best_bpf: 2.1886385221739073
+    final_bpf: 2.1886385221739073
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.3674210980534554
+    final_train_loss_ema: 1.2829152672163924
+    final_tail_mean_train_loss: 1.3081061603531006
+    final_tail_mean_train_loss_ema: 1.3118983355389424
+    final_tail_record_count: 63
+    one_family_step_count: 580
+    mixed_family_step_count: 45
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 575
+    family_block_count: 580
+    estimated_family_switch_count: 579
+  parent_delta_ref: null
+  dimension_family: model
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row
+    at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target
+    between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+  upstream_delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width
+    screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter
+    interpolation instead of inheriting the historical schedulefree ladder.
+  entangled_legacy_stage: none
+  expected_effect: If the fresh Muon fixed-budget law stays smooth beyond the upper
+    seed, `144x4` should provide the first interior Phase-1 measurement between the
+    carried `128x2` baseline and the retained ceiling probe.
+  adequacy_knobs:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+    reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute after the `72x1` and `112x3` fresh-Muon seed rows so the rederived family
+      stays an ordered diagonal around the landed width screen.
+    - Compare directly against the carried `128x2` Muon baseline at matched regime
+      budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+    - Treat this row as interior fresh-Muon Phase-1 evidence rather than as an upper-family
+      reopen selector output.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 9
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+- order: 2
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
+  dynamic_model_overrides: null
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 2500
+    max_grad_norm: 4.271018091022219
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 1961.8925335267559
+    wall_elapsed_seconds: 1980.4997803838924
+    peak_vram_allocated: 3068090368
+    peak_vram_reserved: 7765753856
+    end_to_end_wall_seconds: 2001.2573917103
+    loader_setup_seconds: 20.55282300291583
+    throughput_examples_per_second: 81.55390637650233
+    throughput_tokens_per_second: 487893.3089567956
+    non_train_overhead_seconds: 18.75265457155183
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 2520
+    tokens_per_step: 382877.696
+    tokens_seen: 957194240
+    token_budget: 957194240
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.507891654839319
+    final_log_loss: 0.507891654839319
+    best_brier_score: 0.30953249632666074
+    final_brier_score: 0.30953249632666074
+    best_roc_auc: 0.7718923833213517
+    final_roc_auc: 0.7718923833213517
+    best_bpc: 2.396527912263809
+    final_bpc: 2.396527912263809
+    best_bpf: 2.396453592980478
+    final_bpf: 2.396453592980478
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0272985249757767
+    final_train_loss_ema: 1.095487027726373
+    final_tail_mean_train_loss: 1.1281592704206704
+    final_tail_mean_train_loss_ema: 1.1312624687628345
+    final_tail_record_count: 250
+    one_family_step_count: 147
+    mixed_family_step_count: 2353
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 139
+    family_block_count: 147
+    estimated_family_switch_count: 146
+  parent_delta_ref: null
+  dimension_family: model
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row
+    at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target
+    between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+  upstream_delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width
+    screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter
+    interpolation instead of inheriting the historical schedulefree ladder.
+  entangled_legacy_stage: none
+  expected_effect: If the fresh Muon fixed-budget law stays smooth beyond the upper
+    seed, `144x4` should provide the first interior Phase-1 measurement between the
+    carried `128x2` baseline and the retained ceiling probe.
+  adequacy_knobs:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+    reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute after the `72x1` and `112x3` fresh-Muon seed rows so the rederived family
+      stays an ordered diagonal around the landed width screen.
+    - Compare directly against the carried `128x2` Muon baseline at matched regime
+      budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+    - Treat this row as interior fresh-Muon Phase-1 evidence rather than as an upper-family
+      reopen selector output.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 2500
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 2500
+  resolved_surface_fingerprint: c4930ff2cd45ed5cbe10bc853eb181e43201c6a89c7ee86ae7b608df225e9ccd
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 11
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+- order: 3
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the strict shared-anchor
+    LMO transfer study without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  - This imported low-batch row is also the shared T0 anchor for the strict LMO transfer
+    regimes.
+  dynamic_model_overrides: null
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 5000
+    max_grad_norm: 2.936327000965149
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 3780.5150319170207
+    wall_elapsed_seconds: 3812.982417874038
+    peak_vram_allocated: 3068100608
+    peak_vram_reserved: 8241807360
+    end_to_end_wall_seconds: 3833.3359849727713
+    loader_setup_seconds: 20.149004251230508
+    throughput_examples_per_second: 84.64455168102708
+    throughput_tokens_per_second: 506299.0158326164
+    non_train_overhead_seconds: 32.61169299064204
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 5024
+    tokens_per_step: 382814.208
+    tokens_seen: 1914071040
+    token_budget: 1914071040
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.49140312704015116
+    final_log_loss: 0.49140312704015116
+    best_brier_score: 0.29893815856001277
+    final_brier_score: 0.29893815856001277
+    best_roc_auc: 0.78658115657993
+    final_roc_auc: 0.78658115657993
+    best_bpc: 3.032832350861403
+    final_bpc: 3.032832350861403
+    best_bpf: 3.0327029591538555
+    final_bpf: 3.0327029591538555
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0004463642835617
+    final_train_loss_ema: 1.026697086549313
+    final_tail_mean_train_loss: 1.0992620735913514
+    final_tail_mean_train_loss_ema: 1.1018730984280445
+    final_tail_record_count: 500
+    one_family_step_count: 225
+    mixed_family_step_count: 4775
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 217
+    family_block_count: 225
+    estimated_family_switch_count: 224
+  parent_delta_ref: null
+  dimension_family: model
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row
+    at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target
+    between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+  upstream_delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width
+    screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter
+    interpolation instead of inheriting the historical schedulefree ladder.
+  entangled_legacy_stage: none
+  expected_effect: If the fresh Muon fixed-budget law stays smooth beyond the upper
+    seed, `144x4` should provide the first interior Phase-1 measurement between the
+    carried `128x2` baseline and the retained ceiling probe.
+  adequacy_knobs:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget
+    reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute after the `72x1` and `112x3` fresh-Muon seed rows so the rederived family
+      stays an ordered diagonal around the landed width screen.
+    - Compare directly against the carried `128x2` Muon baseline at matched regime
+      budget using `final_log_loss_at_matched_regime_budget` as the primary metric.
+    - Treat this row as interior fresh-Muon Phase-1 evidence rather than as an upper-family
+      reopen selector output.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: ad68d3446dbc6cbc160bd2cb424a3e7849cb1f44f713092cfbc276b2f844799d
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 12
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+- order: 4
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 156
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 156
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 39936
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch
+    `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+  upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side
+    gain also improves the `144x4` NS winner when geometry is held fixed.
+  entangled_legacy_stage: none
+  expected_effect: If batch-side movement generalizes across the compact frontier,
+    this row should improve `144x4` materially enough to challenge the carried low-batch
+    point on the corrected quality/time frontier.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `144x4`.
+    - Compare directly against the `144x4` low-batch floor and the two literature-backed
+      `144x4` prescriptions.
+    - Keep this contract only if the corrected gain is large enough to offset the
+      extra train time.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 156
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 156
+  resolved_surface_fingerprint: 07d38633c5b9e05798095e8fd8a85279f9eb442a88381f66864d11a25d4ab0e9
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 40000
+    realized_effective_budget: 39936
+    budget_drift: -0.0016000000000000458
+    batch_drift: 0.0
+- order: 5
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch
+    `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+  upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side
+    gain also improves the `144x4` NS winner when geometry is held fixed.
+  entangled_legacy_stage: none
+  expected_effect: If batch-side movement generalizes across the compact frontier,
+    this row should improve `144x4` materially enough to challenge the carried low-batch
+    point on the corrected quality/time frontier.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `144x4`.
+    - Compare directly against the `144x4` low-batch floor and the two literature-backed
+      `144x4` prescriptions.
+    - Keep this contract only if the corrected gain is large enough to offset the
+      extra train time.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 8f07b12c8809233dd626a6e00b4fea37644d2bd014798857d85d2443dac4440f
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 6
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 1250
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 1250
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    strict shared-anchor LMO transfer regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  - This row remains a carried high-batch baseline; it is not the source of the shared
+    anchor transfer law.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch
+    `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+  upstream_delta: This is the direct test of whether the corrected Phase-2 batch-side
+    gain also improves the `144x4` NS winner when geometry is held fixed.
+  entangled_legacy_stage: none
+  expected_effect: If batch-side movement generalizes across the compact frontier,
+    this row should improve `144x4` materially enough to challenge the carried low-batch
+    point on the corrected quality/time frontier.
+  adequacy_knobs:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+  parameter_adequacy_policy:
+    default_plan:
+    - Execute as the empirical high-batch carry-forward row for `144x4`.
+    - Compare directly against the `144x4` low-batch floor and the two literature-backed
+      `144x4` prescriptions.
+    - Keep this contract only if the corrected gain is large enough to offset the
+      extra train time.
+    default_negative_decision: defer
+    reject_requires:
+    - isolated_change
+    - adequacy_plan_complete
+    - clearly_worse_without_offsetting_benefit
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 1250
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 16
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 1250
+  resolved_surface_fingerprint: 05faa2cd610b3208f72916bef78cb0beb436f3a289b4d483370cad05e09b4988
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 7
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 3.5355339059327384e-07
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.0003535533905932738
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row
+    `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without
+    local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 3.5355339059327384e-07
+      schedule_stages:
+      - name: prior_dump
+        steps: 2500
+        lr_max: 0.0003535533905932738
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 2500
+  resolved_surface_fingerprint: 52a7a31f13b3d6c11dd9239ded32f13a215da2b8f44d9bb3efec3002ba0d7c12
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: B
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+      resolved_from_order: 1
+      resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+      resolution_reason: shared_anchor
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 160000
+  transfer_resolution:
+    phase: validation
+    regime_label: B
+    formula_label: Theorem 2 fixed-batch transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 160000
+    base_effective_budget: 40000
+    realized_effective_budget: 160000
+    base_effective_batch: 64
+    target_effective_batch: 64.0
+    realized_effective_batch: 64
+    base_lr_max: 0.001
+    target_lr_max: 0.0003535533905932738
+    base_momentum: 0.95
+    target_momentum: 0.975
+    base_alpha: 0.050000000000000044
+    target_alpha: 0.025000000000000022
+    grad_accum_steps: 4
+    max_steps: 2500
+    min_lr: 3.5355339059327384e-07
+    budget_drift: 0.0
+    batch_drift: 0.0
+    resolved_from_order: 1
+    resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+    resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+    resolution_reason: shared_anchor
+    shared_anchor_provenance:
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_order: 1
+      anchor_delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+      anchor_run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+      anchor_imported_baseline_provenance:
+        source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+        source_order: 9
+        source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+        source_kind: carry_lowbatch
+      anchor_candidate_label: carry_lowbatch_shared_anchor_t0
+- order: 8
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.1022410381342863e-07
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9823223304703363
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.00021022410381342862
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row
+    `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the strict shared T0 anchor transfer should extrapolate cleanly to T1/T2 without
+    local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.1022410381342863e-07
+      schedule_stages:
+      - name: prior_dump
+        steps: 5000
+        lr_max: 0.00021022410381342862
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 5000
+  resolved_surface_fingerprint: 90f46b16e7a68ad05bac9b9476347cadc60d270c4cbc8bce67b7e1284939802a
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: B
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+      resolved_from_order: 1
+      resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+      resolution_reason: shared_anchor
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 320000
+  transfer_resolution:
+    phase: validation
+    regime_label: B
+    formula_label: Theorem 2 fixed-batch transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_b
+    target_effective_budget: 320000
+    base_effective_budget: 40000
+    realized_effective_budget: 320000
+    base_effective_batch: 64
+    target_effective_batch: 64.0
+    realized_effective_batch: 64
+    base_lr_max: 0.001
+    target_lr_max: 0.00021022410381342862
+    base_momentum: 0.95
+    target_momentum: 0.9823223304703363
+    base_alpha: 0.050000000000000044
+    target_alpha: 0.017677669529663705
+    grad_accum_steps: 4
+    max_steps: 5000
+    min_lr: 2.1022410381342863e-07
+    budget_drift: 0.0
+    batch_drift: 0.0
+    resolved_from_order: 1
+    resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+    resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+    resolution_reason: shared_anchor
+    shared_anchor_provenance:
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_order: 1
+      anchor_delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+      anchor_run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+      anchor_imported_baseline_provenance:
+        source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+        source_order: 9
+        source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+        source_kind: carry_lowbatch
+      anchor_candidate_label: carry_lowbatch_shared_anchor_t0
+- order: 9
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 4.4544935907016965e-07
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9685019737526281
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 2000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2000
+          lr_max: 0.00044544935907016964
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row
+    `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the strict shared T0 anchor transfer should beat both carried baselines
+    on corrected benchmark log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 4.4544935907016965e-07
+      schedule_stages:
+      - name: prior_dump
+        steps: 2000
+        lr_max: 0.00044544935907016964
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 2000
+  resolved_surface_fingerprint: baefd0b2c2c956be40d031eda08bf5f16b7aba46eb935b0b929195aee58be3c7
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: D
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+      resolved_from_order: 1
+      resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+      resolution_reason: shared_anchor
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 160000
+  transfer_resolution:
+    phase: validation
+    regime_label: D
+    formula_label: Theorem 3 joint-transfer proxy
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 160000
+    base_effective_budget: 40000
+    realized_effective_budget: 160000
+    base_effective_batch: 64
+    target_effective_batch: 80.63494719327188
+    realized_effective_batch: 80
+    base_lr_max: 0.001
+    target_lr_max: 0.00044544935907016964
+    base_momentum: 0.95
+    target_momentum: 0.9685019737526281
+    base_alpha: 0.050000000000000044
+    target_alpha: 0.03149802624737186
+    grad_accum_steps: 5
+    max_steps: 2000
+    min_lr: 4.4544935907016965e-07
+    budget_drift: 0.0
+    batch_drift: -0.007874342519875399
+    resolved_from_order: 1
+    resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+    resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+    resolution_reason: shared_anchor
+    shared_anchor_provenance:
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_order: 1
+      anchor_delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+      anchor_run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+      anchor_imported_baseline_provenance:
+        source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+        source_order: 9
+        source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+        source_kind: carry_lowbatch
+      anchor_candidate_label: carry_lowbatch_shared_anchor_t0
+- order: 10
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.9730177875068024e-07
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 3333
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 3333
+          lr_max: 0.00029730177875068024
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried low-batch 144x4 Muon T0 artifact as the single shared anchor for
+    LMO transfer.
+  - Apply the paper-derived law directly at the requested budget without any regime-specific
+    T0 search or local retuning.
+  - Choose the kept regime by corrected benchmark log loss at T2, using T1 only as
+    a tie-break and stability check.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute the strict shared-anchor LMO transfer row and compare it against
+    the carried high-batch baseline at the matched budget.
+  notes:
+  - 'Strict shared-anchor LMO transfer under issue #284; derive this row from the
+    carried low-batch T0 anchor with no empirical T0 search.'
+  - Use corrected openml_classification_medium_v1 only and keep the T2-first, T1 tie-break
+    regime winner rule.
+  - Resolved transfer training overrides `transfer_schedule` from shared anchor row
+    `1` in `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the strict shared T0 anchor transfer should beat both carried baselines
+    on corrected benchmark log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.9730177875068024e-07
+      schedule_stages:
+      - name: prior_dump
+        steps: 3333
+        lr_max: 0.00029730177875068024
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 3333
+  resolved_surface_fingerprint: 91b360b6bd1ad5ef9e56441aa71787fb618e33a5b3cf59c7dfcb3e31091f1c7e
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: shared_anchor_transfer
+      anchor_order: 1
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_label: carry_lowbatch_shared_anchor_t0
+      regime_label: D
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+      resolved_from_order: 1
+      resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+      resolution_reason: shared_anchor
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D shared-anchor transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 320000
+  transfer_resolution:
+    phase: validation
+    regime_label: D
+    formula_label: Theorem 3 joint-transfer proxy
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: shared_anchor_regime_d
+    target_effective_budget: 320000
+    base_effective_budget: 40000
+    realized_effective_budget: 319968
+    base_effective_batch: 64
+    target_effective_batch: 90.50966799187808
+    realized_effective_batch: 96
+    base_lr_max: 0.001
+    target_lr_max: 0.00029730177875068024
+    base_momentum: 0.95
+    target_momentum: 0.975
+    base_alpha: 0.050000000000000044
+    target_alpha: 0.025000000000000022
+    grad_accum_steps: 6
+    max_steps: 3333
+    min_lr: 2.9730177875068024e-07
+    budget_drift: -9.999999999998899e-05
+    batch_drift: 0.060660171779821415
+    resolved_from_order: 1
+    resolved_from_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+    resolved_candidate_label: carry_lowbatch_shared_anchor_t0
+    resolution_reason: shared_anchor
+    shared_anchor_provenance:
+      anchor_sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
+      anchor_order: 1
+      anchor_delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+      anchor_run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+      anchor_imported_baseline_provenance:
+        source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+        source_order: 9
+        source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+        source_kind: carry_lowbatch
+      anchor_candidate_label: carry_lowbatch_shared_anchor_t0
+canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/resolved_queue.yaml
+inputs_fingerprint: 93c50ed09ab4c89cb673c50762262e5b366354859f8aa06adcf06de34e53982d

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
-sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+sweep_id: tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1
 parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-status: superseded
+status: draft
 complexity_level: classification_md
 anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
 benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -9,21 +9,17 @@ control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
 external_benchmarks: []
 training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
-surface_role: classification_training_dynamics_transfer_screen
+surface_role: classification_training_dynamics_transfer
 comparison_policy: anchor_only
 upstream_reference:
   name: Deriving Hyperparameter Scaling Laws via Modern Optimization Theory
   model_source: https://arxiv.org/abs/2603.15958
 anchor_surface:
   notes:
-  - 'This sweep is superseded context only; the active #284 study is now the strict
-    shared-anchor LMO transfer sweep tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1.'
-  - Hold geometry fixed at 144x4 and use the paper-derived budget-transfer study to
-    choose one T0 anchor for Regime B and one for Regime D.
-  - Regime B keeps effective batch fixed at 64 while scaling momentum and lr with
-    budget; Regime D jointly scales batch, momentum, and lr.
-  - Use the corrected openml_classification_medium_v1 anchor benchmark with natural
-    missingness preserved; fail fast if any row drifts to a binary surface.
+  - 'This sweep is the active #284 strict shared-anchor LMO transfer study; the earlier screen-based transfer sweeps are superseded context only.'
+  - Keep geometry fixed at 144x4, reuse one carried low-batch Muon T0 artifact as the shared anchor, and derive Regime B and Regime D deterministically from that anchor.
+  - 'Do not perform any T0 hyperparameter search in the canonical #284 path; T0 is the shared carried anchor and the regime comparison happens at T1/T2.'
+  - Primary decision criterion is corrected benchmark log loss on openml_classification_medium_v1 with a T2-first, T1 tie-break winner rule; runtime remains diagnostic only.
   dimension_table: []
 anchor_context:
   run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/matrix.md
@@ -1,0 +1,488 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/queue.yaml` plus `reference/system_delta_catalog.yaml` and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_009_muon_training_dynamics_transfer_medium_v1`
+- Sweep status: `draft`
+- Parent sweep id: `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
+- Complexity level: `classification_md`
+
+## Locked Surface
+
+- Anchor run id: `sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+- Benchmark manifest: local benchmark-manifest id `openml_classification_medium_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_medium_v1`
+- External benchmarks: `none`
+- Training experiment: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Training config profile: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Surface role: `classification_training_dynamics_transfer`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final BPC `2.1383`, final BPF `2.1383`, final log loss `0.3951`, final Brier score `0.2585`, best ROC AUC `0.7563`, final ROC AUC `0.7583`, final training time `8686.8s`
+
+## Anchor Comparison
+
+Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimization Theory` from `https://arxiv.org/abs/2603.15958`.
+
+| Dimension | Upstream Deriving Hyperparameter Scaling Laws via Modern Optimization Theory | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the transfer study without retraining. |
+| 2 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the transfer study without retraining. |
+| 3 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1` | classification_scaling_law | no | ready | none | Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe. | Benchmark this imported low-batch baseline into the transfer study without retraining. |
+| 4 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the paper-derived regimes on corrected benchmark log loss. |
+| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the paper-derived regimes on corrected benchmark log loss. |
+| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1` | classification_scaling_law | no | ready | none | Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface. | Benchmark this carried high-batch baseline and compare it against the paper-derived regimes on corrected benchmark log loss. |
+| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute regime B on T0 only after the T0 screen chooses its anchor. |
+| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute regime B on T1 only after the T0 screen chooses its anchor. |
+| 9 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Execute regime B on T2 only after the T0 screen chooses its anchor. |
+| 10 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute regime D on T0 only after the T0 screen chooses its anchor. |
+| 11 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute regime D on T1 only after the T0 screen chooses its anchor. |
+| 12 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Execute regime D on T2 only after the T0 screen chooses its anchor. |
+
+## Detailed Rows
+
+### 1. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 9, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.6461` (step 625)
+  - Final log loss: `0.6461`
+  - Final Brier score: `0.4026`
+  - Final ROC AUC: `0.6658`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `2.1886`
+  - Final BPF (legacy feature-cell diagnostic): `2.1886`
+  - max_grad_norm: `3.595`
+
+### 2. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 160000, 'realized_effective_budget': 160000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 11, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.5079` (step 2500)
+  - Final log loss: `0.5079`
+  - Final Brier score: `0.3095`
+  - Final ROC AUC: `0.7719`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `2.3965`
+  - Final BPF (legacy feature-cell diagnostic): `2.3965`
+  - max_grad_norm: `4.271`
+
+### 3. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1`
+
+- Dimension family: `model`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Execute the first fresh-Muon interpolated TF-RD-009 width-depth row at `d_icl=144`, `sandwich_layers=4`, using the rederived log-space interior target between the `112x3` seed and the retained `264x6` Phase-1 ceiling probe.
+- Rationale: Import the corrected 144x4 low-batch Muon baseline from the completed NS sweep without retraining.
+- Hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study and should remain a valid corrected benchmark reference at the matching budget rung.
+- Upstream delta: TF-RD-009 rederives the Muon Phase-1 diagonal from the landed width screen plus the frozen RTX 8000 planning formulas, then uses log-space parameter interpolation instead of inheriting the historical schedulefree ladder.
+- Anchor delta: Reuse the completed NS low-batch train artifact and benchmark it into the transfer study without retraining.
+- Expected effect: If the fresh Muon fixed-budget law stays smooth beyond the upper seed, `144x4` should provide the first interior Phase-1 measurement between the carried `128x2` baseline and the retained ceiling probe.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Model overrides: `{'arch': 'tabfoundry_sandwich', 'input_normalization': 'train_zscore_clip', 'many_class_base': 10, 'head_hidden_dim': 96, 'sandwich_latents': 24, 'sandwich_heads': 1, 'sandwich_ff_expansion': 2, 'sandwich_summary_tokens_per_axis': 3, 'sandwich_self_attention_per_cross': 4, 'sandwich_pre_row_attention_layers': 1, 'sandwich_pre_column_attention_layers': 1, 'sandwich_pre_column_inducing_tokens': 16, 'feature_type_conditioning': 'film', 'floating_likelihood': 'single_gaussian', 'integer_likelihood': 'hybrid_mixture', 'd_icl': 144, 'sandwich_layers': 4}`
+- Reuse train artifact: `outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train`
+- Reuse training surface fingerprint: `7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_lowbatch', 'formula_label': 'carried low-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'carry_lowbatch', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 320000, 'realized_effective_budget': 320000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Imported baseline provenance: `{'source_sweep_id': 'tf_rd_009_muon_ns_one_epoch_medium_v1', 'source_order': 12, 'source_run_id': 'sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1', 'source_kind': 'carry_lowbatch'}`
+- Parameter adequacy plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains directly comparable to the transfer regimes.
+- Adequacy knobs to dimension explicitly:
+  - fixed TF-RD-010 curated medium benchmark contract
+  - carried post-#271 packed Muon runtime and optimizer surface
+  - carried TF-RD-024 heads1 architecture with non-scaling sandwich knobs frozen
+  - joint width-depth movement only; no optimizer retune, curriculum slice, or token-budget reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1 order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to any binary benchmark surface.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/result_card.md`
+- Benchmark metrics:
+  - Best log loss: `0.4914` (step 5000)
+  - Final log loss: `0.4914`
+  - Final Brier score: `0.2989`
+  - Final ROC AUC: `0.7866`
+  - Drift (final − best): `0.0000`
+  - Legacy feature-cell diagnostics remain secondary to log loss on classification-objective rows.
+  - Final BPC (legacy feature-cell diagnostic): `3.0328`
+  - Final BPF (legacy feature-cell diagnostic): `3.0327`
+  - max_grad_norm: `2.936`
+
+### 4. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 156}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 156, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 40000, 'realized_effective_budget': 39936, 'budget_drift': -0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 5. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 160000, 'realized_effective_budget': 160000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 6. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Re-run `144x4` at the fixed 5000-step endpoint with the empirical high-batch `B_eff=256` carry-forward Muon contract and unchanged LR/beta surface.
+- Rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful transfer study at the requested budget rung.
+- Hypothesis: A pure carry-forward high-batch baseline distinguishes the value of budget-faithful transfer from a simple fixed high-batch contract.
+- Upstream delta: This is the direct test of whether the corrected Phase-2 batch-side gain also improves the `144x4` NS winner when geometry is held fixed.
+- Anchor delta: Keep the carried Muon high-batch optimizer surface and adjust only the step budget needed for the requested rung.
+- Expected effect: If batch-side movement generalizes across the compact frontier, this row should improve `144x4` materially enough to challenge the carried low-batch point on the corrected quality/time frontier.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 16, 'max_steps': 1250}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 1250, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'baseline', 'regime_label': 'carry_highbatch', 'formula_label': 'carried high-batch baseline', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'carry_highbatch', 'target_effective_batch': 256, 'realized_effective_batch': 256, 'target_effective_budget': 320000, 'realized_effective_budget': 320000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding whether this baseline still merits a later Phase-2B rerun.
+- Adequacy knobs to dimension explicitly:
+  - corrected `openml_classification_medium_v1` benchmark contract
+  - fixed `tf_rd_010_dagzoo_medium_control_curated_v6` corpus
+  - fixed `5000`-step one-epoch endpoint
+  - carried Muon LR, beta, and weight-decay surface
+  - empirical high-batch reference only; no broader optimizer reopen
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - The earlier heuristic selector remains preserved context only; this row is the budget-faithful carried high-batch baseline for the transfer study.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 7. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T0 rung.
+- Hypothesis: Regime B should extrapolate from its winning T0 anchor to T0 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T0.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'B', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 1}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 2}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 3}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 4}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 5}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 6}], 'tie_break_preference': 'regime_b_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 40000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Dynamic reuse train artifact: `{'t0_winner': {'kind': 'screen_winner_artifact', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 1}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 2}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 3}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 4}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 5}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 6}], 'tie_break_preference': 'regime_b_lr0.001_m0.9_beff64'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'paper regime B fixed-batch transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_screen_winner', 'target_effective_budget': 40000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime B on T0.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 8. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
+- Hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T1.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 2500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2500, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'B', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 1}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 2}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 3}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 4}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 5}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 6}], 'tie_break_preference': 'regime_b_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'paper regime B fixed-batch transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'regime_b_screen_winner', 'target_effective_budget': 160000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime B on T1.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 9. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
+- Hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime B and apply pure paper-derived transfer to T2.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'B', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 1}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 2}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 3}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 4}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 5}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 6}], 'tie_break_preference': 'regime_b_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': 64, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'B', 'formula_label': 'paper regime B fixed-batch transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'regime_b_screen_winner', 'target_effective_budget': 320000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime B on T2.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 10. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T0 rung.
+- Hypothesis: Regime D should extrapolate from its winning T0 anchor to T0 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T0.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'D', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 7}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 8}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 9}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 10}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 11}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 12}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 13}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 14}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 15}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 16}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 17}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 18}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 19}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 20}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 21}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 22}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 23}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 24}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 25}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 26}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 27}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 28}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 29}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 30}], 'tie_break_preference': 'regime_d_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 40000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Dynamic reuse train artifact: `{'t0_winner': {'kind': 'screen_winner_artifact', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 7}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 8}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 9}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 10}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 11}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 12}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 13}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 14}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 15}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 16}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 17}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 18}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 19}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 20}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 21}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 22}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 23}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 24}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 25}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 26}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 27}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 28}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 29}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 30}], 'tie_break_preference': 'regime_d_lr0.001_m0.9_beff64'}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'paper regime D joint batch+momentum+lr transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_screen_winner', 'target_effective_budget': 40000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime D on T0.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 11. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
+- Hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T1.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 2500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 2500, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'D', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 7}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 8}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 9}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 10}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 11}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 12}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 13}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 14}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 15}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 16}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 17}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 18}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 19}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 20}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 21}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 22}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 23}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 24}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 25}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 26}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 27}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 28}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 29}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 30}], 'tie_break_preference': 'regime_d_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 160000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'paper regime D joint batch+momentum+lr transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T1', 'candidate_label': 'regime_d_screen_winner', 'target_effective_budget': 160000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime D on T1.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 12. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
+- Hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without local retuning.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Lock the winning T0 anchor for regime D and apply pure paper-derived transfer to T2.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 5000}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 5000, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Dynamic training overrides: `{'transfer_schedule': {'kind': 'screen_winner_transfer', 'regime_label': 'D', 'compare_orders': [{'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 7}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 8}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 9}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 10}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 11}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 12}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 13}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 14}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 15}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 16}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 17}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 18}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 19}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 20}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 21}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 22}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 23}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 24}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 25}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 26}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 27}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 28}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 29}, {'sweep_id': 'tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1', 'order': 30}], 'tie_break_preference': 'regime_d_lr0.001_m0.9_beff64', 'base_effective_budget': 40000, 'target_effective_budget': 320000, 'fixed_effective_batch': None, 'min_lr_ratio': 0.001, 'max_budget_drift': 0.02}}`
+- Transfer context: `{'phase': 'validation', 'regime_label': 'D', 'formula_label': 'paper regime D joint batch+momentum+lr transfer', 'base_budget_label': 'T0', 'target_budget_label': 'T2', 'candidate_label': 'regime_d_screen_winner', 'target_effective_budget': 320000}`
+- Parameter adequacy plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1 before executing regime D on T2.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation from the kept T0 anchor.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `benchmark_full`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1; this row stays placeholder-only until screen metrics exist.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/queue.yaml
@@ -1,0 +1,1958 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_009_muon_training_dynamics_transfer_medium_v1
+rows:
+- order: 1
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 4fc459d869ad4846c6cfae41b5c03ff051b4d47a924f1126afbec3d8ee4a7c5a
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the transfer study
+    without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 09 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 625
+    max_grad_norm: 3.595210751679737
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 563.5871033887379
+    wall_elapsed_seconds: 572.867870552931
+    peak_vram_allocated: 3068066304
+    peak_vram_reserved: 7589593088
+    end_to_end_wall_seconds: 593.1992791611701
+    loader_setup_seconds: 20.120247365906835
+    throughput_examples_per_second: 70.97394486049788
+    throughput_tokens_per_second: 424133.93522087584
+    non_train_overhead_seconds: 9.431410214398056
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 635
+    tokens_per_step: 382458.2656
+    tokens_seen: 239036416
+    token_budget: 239036416
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.6461466098688694
+    final_log_loss: 0.6461466098688694
+    best_brier_score: 0.4025780370601524
+    final_brier_score: 0.4025780370601524
+    best_roc_auc: 0.6658360736913753
+    final_roc_auc: 0.6658360736913753
+    best_bpc: 2.1886389592728532
+    final_bpc: 2.1886389592728532
+    best_bpf: 2.1886385221739073
+    final_bpf: 2.1886385221739073
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.3674210980534554
+    final_train_loss_ema: 1.2829152672163924
+    final_tail_mean_train_loss: 1.3081061603531006
+    final_tail_mean_train_loss_ema: 1.3118983355389424
+    final_tail_record_count: 63
+    one_family_step_count: 580
+    mixed_family_step_count: 45
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 575
+    family_block_count: 580
+    estimated_family_switch_count: 579
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 9
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_09_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 2
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: a4c7d3c6553c38115717e1178045a9b795c21c50d5104cbea7c9e02b3125eb6f
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the transfer study
+    without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 11 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 2500
+    max_grad_norm: 4.271018091022219
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 1961.8925335267559
+    wall_elapsed_seconds: 1980.4997803838924
+    peak_vram_allocated: 3068090368
+    peak_vram_reserved: 7765753856
+    end_to_end_wall_seconds: 2001.2573917103
+    loader_setup_seconds: 20.55282300291583
+    throughput_examples_per_second: 81.55390637650233
+    throughput_tokens_per_second: 487893.3089567956
+    non_train_overhead_seconds: 18.75265457155183
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 2520
+    tokens_per_step: 382877.696
+    tokens_seen: 957194240
+    token_budget: 957194240
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.507891654839319
+    final_log_loss: 0.507891654839319
+    best_brier_score: 0.30953249632666074
+    final_brier_score: 0.30953249632666074
+    best_roc_auc: 0.7718923833213517
+    final_roc_auc: 0.7718923833213517
+    best_bpc: 2.396527912263809
+    final_bpc: 2.396527912263809
+    best_bpf: 2.396453592980478
+    final_bpf: 2.396453592980478
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0272985249757767
+    final_train_loss_ema: 1.095487027726373
+    final_tail_mean_train_loss: 1.1281592704206704
+    final_tail_mean_train_loss_ema: 1.1312624687628345
+    final_tail_record_count: 250
+    one_family_step_count: 147
+    mixed_family_step_count: 2353
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 139
+    family_block_count: 147
+    estimated_family_switch_count: 146
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 11
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_11_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 3
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1
+  status: ready
+  rationale: Import the corrected 144x4 low-batch Muon baseline from the completed
+    NS sweep without retraining.
+  hypothesis: The carried low-batch 144x4 baseline anchors the faithful transfer study
+    and should remain a valid corrected benchmark reference at the matching budget
+    rung.
+  anchor_delta: Reuse the completed NS low-batch train artifact and benchmark it into
+    the transfer study without retraining.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  reuse_train_artifact:
+    run_dir: outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1/sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1/train
+    training_surface_fingerprint: 7ced1d99f22a54bfcb426e1cfb57b5f40bfc925b674839077baadc1b8d838e40
+  parameter_adequacy_plan:
+  - Do not retrain the carried low-batch baseline; benchmark only from the preserved
+    NS train artifact.
+  - Keep the corrected medium anchor benchmark fixed so the low-batch baseline remains
+    directly comparable to the transfer regimes.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this imported low-batch baseline into the transfer study
+    without retraining.
+  notes:
+  - Import low-batch baseline provenance from tf_rd_009_muon_ns_one_epoch_medium_v1
+    order 12 (sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1).
+  - This baseline remains corrected-medium multiclass only and should not drift to
+    any binary benchmark surface.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics:
+    best_step: 5000
+    max_grad_norm: 2.936327000965149
+    clipped_step_fraction: 0.0
+    train_elapsed_seconds: 3780.5150319170207
+    wall_elapsed_seconds: 3812.982417874038
+    peak_vram_allocated: 3068100608
+    peak_vram_reserved: 8241807360
+    end_to_end_wall_seconds: 3833.3359849727713
+    loader_setup_seconds: 20.149004251230508
+    throughput_examples_per_second: 84.64455168102708
+    throughput_tokens_per_second: 506299.0158326164
+    non_train_overhead_seconds: 32.61169299064204
+    loader_effective_num_workers: 8
+    loader_effective_prefetch_factor: 4
+    compile_shape_dispatch_max_families: 16
+    loader_task_batch_cache_mode: bounded_streaming
+    compile_shape_dispatch_mode: signature_family
+    compile_dispatch_compiled_family_count: 16
+    compile_dispatch_family_switch_count: 5024
+    tokens_per_step: 382814.208
+    tokens_seen: 1914071040
+    token_budget: 1914071040
+    unique_task_budget: 1343408
+    objective_metric: final_log_loss_at_matched_regime_budget
+    curriculum_id: tf_rd_010_dagzoo_medium_control
+    best_log_loss: 0.49140312704015116
+    final_log_loss: 0.49140312704015116
+    best_brier_score: 0.29893815856001277
+    final_brier_score: 0.29893815856001277
+    best_roc_auc: 0.78658115657993
+    final_roc_auc: 0.78658115657993
+    best_bpc: 3.032832350861403
+    final_bpc: 3.032832350861403
+    best_bpf: 3.0327029591538555
+    final_bpf: 3.0327029591538555
+    final_minus_best_bpc: 0.0
+    final_minus_best_bpf: 0.0
+    final_minus_best_log_loss: 0.0
+    final_minus_best_brier_score: 0.0
+    final_minus_best_roc_auc: 0.0
+    drift: 0.0
+    final_train_loss: 1.0004463642835617
+    final_train_loss_ema: 1.026697086549313
+    final_tail_mean_train_loss: 1.0992620735913514
+    final_tail_mean_train_loss_ema: 1.1018730984280445
+    final_tail_record_count: 500
+    one_family_step_count: 225
+    mixed_family_step_count: 4775
+    consecutive_repeated_family_step_count: 0
+    consecutive_switched_family_step_count: 217
+    family_block_count: 225
+    estimated_family_switch_count: 224
+  parent_delta_ref: null
+  imported_baseline_provenance:
+    source_sweep_id: tf_rd_009_muon_ns_one_epoch_medium_v1
+    source_order: 12
+    source_run_id: sd_tf_rd_009_muon_ns_one_epoch_medium_v1_12_delta_tf_rd_009_cls_sandwich_dicl144_layers4_v1_v1
+    source_kind: carry_lowbatch
+  transfer_context:
+    phase: baseline
+    regime_label: carry_lowbatch
+    formula_label: carried low-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_lowbatch
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 4
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 156
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 156
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 39936
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    paper-derived regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 40000
+    realized_effective_budget: 39936
+    budget_drift: -0.0016000000000000458
+    batch_drift: 0.0
+- order: 5
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    paper-derived regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 160000
+    realized_effective_budget: 160000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 6
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1
+  status: ready
+  rationale: Carry the empirical 144x4 Muon high-batch baseline into the faithful
+    transfer study at the requested budget rung.
+  hypothesis: A pure carry-forward high-batch baseline distinguishes the value of
+    budget-faithful transfer from a simple fixed high-batch contract.
+  anchor_delta: Keep the carried Muon high-batch optimizer surface and adjust only
+    the step budget needed for the requested rung.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 16
+        max_steps: 1250
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 1250
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use the carried high-batch Muon contract as a baseline against the paper-derived
+    transfer regimes.
+  - Do not let runtime or wall time override corrected benchmark log loss when deciding
+    whether this baseline still merits a later Phase-2B rerun.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Benchmark this carried high-batch baseline and compare it against the
+    paper-derived regimes on corrected benchmark log loss.
+  notes:
+  - The earlier heuristic selector remains preserved context only; this row is the
+    budget-faithful carried high-batch baseline for the transfer study.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: baseline
+    regime_label: carry_highbatch
+    formula_label: carried high-batch baseline
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: carry_highbatch
+    target_effective_batch: 256
+    realized_effective_batch: 256
+    target_effective_budget: 320000
+    realized_effective_budget: 320000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 7
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T0 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T0 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T0.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime B on T0.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime B on T0 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: B
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 1
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 2
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 3
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 4
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 5
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 6
+      tie_break_preference: regime_b_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 40000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B fixed-batch transfer
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_screen_winner
+    target_effective_budget: 40000
+  dynamic_reuse_train_artifact:
+    t0_winner:
+      kind: screen_winner_artifact
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 1
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 2
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 3
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 4
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 5
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 6
+      tie_break_preference: regime_b_lr0.001_m0.9_beff64
+- order: 8
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T1 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime B on T1.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime B on T1 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: B
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 1
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 2
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 3
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 4
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 5
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 6
+      tie_break_preference: regime_b_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B fixed-batch transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: regime_b_screen_winner
+    target_effective_budget: 160000
+  dynamic_reuse_train_artifact: null
+- order: 9
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime B at 144x4 on the T2 rung.
+  hypothesis: Regime B should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime B and apply pure paper-derived
+    transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime B on T2.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime B on T2 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: B
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 1
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 2
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 3
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 4
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 5
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 6
+      tie_break_preference: regime_b_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: 64
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: B
+    formula_label: paper regime B fixed-batch transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: regime_b_screen_winner
+    target_effective_budget: 320000
+  dynamic_reuse_train_artifact: null
+- order: 10
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T0 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T0 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T0.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime D on T0.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime D on T0 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: D
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 7
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 8
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 9
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 10
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 11
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 12
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 13
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 14
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 15
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 16
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 17
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 18
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 19
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 20
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 21
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 22
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 23
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 24
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 25
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 26
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 27
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 28
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 29
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 30
+      tie_break_preference: regime_d_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 40000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D joint batch+momentum+lr transfer
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_screen_winner
+    target_effective_budget: 40000
+  dynamic_reuse_train_artifact:
+    t0_winner:
+      kind: screen_winner_artifact
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 7
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 8
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 9
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 10
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 11
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 12
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 13
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 14
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 15
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 16
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 17
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 18
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 19
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 20
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 21
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 22
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 23
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 24
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 25
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 26
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 27
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 28
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 29
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 30
+      tie_break_preference: regime_d_lr0.001_m0.9_beff64
+- order: 11
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T1 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T1 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T1.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 2500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 2500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 160000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime D on T1.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime D on T1 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: D
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 7
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 8
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 9
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 10
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 11
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 12
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 13
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 14
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 15
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 16
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 17
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 18
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 19
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 20
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 21
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 22
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 23
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 24
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 25
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 26
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 27
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 28
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 29
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 30
+      tie_break_preference: regime_d_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 160000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D joint batch+momentum+lr transfer
+    base_budget_label: T0
+    target_budget_label: T1
+    candidate_label: regime_d_screen_winner
+    target_effective_budget: 160000
+  dynamic_reuse_train_artifact: null
+- order: 12
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Apply faithful paper-derived transfer regime D at 144x4 on the T2 rung.
+  hypothesis: Regime D should extrapolate from its winning T0 anchor to T2 without
+    local retuning.
+  anchor_delta: Lock the winning T0 anchor for regime D and apply pure paper-derived
+    transfer to T2.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 5000
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 5000
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 320000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+    before executing regime D on T2.
+  - Do not retune beyond the screen winner; larger-budget rows must be pure extrapolation
+    from the kept T0 anchor.
+  execution_policy: benchmark_full
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Execute regime D on T2 only after the T0 screen chooses its anchor.
+  notes:
+  - Resolve the winning T0 anchor from tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1;
+    this row stays placeholder-only until screen metrics exist.
+  dynamic_model_overrides: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dynamic_training_overrides:
+    transfer_schedule:
+      kind: screen_winner_transfer
+      regime_label: D
+      compare_orders:
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 7
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 8
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 9
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 10
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 11
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 12
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 13
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 14
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 15
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 16
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 17
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 18
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 19
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 20
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 21
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 22
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 23
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 24
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 25
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 26
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 27
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 28
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 29
+      - sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+        order: 30
+      tie_break_preference: regime_d_lr0.001_m0.9_beff64
+      base_effective_budget: 40000
+      target_effective_budget: 320000
+      fixed_effective_batch: null
+      min_lr_ratio: 0.001
+      max_budget_drift: 0.02
+  transfer_context:
+    phase: validation
+    regime_label: D
+    formula_label: paper regime D joint batch+momentum+lr transfer
+    base_budget_label: T0
+    target_budget_label: T2
+    candidate_label: regime_d_screen_winner
+    target_effective_budget: 320000
+  dynamic_reuse_train_artifact: null

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
 sweep_id: tf_rd_009_muon_training_dynamics_transfer_medium_v1
 parent_sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
-status: draft
+status: superseded
 complexity_level: classification_md
 anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
 benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -16,9 +16,8 @@ upstream_reference:
   model_source: https://arxiv.org/abs/2603.15958
 anchor_surface:
   notes:
-  - 'This sweep is the active #284 faithful transfer study, and the earlier
-    heuristic selector is now superseded context rather than the canonical
-    training-dynamics decision surface.'
+  - 'This sweep is superseded context only; the active #284 study is now the strict
+    shared-anchor LMO transfer sweep tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1.'
   - Keep geometry fixed at 144x4 and compare carried low-batch, carried high-batch,
     Regime B, and Regime D across T0/T1/T2.
   - The earlier 5000-step high-batch selector row remains preserved historical context

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_medium_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
-sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
-parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-status: superseded
+sweep_id: tf_rd_009_muon_training_dynamics_transfer_medium_v1
+parent_sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+status: draft
 complexity_level: classification_md
 anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
 benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -9,25 +9,23 @@ control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
 external_benchmarks: []
 training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
-surface_role: classification_training_dynamics_selector
+surface_role: classification_training_dynamics_transfer
 comparison_policy: anchor_only
 upstream_reference:
-  name: PerceiverIO
-  model_source: https://openreview.net/forum?id=fILj7WpI-g
+  name: Deriving Hyperparameter Scaling Laws via Modern Optimization Theory
+  model_source: https://arxiv.org/abs/2603.15958
 anchor_surface:
   notes:
-  - 'PR #280 closed the corrected Muon Phase-2 study as a directional `L(N,S)` result,
-    not a stable compute-optimal law surface.'
-  - 'The next defended TF-RD-009 move is cleanup-first navigation and contract hardening
-    under #283, then the compact training-dynamics selector under #284.'
-  - Keep `60x2` as the formal external Muon anchor from `tf_rd_009_muon_width_screen_medium_v1`,
-    but carry `128x2` as the in-family baseline into this selector.
-  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
-    corpus fixed; historical schedulefree TF-RD-009 remains preserved context only.
-  - Rank selector rows on the quality/time Pareto frontier before any Muon Phase-2B
-    rerun or upper-family reopening.
-  - 'Superseded by the faithful paper-derived transfer screen plus validation sweeps
-    under issue #284; keep this selector as historical context only.'
+  - 'This sweep is the active #284 faithful transfer study, and the earlier
+    heuristic selector is now superseded context rather than the canonical
+    training-dynamics decision surface.'
+  - Keep geometry fixed at 144x4 and compare carried low-batch, carried high-batch,
+    Regime B, and Regime D across T0/T1/T2.
+  - The earlier 5000-step high-batch selector row remains preserved historical context
+    only; the formal transfer surface stays budget-faithful to the rung-equivalent
+    effective-task budgets.
+  - Primary decision criterion is corrected benchmark log loss on openml_classification_medium_v1;
+    runtime remains diagnostic only.
   dimension_table: []
 anchor_context:
   run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/matrix.md
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/matrix.md
@@ -1,0 +1,1118 @@
+# System Delta Matrix
+
+This file is rendered from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml` (derived from `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/queue.yaml` plus `reference/system_delta_catalog.yaml`) and the canonical benchmark registry.
+
+## Sweep
+
+- Sweep id: `tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1`
+- Sweep status: `draft`
+- Parent sweep id: `tf_rd_009_muon_batch_critical_one_epoch_medium_v1`
+- Complexity level: `classification_md`
+- Resolved queue path: `reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml`
+- Resolved queue inputs fingerprint: `4e0f5eb1a50b7ef600b55d93c12d9cfeb813add417a9064b385064cf54d7ec3e`
+
+## Locked Surface
+
+- Anchor run id: `sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1`
+- Benchmark manifest: local benchmark-manifest id `openml_classification_medium_v1`
+- Control baseline id: `cls_benchmark_linear_multiclass_medium_v1`
+- External benchmarks: `none`
+- Training experiment: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Training config profile: `cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1`
+- Surface role: `classification_training_dynamics_transfer_screen`
+- Comparison policy: `anchor_only`
+- Anchor metrics: final BPC `2.1383`, final BPF `2.1383`, final log loss `0.3951`, final Brier score `0.2585`, best ROC AUC `0.7563`, final ROC AUC `0.7583`, final training time `8686.8s`
+
+## Anchor Comparison
+
+Upstream reference: `Deriving Hyperparameter Scaling Laws via Modern Optimization Theory` from `https://arxiv.org/abs/2603.15958`.
+
+| Dimension | Upstream Deriving Hyperparameter Scaling Laws via Modern Optimization Theory | Locked anchor | Interpretation |
+| --- | --- | --- | --- |
+
+## Queue Summary
+
+| Order | Delta | Family | Binary | Status | Recipe alias | Effective change | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 2 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 3 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 4 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 5 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 6 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget. | Screen regime B on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 7 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 8 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 9 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 10 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 11 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 12 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 13 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 14 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 15 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 16 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 17 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 18 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 19 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 20 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 21 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 22 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 23 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 24 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 25 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 26 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 27 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 28 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 29 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+| 30 | `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1` | classification_scaling_law | no | ready | none | Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget. | Screen regime D on T0 and keep only the winning candidate for benchmark-backed transfer validation. |
+
+## Detailed Rows
+
+### 1. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.001_m0.9_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 2. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.001_m0.95_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 3. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.001_m0.975_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 4. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.002_m0.9_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 5. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.002_m0.95_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 6. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective batch fixed while transferring Muon momentum and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+- Hypothesis: Regime B candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the paper fixed-batch transfer law is the better inductive bias, the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'B', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_b_lr0.002_m0.975_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 7. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.9_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 8. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.95_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 9. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.975_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 10. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.9_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 11. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.95_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 12. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 4, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 625}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 4, 'max_steps': 625}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 625, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.975_beff64', 'target_effective_batch': 64, 'realized_effective_batch': 64, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 13. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.9_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 14. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.95_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 15. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.975_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 16. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.9_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 17. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.95_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 18. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=80 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 5, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 500}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 5, 'max_steps': 500}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 500, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.975_beff80', 'target_effective_batch': 80, 'realized_effective_batch': 80, 'target_effective_budget': 40000, 'realized_effective_budget': 40000, 'budget_drift': 0.0, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 19. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.9_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 20. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.95_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 21. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.975_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 22. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.9_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 23. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.95_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 24. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=96 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 6, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 417}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 6, 'max_steps': 417}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 417, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.975_beff96', 'target_effective_batch': 96, 'realized_effective_batch': 96, 'target_effective_budget': 40000, 'realized_effective_budget': 40032, 'budget_drift': 0.0007999999999999119, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 25. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.9_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 26. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.95_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 27. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 1e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.001, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.001_m0.975_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 28. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.9}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.9_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 29. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.95}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.95_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending
+
+### 30. `delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1`
+
+- Dimension family: `training`
+- Status: `ready`
+- Binary applicable: `False`
+- Recipe alias: `none`
+- Description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers effective batch, Muon momentum, and lr with budget.
+- Rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+- Hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=128 may be the best T0 anchor for faithful transfer.
+- Upstream delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+- Anchor delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any extrapolation.
+- Expected effect: If the joint batch+momentum+lr transfer law is the better inductive bias, the screened T0 anchor should beat both carried baselines on corrected benchmark log loss.
+- Effective labels: model=`tabfoundry_sandwich`, data=`tf_rd_010_dagzoo_medium_control`, preprocessing=`runtime_default`, training=`prior_cosine_warmup`
+- Resolved surface fingerprint: `09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7`
+- Resolved runtime surface: `{'seed': 1, 'mixed_precision': 'bf16', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'non_blocking_device_transfer': True, 'grad_clip': 0.0, 'grad_accum_steps': 8, 'compile_model': True, 'compile_dynamic': True, 'compile_backend': 'eager', 'compile_mode': 'max-autotune-no-cudagraphs', 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'trace_activations': False, 'signature_family_run_length': 4, 'module_grad_norm_every': 1, 'profile_step_timing': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'max_steps': 313}`
+- Training overrides: `{'optimizer': {'name': 'muon', 'require_requested': True, 'weight_decay': 0.01, 'betas': [0.9, 0.95], 'min_lr': 2e-06, 'muon_per_parameter_lr': True, 'muon_lr_scale_base': 0.2, 'muon_partition_non2d': True, 'momentum': 0.975}, 'runtime': {'mixed_precision': 'bf16', 'grad_clip': 0.0, 'trace_activations': False, 'activation_checkpointing': True, 'eval_every': 25, 'checkpoint_every': 25, 'val_batches': 0, 'loader_task_batch_cache': False, 'loader_task_batch_cache_mode': 'bounded_streaming', 'num_workers': 'auto', 'loader_pin_memory': True, 'loader_persistent_workers': False, 'loader_prefetch_factor': 'auto', 'non_blocking_device_transfer': True, 'compile_model': True, 'compile_backend': 'eager', 'compile_dynamic': True, 'compile_shape_dispatch_mode': 'signature_family', 'compile_shape_dispatch_max_families': 16, 'signature_family_run_length': 4, 'grad_accum_steps': 8, 'max_steps': 313}, 'schedule': {'stages': [{'name': 'prior_dump', 'steps': 313, 'lr_max': 0.002, 'lr_schedule': 'linear', 'warmup_ratio': 0.1}]}}`
+- Transfer context: `{'phase': 'screen', 'regime_label': 'D', 'formula_label': 'paper T0 screen anchor', 'base_budget_label': 'T0', 'target_budget_label': 'T0', 'candidate_label': 'regime_d_lr0.002_m0.975_beff128', 'target_effective_batch': 128, 'realized_effective_batch': 128, 'target_effective_budget': 40000, 'realized_effective_budget': 40064, 'budget_drift': 0.0016000000000000458, 'batch_drift': 0.0}`
+- Parameter adequacy plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope, then clipped_step_fraction, then final_train_loss_ema.
+- Adequacy knobs to dimension explicitly:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+- Execution policy: `screen_only`
+- Benchmark checkpoint selection: `best_and_final`
+- Interpretation status: `pending`
+- Decision: `None`
+- Notes:
+  - Faithful paper-derived transfer screen under issue #284; hold geometry fixed at 144x4.
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+- Follow-up run ids: `[]`
+- Result card path: `outputs/staged_ladder/research/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1/result_card.md`
+- Benchmark metrics: pending

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/queue.yaml
@@ -1,0 +1,3753 @@
+schema: tab-foundry-system-delta-sweep-queue-v1
+sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+rows:
+- order: 1
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 2
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 3
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 4
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 5
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 6
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 7
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 8
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 9
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 10
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 11
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 12
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 13
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 14
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 15
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 16
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 17
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 18
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 19
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 20
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 21
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 22
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 23
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 24
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 25
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 26
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 27
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=128 may
+    be the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 28
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 29
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 30
+  delta_ref: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=128 may
+    be the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml
@@ -253,7 +253,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -621,7 +621,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -989,7 +989,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -1357,7 +1357,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -1725,7 +1725,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2093,7 +2093,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2462,7 +2462,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -2831,7 +2831,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -3200,7 +3200,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -3569,7 +3569,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -3938,7 +3938,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -4307,7 +4307,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -4676,7 +4676,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -5045,7 +5045,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -5414,7 +5414,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -5783,7 +5783,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -6152,7 +6152,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -6521,7 +6521,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -6890,7 +6890,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -7259,7 +7259,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -7628,7 +7628,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -7997,7 +7997,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -8366,7 +8366,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -8735,7 +8735,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -9104,7 +9104,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -9473,7 +9473,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -9842,7 +9842,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -10211,7 +10211,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -10580,7 +10580,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454
@@ -10949,7 +10949,7 @@ rows:
       corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
       corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
       manifest:
-        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+        manifest_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
       dagzoo_provenance:
         acceptance_rate: 0.9985836421932587
         accepted_datasets: 1729454

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml
@@ -1,0 +1,11114 @@
+schema: tab-foundry-system-delta-resolved-queue-v1
+generated_from_sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+catalog_path: reference/system_delta_catalog.yaml
+canonical_sweep_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/sweep.yaml
+canonical_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/queue.yaml
+canonical_matrix_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/matrix.md
+sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
+parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
+sweep_status: draft
+complexity_level: classification_md
+anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
+control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
+external_benchmarks: []
+training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+surface_role: classification_training_dynamics_transfer_screen
+comparison_policy: anchor_only
+upstream_reference:
+  name: Deriving Hyperparameter Scaling Laws via Modern Optimization Theory
+  model_source: https://arxiv.org/abs/2603.15958
+anchor_surface:
+  notes:
+  - 'This sweep replaces the compact heuristic selector as the active #284 screen
+    and treats the earlier selector as superseded context only.'
+  - Hold geometry fixed at 144x4 and use the paper-derived budget-transfer study to
+    choose one T0 anchor for Regime B and one for Regime D.
+  - Regime B keeps effective batch fixed at 64 while scaling momentum and lr with
+    budget; Regime D jointly scales batch, momentum, and lr.
+  - Use the corrected openml_classification_medium_v1 anchor benchmark with natural
+    missingness preserved; fail fast if any row drifts to a binary surface.
+  dimension_table: []
+anchor_context:
+  run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
+  experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
+  model:
+    arch: tabfoundry_sandwich
+    benchmark_profile: null
+    stage: null
+    stage_label: null
+    module_selection: null
+  surface_labels:
+    data: tf_rd_010_dagzoo_medium_control
+    model: tabfoundry_sandwich
+    preprocessing: runtime_default
+    training: prior_cosine_warmup
+rows:
+- order: 1
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 2
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 3
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.001_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 4
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 5
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 6
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime B at 144x4 on T0.
+  hypothesis: Regime B candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime B on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime B, which keeps effective
+    batch fixed while transferring Muon momentum and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the paper fixed-batch transfer law is the better inductive bias,
+    the screened T0 anchor should extrapolate cleanly to T1/T2 without local retuning.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: B
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_b_lr0.002_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 7
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 8
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 9
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: 6da2f3eeb7d91544df4285a2b2060bda44950c8e0b2a4f2f82552abb2b8f6567
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 10
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 11
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 12
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=64 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 4
+        max_steps: 625
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 625
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 625
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 4
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 625
+  resolved_surface_fingerprint: b1b16140b1c4030d2da1e02fa2bb39adca58cda45df052302e78c0db9961893f
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff64
+    target_effective_batch: 64
+    realized_effective_batch: 64
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 13
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 14
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 15
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 0652cd7a1a2f4f4378b0bc4201fd46927d3237fff532f57e865f87d945e715a1
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 16
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 17
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 18
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=80 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 5
+        max_steps: 500
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 500
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40000
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 500
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 5
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 500
+  resolved_surface_fingerprint: 633593b78c242bf9b3d024d12f3f9e74515c92df6c4610eb748f401437e0ce50
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff80
+    target_effective_batch: 80
+    realized_effective_batch: 80
+    target_effective_budget: 40000
+    realized_effective_budget: 40000
+    budget_drift: 0.0
+    batch_drift: 0.0
+- order: 19
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 20
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 21
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: df8dc783cbed79e092a8cb91b10990e689e1bb0f79e5e24184b66da7ef85d9c8
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 22
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: 66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 23
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: 66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 24
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=96 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 6
+        max_steps: 417
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 417
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40032
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 417
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 6
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 417
+  resolved_surface_fingerprint: 66ff51cd4381a71a8b2e32bab1785f7d94c1361830e0bdb47353ec65466265dd
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff96
+    target_effective_batch: 96
+    realized_effective_batch: 96
+    target_effective_budget: 40000
+    realized_effective_budget: 40032
+    budget_drift: 0.0007999999999999119
+    batch_drift: 0.0
+- order: 25
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.9, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.9_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 26
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.95, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.95_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 27
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.001, momentum=0.975, B_eff=128 may
+    be the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 1.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.001
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 1.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.001
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 1770a916bb5a44aa876d02f68fefe83658abdd2f262db49c43d7611a0fb12d56
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.001_m0.975_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 28
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.9, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.9
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.9_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 29
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.95, B_eff=128 may be
+    the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.95
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.95_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+- order: 30
+  delta_id: delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_d_v1
+  status: ready
+  rationale: Paper-derived Muon transfer screen row for regime D at 144x4 on T0.
+  hypothesis: Regime D candidate with lr_max=0.002, momentum=0.975, B_eff=128 may
+    be the best T0 anchor for faithful transfer.
+  anchor_delta: Hold 144x4 fixed and screen the paper-derived T0 anchor before any
+    extrapolation.
+  model:
+    arch: tabfoundry_sandwich
+    input_normalization: train_zscore_clip
+    many_class_base: 10
+    head_hidden_dim: 96
+    sandwich_latents: 24
+    sandwich_heads: 1
+    sandwich_ff_expansion: 2
+    sandwich_summary_tokens_per_axis: 3
+    sandwich_self_attention_per_cross: 4
+    sandwich_pre_row_attention_layers: 1
+    sandwich_pre_column_attention_layers: 1
+    sandwich_pre_column_inducing_tokens: 16
+    feature_type_conditioning: film
+    floating_likelihood: single_gaussian
+    integer_likelihood: hybrid_mixture
+    d_icl: 144
+    sandwich_layers: 4
+  data:
+    surface_label: tf_rd_010_dagzoo_medium_control
+    source: manifest
+    corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+    surface_overrides:
+      source: manifest
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+  preprocessing:
+    surface_label: runtime_default
+  training:
+    surface_label: prior_cosine_warmup
+    task_batch_size: 16
+    prior_dump_batch_size: 64
+    overrides:
+      optimizer:
+        name: muon
+        require_requested: true
+        weight_decay: 0.01
+        betas:
+        - 0.9
+        - 0.95
+        min_lr: 2.0e-06
+        muon_per_parameter_lr: true
+        muon_lr_scale_base: 0.2
+        muon_partition_non2d: true
+        momentum: 0.975
+      runtime:
+        mixed_precision: bf16
+        grad_clip: 0.0
+        trace_activations: false
+        activation_checkpointing: true
+        eval_every: 25
+        checkpoint_every: 25
+        val_batches: 0
+        loader_task_batch_cache: false
+        loader_task_batch_cache_mode: bounded_streaming
+        num_workers: auto
+        loader_pin_memory: true
+        loader_persistent_workers: false
+        loader_prefetch_factor: auto
+        non_blocking_device_transfer: true
+        compile_model: true
+        compile_backend: eager
+        compile_dynamic: true
+        compile_shape_dispatch_mode: signature_family
+        compile_shape_dispatch_max_families: 16
+        signature_family_run_length: 4
+        grad_accum_steps: 8
+        max_steps: 313
+      schedule:
+        stages:
+        - name: prior_dump
+          steps: 313
+          lr_max: 0.002
+          lr_schedule: linear
+          warmup_ratio: 0.1
+    one_epoch_contract:
+      enabled: true
+      scope: train_manifest_unique_tasks
+      required_train_tasks_expression: max_steps * task_batch_size * grad_accum_steps
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      largest_required_train_tasks: 40064
+      expected_train_records_available: 1344081
+  parameter_adequacy_plan:
+  - Use train-only screen metrics to choose exactly one T0 anchor per paper regime
+    before any benchmark or larger-budget transfer.
+  - Rank candidates by lower upper_block_final_window_mean, then upper_block_post_warmup_mean_slope,
+    then clipped_step_fraction, then final_train_loss_ema.
+  execution_policy: screen_only
+  benchmark_checkpoint_selection: best_and_final
+  run_id: null
+  followup_run_ids: []
+  decision: null
+  interpretation_status: pending
+  confounders: []
+  next_action: Screen regime D on T0 and keep only the winning candidate for benchmark-backed
+    transfer validation.
+  notes:
+  - 'Faithful paper-derived transfer screen under issue #284; hold geometry fixed
+    at 144x4.'
+  - This row is train-only and exists solely to choose the T0 anchor for its regime.
+  dynamic_model_overrides: null
+  reuse_train_artifact: null
+  screen_metrics: null
+  benchmark_metrics: null
+  parent_delta_ref: null
+  dimension_family: training
+  family: classification_scaling_law
+  binary_applicable: false
+  description: Hold 144x4 fixed and instantiate paper Regime D, which jointly transfers
+    effective batch, Muon momentum, and lr with budget.
+  upstream_delta: Faithful TF-RD-009 Muon transfer study derived from https://arxiv.org/abs/2603.15958.
+  entangled_legacy_stage: none
+  expected_effect: If the joint batch+momentum+lr transfer law is the better inductive
+    bias, the screened T0 anchor should beat both carried baselines on corrected benchmark
+    log loss.
+  adequacy_knobs:
+  - paper-derived budget transfer law
+  - corrected openml_classification_medium_v1 anchor benchmark
+  - 144x4 geometry held fixed
+  parameter_adequacy_policy:
+    default_plan: []
+  applicability_guards: []
+  resolved_surface:
+    labels:
+      model: tabfoundry_sandwich
+      data: tf_rd_010_dagzoo_medium_control
+      preprocessing: runtime_default
+      training: prior_cosine_warmup
+    model:
+      arch: tabfoundry_sandwich
+      stage: null
+      stage_label: null
+      input_normalization: train_zscore_clip
+      feature_group_size: 1
+      many_class_base: 10
+      build_spec:
+        task: classification
+        arch: tabfoundry_sandwich
+        input_normalization: train_zscore_clip
+        feature_group_size: 1
+        many_class_train_mode: path_nll
+        max_mixed_radix_digits: 64
+        norm_type: layernorm
+        many_class_base: 10
+        d_col: 128
+        d_icl: 144
+        head_hidden_dim: 96
+        pre_encoder_clip: null
+        sandwich_latents: 24
+        sandwich_layers: 4
+        sandwich_heads: 1
+        sandwich_ff_expansion: 2
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        sandwich_summary_tokens_per_axis: 3
+        sandwich_self_attention_per_cross: 4
+        sandwich_pre_row_attention_layers: 1
+        sandwich_pre_column_attention_layers: 1
+        sandwich_pre_column_inducing_tokens: 16
+        sandwich_packed_attention: true
+        feature_type_conditioning: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+      architecture:
+        initial_input_tokens: full_cell_plus_row_col_summary_stream
+        initial_input_token_count: R_times_C_plus_K_times_(R_plus_C)
+        repeated_input_tokens: row_col_summary_stream
+        repeated_input_token_count: K_times_(R_plus_C)
+        summary_tokens_per_axis: 3
+        pre_perceiver_cell_mixer: row_feature_self_attention_then_column_row_isab
+        pre_row_attention_layers: 1
+        pre_column_attention_layers: 1
+        pre_column_inducing_tokens: 16
+        label_injection: fused_into_row_summaries_and_feature_cells
+        summary_builder: summary_query_attention
+        position_encoding: shared_fourier_row_col
+        feature_type_encoding: film
+        floating_likelihood: single_gaussian
+        integer_likelihood: hybrid_mixture
+        sandwich_activation: gelu
+        sandwich_block_norm: layernorm
+        latent_core: stage0_full_cell_plus_summary_then_summary_repeated_cross_self_stages
+        layer_semantics: stage0_hybrid_then_summary_repeated_stages
+        readout: latent_then_full_cell_cross_attention_then_latent_conditioned_query_pool
+        latents: 24
+        layers: 4
+        heads: 1
+        ff_expansion: 2
+        self_attention_per_cross: 4
+    data:
+      surface_label: tf_rd_010_dagzoo_medium_control
+      source: manifest
+      filter_policy: null
+      allow_missing_values: true
+      corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      requested_corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+      materialization_state: finalized
+      recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+      corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+      corpus_record_path: outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/corpus_record.json
+      manifest:
+        manifest_path: /workspace/tab-foundry/outputs/corpora/tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953/manifest.parquet
+      dagzoo_provenance:
+        acceptance_rate: 0.9985836421932587
+        accepted_datasets: 1729454
+        comparator_role: control
+        config_refs:
+        - configs/default.yaml
+        corpus_id: tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6/tf_rd_010_dagzoo_medium_control_curated_v6__b6ad26d9c953
+        corpus_variant: tf_rd_010_dagzoo_medium_control
+        curated_accepted_datasets: 1493424
+        filter_policy: accepted_only
+        generator_fingerprint: d44739995b76
+        invocation_count: 144
+        manifest_record_count: 1493424
+        materialization_timing:
+          cumulative_copy_elapsed_seconds: 11214.598361142067
+          cumulative_filter_elapsed_seconds: 795.7731741687458
+          cumulative_generate_elapsed_seconds: 139096.5615566939
+          cumulative_generated_datasets: 1731907
+          cumulative_invocation_elapsed_seconds: 153944.14504301702
+          cumulative_local_overhead_elapsed_seconds: 2837.2119510123157
+          cumulative_round_count: 144
+          cumulative_upstream_elapsed_seconds: 139892.33473086264
+          invocation_fanout_elapsed_seconds: 6953.243410833005
+          manifest_build_elapsed_seconds: 1068.3320622059982
+          manifest_workers: 32
+          promotion_elapsed_seconds: 13.678867887007073
+          recipe_elapsed_seconds: 8035.271685323009
+          staged_compaction_elapsed_seconds: 39.46334980899701
+          staged_compaction_status: completed
+          timed_invocation_count: 144
+        provenance_labels:
+          balanced_front_shape: inherited_from_v1
+          benchmark_family: tf_rd_010
+          comparator_role: control
+          corpus_recipe_version: v6
+          corpus_variant: tf_rd_010_dagzoo_medium_control
+          downstream_issue: 205
+          manifest_record_count: 1493424
+          per_invocation_num_datasets: 10371
+          supersedes_for_tf_rd_009_phase2: tf_rd_010_dagzoo_medium_control_curated_v5
+          synthetic_epoch_regime: one_epoch_1493424_records_phase2_bcrit_5000x16x16
+          target_derivation: tabiclv2_latent_node
+          task_grid: balanced_rows_features_classes_v1
+        recipe_id: tf_rd_010_dagzoo_medium_control_curated_v6
+        recipe_kind: dagzoo_python_generated
+        rejected_datasets: 2453
+        review_summary:
+          class_counts:
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          config_refs:
+          - configs/default.yaml
+          feature_counts:
+          - 6
+          - 10
+          - 14
+          - 20
+          grid_family: balanced_rows_features_classes_v1
+          invocation_count: 144
+          manifest_record_count: 1493424
+          missingness: null
+          num_datasets_per_invocation: 10371
+          row_totals:
+          - 128
+          - 256
+          - 512
+          - 1024
+          target_derivation: tabiclv2_latent_node
+        surface_label: tf_rd_010_dagzoo_medium_control
+        target_derivation: tabiclv2_latent_node
+        target_relevant_feature_count_range:
+          max: 20
+          min: 0
+        target_relevant_feature_fraction_range:
+          max: 1.0
+          min: 0.0
+      overrides:
+        source: manifest
+        manifest_path: null
+        surface_label: tf_rd_010_dagzoo_medium_control
+        corpus_ref: tf_rd_010_dagzoo_medium_control_curated_v6
+        filter_policy: null
+        dagzoo_provenance: null
+        allow_missing_values: null
+    preprocessing:
+      surface_label: runtime_default
+      impute_missing: true
+      all_nan_fill: 0.0
+      label_mapping: train_only_remap
+      unseen_test_label_policy: filter
+      feature_order_policy: positional_feature_ids
+      dtype_policy:
+        features: float32
+        classification_labels: int64
+        regression_targets: float32
+      overrides: {}
+    training:
+      surface_label: prior_cosine_warmup
+      loss_surface: classification
+      apply_schedule: true
+      task_batch_size: 16
+      optimizer_name: muon
+      optimizer_min_lr: 2.0e-06
+      schedule_stages:
+      - name: prior_dump
+        steps: 313
+        lr_max: 0.002
+        lr_schedule: linear
+        warmup_ratio: 0.1
+      overrides: {}
+      backend: manifest
+    runtime:
+      seed: 1
+      mixed_precision: bf16
+      num_workers: auto
+      loader_pin_memory: true
+      loader_persistent_workers: false
+      loader_prefetch_factor: auto
+      loader_task_batch_cache: false
+      loader_task_batch_cache_mode: bounded_streaming
+      non_blocking_device_transfer: true
+      grad_clip: 0.0
+      grad_accum_steps: 8
+      compile_model: true
+      compile_dynamic: true
+      compile_backend: eager
+      compile_mode: max-autotune-no-cudagraphs
+      compile_shape_dispatch_mode: signature_family
+      compile_shape_dispatch_max_families: 16
+      trace_activations: false
+      signature_family_run_length: 4
+      module_grad_norm_every: 1
+      profile_step_timing: false
+      activation_checkpointing: true
+      eval_every: 25
+      checkpoint_every: 25
+      val_batches: 0
+      max_steps: 313
+  resolved_surface_fingerprint: 09eba2e92f3e1b5494dd6795f09424de49e9daead5b5c778f16708a87cd1efb7
+  transfer_context:
+    phase: screen
+    regime_label: D
+    formula_label: paper T0 screen anchor
+    base_budget_label: T0
+    target_budget_label: T0
+    candidate_label: regime_d_lr0.002_m0.975_beff128
+    target_effective_batch: 128
+    realized_effective_batch: 128
+    target_effective_budget: 40000
+    realized_effective_budget: 40064
+    budget_drift: 0.0016000000000000458
+    batch_drift: 0.0
+canonical_resolved_queue_path: reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/resolved_queue.yaml
+inputs_fingerprint: 4e0f5eb1a50b7ef600b55d93c12d9cfeb813add417a9064b385064cf54d7ec3e

--- a/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/sweep.yaml
+++ b/reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1/sweep.yaml
@@ -1,7 +1,7 @@
 schema: tab-foundry-system-delta-sweep-v1
-sweep_id: tf_rd_009_muon_training_dynamics_endpoint_medium_v1
+sweep_id: tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1
 parent_sweep_id: tf_rd_009_muon_batch_critical_one_epoch_medium_v1
-status: superseded
+status: draft
 complexity_level: classification_md
 anchor_run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1
 benchmark_manifest_path: data/manifests/bench/openml_classification_medium_v1/manifest.parquet
@@ -9,25 +9,21 @@ control_baseline_id: cls_benchmark_linear_multiclass_medium_v1
 external_benchmarks: []
 training_experiment: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
 training_config_profile: cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1
-surface_role: classification_training_dynamics_selector
+surface_role: classification_training_dynamics_transfer_screen
 comparison_policy: anchor_only
 upstream_reference:
-  name: PerceiverIO
-  model_source: https://openreview.net/forum?id=fILj7WpI-g
+  name: Deriving Hyperparameter Scaling Laws via Modern Optimization Theory
+  model_source: https://arxiv.org/abs/2603.15958
 anchor_surface:
   notes:
-  - 'PR #280 closed the corrected Muon Phase-2 study as a directional `L(N,S)` result,
-    not a stable compute-optimal law surface.'
-  - 'The next defended TF-RD-009 move is cleanup-first navigation and contract hardening
-    under #283, then the compact training-dynamics selector under #284.'
-  - Keep `60x2` as the formal external Muon anchor from `tf_rd_009_muon_width_screen_medium_v1`,
-    but carry `128x2` as the in-family baseline into this selector.
-  - Keep the corrected `openml_classification_medium_v1` benchmark and `tf_rd_010_dagzoo_medium_control_curated_v6`
-    corpus fixed; historical schedulefree TF-RD-009 remains preserved context only.
-  - Rank selector rows on the quality/time Pareto frontier before any Muon Phase-2B
-    rerun or upper-family reopening.
-  - 'Superseded by the faithful paper-derived transfer screen plus validation sweeps
-    under issue #284; keep this selector as historical context only.'
+  - 'This sweep replaces the compact heuristic selector as the active #284 screen
+    and treats the earlier selector as superseded context only.'
+  - Hold geometry fixed at 144x4 and use the paper-derived budget-transfer study to
+    choose one T0 anchor for Regime B and one for Regime D.
+  - Regime B keeps effective batch fixed at 64 while scaling momentum and lr with
+    budget; Regime D jointly scales batch, momentum, and lr.
+  - Use the corrected openml_classification_medium_v1 anchor benchmark with natural
+    missingness preserved; fail fast if any row drifts to a binary surface.
   dimension_table: []
 anchor_context:
   run_id: sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1

--- a/src/tab_foundry/bench/checkpoint_artifacts.py
+++ b/src/tab_foundry/bench/checkpoint_artifacts.py
@@ -14,6 +14,7 @@ from tab_foundry.benchmark_registry import (
     resolve_registry_path_value,
 )
 from tab_foundry.bench.artifacts import write_json
+from tab_foundry.hashing import sha256_text
 from tab_foundry.repo_paths import repo_root
 from tab_foundry.training.instability import telemetry_path
 from tab_foundry.training.wandb import (
@@ -25,6 +26,9 @@ from tab_foundry.training.wandb import (
 CheckpointSource = Literal["local_registry", "wandb_artifact"]
 
 _WANDB_REQUIRED_FIELDS = ("project", "run_id", "run_name")
+_ARTIFACT_NAME_PREFIX = "benchmark-checkpoint-"
+_WANDB_ARTIFACT_NAME_MAXLEN = 128
+_ARTIFACT_NAME_HASH_HEX = 12
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,7 +63,20 @@ def artifact_name_for_run_id(run_id: str) -> str:
     normalized_run_id = str(run_id).strip()
     if not normalized_run_id:
         raise RuntimeError("run_id must be a non-empty string")
-    return f"benchmark-checkpoint-{normalized_run_id}"
+    artifact_name = f"{_ARTIFACT_NAME_PREFIX}{normalized_run_id}"
+    if len(artifact_name) <= _WANDB_ARTIFACT_NAME_MAXLEN:
+        return artifact_name
+    hash_suffix = sha256_text(normalized_run_id)[:_ARTIFACT_NAME_HASH_HEX]
+    max_run_id_chars = (
+        _WANDB_ARTIFACT_NAME_MAXLEN
+        - len(_ARTIFACT_NAME_PREFIX)
+        - 1
+        - len(hash_suffix)
+    )
+    if max_run_id_chars <= 0:  # pragma: no cover - defensive guard
+        raise RuntimeError("W&B artifact name budget is too small to encode a benchmark checkpoint artifact")
+    truncated_run_id = normalized_run_id[:max_run_id_chars]
+    return f"{_ARTIFACT_NAME_PREFIX}{truncated_run_id}-{hash_suffix}"
 
 
 def normalized_wandb_registry_payload(value: Any) -> dict[str, str] | None:

--- a/src/tab_foundry/bench/control_baseline_freeze.py
+++ b/src/tab_foundry/bench/control_baseline_freeze.py
@@ -9,7 +9,11 @@ import torch
 
 import tab_foundry.control_baseline_registry as read_control_baseline_registry
 from tab_foundry.bench.artifacts import write_json
-from tab_foundry.bench.openml_benchmark import collect_checkpoint_snapshots, resolve_tab_foundry_best_checkpoint
+from tab_foundry.bench.openml_benchmark import (
+    collect_checkpoint_snapshots,
+    default_anchor_control_baseline_id,
+    resolve_tab_foundry_best_checkpoint,
+)
 from tab_foundry.registry.common import (
     copy_jsonable as _copy_jsonable,
     load_comparison_summary as _load_comparison_summary,
@@ -24,7 +28,7 @@ from tab_foundry.repo_paths import repo_root
 
 REGISTRY_SCHEMA = read_control_baseline_registry.REGISTRY_SCHEMA
 REGISTRY_VERSION = read_control_baseline_registry.REGISTRY_VERSION
-DEFAULT_BASELINE_ID = "cls_benchmark_linear_v2"
+DEFAULT_BASELINE_ID = default_anchor_control_baseline_id()
 DEFAULT_EXPERIMENT = "cls_benchmark_staged_prior"
 DEFAULT_CONFIG_PROFILE = DEFAULT_EXPERIMENT
 DEFAULT_BUDGET_CLASS = "short-run"

--- a/src/tab_foundry/bench/openml_benchmark/__init__.py
+++ b/src/tab_foundry/bench/openml_benchmark/__init__.py
@@ -18,11 +18,14 @@ from .bundle import (
     benchmark_bundle_allows_missing_values,
     benchmark_bundle_summary,
     benchmark_bundle_task_type,
+    default_anchor_benchmark_summary,
+    default_anchor_control_baseline_id,
     default_benchmark_bundle_path,
     default_benchmark_manifest_path,
     load_benchmark_bundle,
     load_benchmark_bundle_for_execution,
     normalize_benchmark_bundle,
+    validate_default_anchor_benchmark_summary,
 )
 from .curves import (
     DEFAULT_CHECKPOINT_DIAGNOSTIC_BOOTSTRAP_CONFIDENCE,
@@ -99,6 +102,8 @@ __all__ = [
     "dataset_log_loss_metrics",
     "dataset_picp_90_metrics",
     "dataset_roc_auc_metrics",
+    "default_anchor_benchmark_summary",
+    "default_anchor_control_baseline_id",
     "default_benchmark_bundle_path",
     "default_benchmark_manifest_path",
     "evaluate_classifier",
@@ -120,6 +125,7 @@ __all__ = [
     "save_dataset_cache",
     "summarize_checkpoint_curve",
     "task_bootstrap_roc_auc_interval",
+    "validate_default_anchor_benchmark_summary",
 ]
 
 

--- a/src/tab_foundry/bench/openml_benchmark/bundle.py
+++ b/src/tab_foundry/bench/openml_benchmark/bundle.py
@@ -9,10 +9,12 @@ from typing import Any, Mapping, cast
 from tab_foundry.repo_paths import normalize_repo_relative_path, repo_root
 
 
-BENCHMARK_BUNDLE_FILENAME = "openml_binary_medium_v1.json"
+BENCHMARK_BUNDLE_FILENAME = "openml_classification_medium_v1.json"
+DEFAULT_ANCHOR_CONTROL_BASELINE_ID = "cls_benchmark_linear_multiclass_medium_v1"
 _CLASSIFICATION_TASK_TYPE = "supervised_classification"
 _PERCENT_SCALE_MAX = 100.0
 _REGRESSION_TASK_TYPE = "supervised_regression"
+_OPTIONAL_BUNDLE_KEYS = {"tasks"}
 _ALLOWED_BUNDLE_SELECTION_TASK_TYPES = {
     _CLASSIFICATION_TASK_TYPE,
     _REGRESSION_TASK_TYPE,
@@ -31,6 +33,12 @@ def default_benchmark_manifest_path() -> Path:
 
     bundle_stem = Path(BENCHMARK_BUNDLE_FILENAME).stem
     return repo_root() / "data" / "manifests" / "bench" / bundle_stem / "manifest.parquet"
+
+
+def default_anchor_control_baseline_id() -> str:
+    """Return the canonical control-baseline id paired with the default anchor benchmark."""
+
+    return DEFAULT_ANCHOR_CONTROL_BASELINE_ID
 
 
 def _default_repo_root() -> Path:
@@ -106,6 +114,7 @@ def _normalize_selection(payload: Any) -> dict[str, Any]:
             "min_minority_class_pct",
         }
         | ({"task_type"} if "task_type" in payload else set())
+        | ({"min_classes"} if "min_classes" in payload else set())
         if task_type == _CLASSIFICATION_TASK_TYPE
         else {
             "new_instances",
@@ -141,13 +150,26 @@ def _normalize_selection(payload: Any) -> dict[str, Any]:
     if task_type == _CLASSIFICATION_TASK_TYPE:
         max_classes = payload["max_classes"]
         min_minority_class_pct = payload["min_minority_class_pct"]
+        min_classes = payload.get("min_classes")
         if not isinstance(max_classes, int) or isinstance(max_classes, bool) or max_classes <= 0:
             raise RuntimeError("benchmark bundle selection.max_classes must be a positive int")
+        if min_classes is not None and (
+            not isinstance(min_classes, int)
+            or isinstance(min_classes, bool)
+            or min_classes <= 0
+            or min_classes > max_classes
+        ):
+            raise RuntimeError(
+                "benchmark bundle selection.min_classes must be a positive int "
+                "no larger than max_classes"
+            )
         if not isinstance(min_minority_class_pct, (int, float)) or not 0 <= float(min_minority_class_pct) <= _PERCENT_SCALE_MAX:
             raise RuntimeError(
                 "benchmark bundle selection.min_minority_class_pct must be a percentage between 0 and 100"
             )
         normalized["max_classes"] = int(max_classes)
+        if min_classes is not None:
+            normalized["min_classes"] = int(min_classes)
         normalized["min_minority_class_pct"] = float(min_minority_class_pct)
     return normalized
 
@@ -157,12 +179,13 @@ def normalize_benchmark_bundle(payload: Any) -> dict[str, Any]:
 
     if not isinstance(payload, dict):
         raise RuntimeError("benchmark bundle must be a JSON object")
-    expected_keys = {"name", "version", "selection", "task_ids", "tasks"}
+    required_keys = {"name", "version", "selection", "task_ids"}
+    expected_keys = required_keys | _OPTIONAL_BUNDLE_KEYS
     actual_keys = set(payload.keys())
-    if actual_keys != expected_keys:
+    if not required_keys.issubset(actual_keys) or not actual_keys.issubset(expected_keys):
         raise RuntimeError(
             "benchmark bundle keys mismatch: "
-            f"missing={sorted(expected_keys - actual_keys)}, "
+            f"missing={sorted(required_keys - actual_keys)}, "
             f"extra={sorted(actual_keys - expected_keys)}"
         )
 
@@ -170,15 +193,15 @@ def normalize_benchmark_bundle(payload: Any) -> dict[str, Any]:
     version = payload["version"]
     selection = payload["selection"]
     task_ids = payload["task_ids"]
-    tasks = payload["tasks"]
+    tasks = payload.get("tasks", [])
     if not isinstance(name, str) or not name.strip():
         raise RuntimeError("benchmark bundle name must be a non-empty string")
     if not isinstance(version, int) or version <= 0:
         raise RuntimeError("benchmark bundle version must be a positive int")
     if not isinstance(task_ids, list) or not task_ids:
         raise RuntimeError("benchmark bundle task_ids must be a non-empty list")
-    if not isinstance(tasks, list) or not tasks:
-        raise RuntimeError("benchmark bundle tasks must be a non-empty list")
+    if not isinstance(tasks, list):
+        raise RuntimeError("benchmark bundle tasks must be a list when present")
 
     normalized_selection = _normalize_selection(selection)
     selection_task_type = str(normalized_selection["task_type"])
@@ -211,7 +234,7 @@ def normalize_benchmark_bundle(payload: Any) -> dict[str, Any]:
             normalized_task["n_classes"] = int(task_payload["n_classes"])
         normalized_tasks.append(normalized_task)
 
-    if normalized_task_ids != [int(task["task_id"]) for task in normalized_tasks]:
+    if normalized_tasks and normalized_task_ids != [int(task["task_id"]) for task in normalized_tasks]:
         raise RuntimeError("benchmark bundle task_ids must match tasks[].task_id order exactly")
 
     return {
@@ -321,3 +344,73 @@ def benchmark_bundle_summary(
         "allow_missing_values": allow_missing_values,
         "all_tasks_no_missing": None if allow_missing_values is None else (not allow_missing_values),
     }
+
+
+def _normalized_bundle_summary_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    task_ids = [int(task_id) for task_id in cast(list[Any], payload.get("task_ids", []))]
+    selection_raw = payload.get("selection")
+    selection = (
+        cast(dict[str, Any], json.loads(json.dumps(selection_raw, sort_keys=True)))
+        if isinstance(selection_raw, Mapping)
+        else None
+    )
+    source_path_value = payload.get("source_path")
+    source_path = (
+        canonical_benchmark_bundle_source_path(str(source_path_value))
+        if isinstance(source_path_value, str) and source_path_value.strip()
+        else None
+    )
+    return {
+        "name": str(payload["name"]),
+        "version": int(payload["version"]),
+        "source_path": source_path,
+        "task_count": int(payload["task_count"]),
+        "task_ids": task_ids,
+        "selection": selection,
+        "allow_missing_values": (
+            None
+            if payload.get("allow_missing_values") is None
+            else bool(payload["allow_missing_values"])
+        ),
+        "all_tasks_no_missing": (
+            None
+            if payload.get("all_tasks_no_missing") is None
+            else bool(payload["all_tasks_no_missing"])
+        ),
+    }
+
+
+def default_anchor_benchmark_summary() -> dict[str, Any]:
+    """Return the canonical medium-multiclass anchor benchmark summary."""
+
+    bundle_path = default_benchmark_bundle_path()
+    bundle = load_benchmark_bundle(bundle_path, allow_missing_values=True)
+    return benchmark_bundle_summary(bundle, source_path=bundle_path)
+
+
+def validate_default_anchor_benchmark_summary(
+    bundle_summary: Mapping[str, Any] | None,
+) -> list[str]:
+    """Return contract issues when the default anchor benchmark resolves to a stale surface."""
+
+    if bundle_summary is None:
+        return ["default anchor benchmark summary is missing from the resolved manifest surface"]
+    expected = _normalized_bundle_summary_payload(default_anchor_benchmark_summary())
+    actual = _normalized_bundle_summary_payload(bundle_summary)
+    issues: list[str] = []
+    for key in (
+        "name",
+        "version",
+        "source_path",
+        "task_count",
+        "task_ids",
+        "selection",
+        "allow_missing_values",
+        "all_tasks_no_missing",
+    ):
+        if actual[key] != expected[key]:
+            issues.append(
+                "default anchor benchmark mismatch for "
+                f"{key}: expected={expected[key]!r} actual={actual[key]!r}"
+            )
+    return issues

--- a/src/tab_foundry/bench/openml_benchmark/datasets.py
+++ b/src/tab_foundry/bench/openml_benchmark/datasets.py
@@ -15,6 +15,7 @@ from tab_realdata_hub.openml import (
 )
 from tab_foundry.data.dataset import load_manifest_record_metadata
 
+from .bundle import default_benchmark_manifest_path, validate_default_anchor_benchmark_summary
 from .dataset_common import BenchmarkDataset, _assert_finite_benchmark_datasets
 
 __all__ = [
@@ -193,6 +194,13 @@ def load_benchmark_manifest_datasets(
             context=f"benchmark manifest {benchmark_manifest_path!s}",
         )
     bundle_summary = benchmark_manifest_bundle_summary(task_records)
+    if resolved_manifest_path == default_benchmark_manifest_path().expanduser().resolve():
+        anchor_contract_issues = validate_default_anchor_benchmark_summary(bundle_summary)
+        if anchor_contract_issues:
+            raise RuntimeError(
+                "default anchor benchmark manifest drift detected:\n- "
+                + "\n- ".join(anchor_contract_issues)
+            )
     return datasets, task_records, {
         "manifest_path": str(loaded.manifest_path),
         "contract_version": int(loaded.contract_version),

--- a/src/tab_foundry/research/navigation.py
+++ b/src/tab_foundry/research/navigation.py
@@ -60,9 +60,23 @@ def _default_anchor_benchmark_contract() -> dict[str, Any]:
     }
 
 
+def _uses_default_anchor_benchmark_contract(
+    *,
+    benchmark_manifest_path: str | Path,
+    control_baseline_id: str | None,
+) -> bool:
+    resolved_manifest_path = Path(str(benchmark_manifest_path)).expanduser().resolve()
+    default_manifest_path = default_benchmark_manifest_path().expanduser().resolve()
+    if resolved_manifest_path != default_manifest_path:
+        return False
+    return _optional_string(control_baseline_id) == default_anchor_control_baseline_id()
+
+
 def _default_anchor_manifest_contract_issues(manifest_path: Path) -> list[str]:
     if manifest_path.expanduser().resolve() != default_benchmark_manifest_path().expanduser().resolve():
         return []
+    if not manifest_path.exists():
+        return ["default anchor benchmark manifest is not materialized locally"]
     characteristics = compute_manifest_characteristics(manifest_path)
     expected_summary = default_anchor_benchmark_summary()
     expected_task_count = int(expected_summary["task_count"])
@@ -316,9 +330,9 @@ def build_sweep_navigation_payload(
         "contract": {
             "benchmark_manifest_path": str(queue["benchmark_manifest_path"]),
             "default_anchor_benchmark": _default_anchor_benchmark_contract(),
-            "uses_default_anchor_benchmark": (
-                Path(str(queue["benchmark_manifest_path"])).expanduser().resolve()
-                == default_benchmark_manifest_path().expanduser().resolve()
+            "uses_default_anchor_benchmark": _uses_default_anchor_benchmark_contract(
+                benchmark_manifest_path=str(queue["benchmark_manifest_path"]),
+                control_baseline_id=_optional_string(queue.get("control_baseline_id")),
             ),
             "control_baseline_id": str(queue["control_baseline_id"]),
             "external_benchmarks": list(cast(Sequence[Any], queue.get("external_benchmarks", []))),
@@ -468,8 +482,11 @@ def build_scaling_navigation_payload(
             "default_anchor_benchmark": _default_anchor_benchmark_contract(),
             "uses_default_anchor_benchmark": (
                 len(benchmark_paths) == 1
-                and Path(next(iter(benchmark_paths))).expanduser().resolve()
-                == default_benchmark_manifest_path().expanduser().resolve()
+                and len(control_baselines) == 1
+                and _uses_default_anchor_benchmark_contract(
+                    benchmark_manifest_path=next(iter(benchmark_paths)),
+                    control_baseline_id=next(iter(control_baselines)),
+                )
             ),
             "control_baseline_id": next(iter(control_baselines)) if len(control_baselines) == 1 else None,
             "training_experiment": next(iter(training_experiments)) if len(training_experiments) == 1 else None,

--- a/src/tab_foundry/research/navigation.py
+++ b/src/tab_foundry/research/navigation.py
@@ -117,7 +117,9 @@ def _winner_from_rows(rows: Sequence[Any]) -> dict[str, Any] | None:
     for row in rows:
         if not isinstance(row, Mapping):
             continue
-        if str(row.get("status", "")).strip() != "completed":
+        status = str(row.get("status", "")).strip()
+        imported_baseline = isinstance(row.get("imported_baseline_provenance"), Mapping)
+        if status != "completed" and not imported_baseline:
             continue
         metrics = row.get("benchmark_metrics")
         if not isinstance(metrics, Mapping):
@@ -380,6 +382,7 @@ def build_scaling_navigation_payload(
     catalog_path: Path,
     sweeps_root: Path,
 ) -> dict[str, Any]:
+    index = load_system_delta_index_payload(index_path)
     queues: dict[str, Mapping[str, Any]] = {}
     for sweep_ref in config.sweeps:
         queues[sweep_ref.sweep_id] = load_system_delta_queue(
@@ -464,12 +467,13 @@ def build_scaling_navigation_payload(
     linked_sweeps: list[dict[str, Any]] = []
     for sweep_ref in config.sweeps:
         queue = queues[sweep_ref.sweep_id]
+        index_entry = index.sweeps.get(sweep_ref.sweep_id)
         linked_sweeps.append(
             {
                 "name": sweep_ref.name,
                 "family": sweep_ref.family,
                 "sweep_id": sweep_ref.sweep_id,
-                "status": str(queue.get("status", "unknown")),
+                "status": "unknown" if index_entry is None else str(index_entry.status),
                 "lineage": sweep_lineage_entries(sweep_id=sweep_ref.sweep_id, index_path=index_path),
                 "winner": _winner_from_rows(cast(Sequence[Any], queue.get("rows", []))),
             }

--- a/src/tab_foundry/research/navigation.py
+++ b/src/tab_foundry/research/navigation.py
@@ -6,9 +6,18 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
+from tab_foundry.bench.openml_benchmark import (
+    default_anchor_benchmark_summary,
+    default_anchor_control_baseline_id,
+    default_benchmark_manifest_path,
+)
+from tab_foundry.data.manifest_characteristics import compute_manifest_characteristics
+from tab_foundry.repo_paths import normalize_repo_relative_path
 from tab_foundry.research.scaling.study import ScalingStudyConfig, default_scaling_studies_root, load_scaling_study_config
 from tab_foundry.research.sweep.catalog import load_system_delta_index_payload
 from tab_foundry.research.sweep.materialize import load_system_delta_queue
+
+_BINARY_CLASS_LIMIT = 2
 
 
 def _optional_string(value: Any) -> str | None:
@@ -40,6 +49,53 @@ def _unique_corpus_refs(rows: Sequence[Any]) -> list[str]:
             if corpus_ref is not None
         }
     )
+
+
+def _default_anchor_benchmark_contract() -> dict[str, Any]:
+    summary = default_anchor_benchmark_summary()
+    return {
+        "benchmark_manifest_path": normalize_repo_relative_path(default_benchmark_manifest_path()),
+        "control_baseline_id": default_anchor_control_baseline_id(),
+        "benchmark_bundle": dict(summary),
+    }
+
+
+def _default_anchor_manifest_contract_issues(manifest_path: Path) -> list[str]:
+    if manifest_path.expanduser().resolve() != default_benchmark_manifest_path().expanduser().resolve():
+        return []
+    characteristics = compute_manifest_characteristics(manifest_path)
+    expected_summary = default_anchor_benchmark_summary()
+    expected_task_count = int(expected_summary["task_count"])
+    issues: list[str] = []
+    if int(characteristics["record_count"]) != expected_task_count:
+        issues.append(
+            "default anchor benchmark manifest record_count mismatch: "
+            f"expected={expected_task_count} actual={int(characteristics['record_count'])}"
+        )
+    expected_allow_missing = bool(expected_summary.get("allow_missing_values"))
+    actual_missing_policy = characteristics.get("missing_value_policy")
+    if expected_allow_missing and str(actual_missing_policy) != "allow_any":
+        issues.append(
+            "default anchor benchmark manifest should preserve natural missingness: "
+            f"expected missing_value_policy='allow_any' actual={actual_missing_policy!r}"
+        )
+    expected_selection = cast(Mapping[str, Any], expected_summary.get("selection", {}))
+    expected_max_classes = expected_selection.get("max_classes")
+    class_distribution = characteristics.get("class_count_distribution")
+    if isinstance(class_distribution, Mapping):
+        actual_max_classes = int(class_distribution["max"])
+        if (
+            expected_max_classes is not None
+            and actual_max_classes <= _BINARY_CLASS_LIMIT
+            and int(expected_max_classes) > _BINARY_CLASS_LIMIT
+        ):
+            issues.append(
+                "default anchor benchmark manifest collapsed to a binary-only surface: "
+                f"expected multiclass max_classes={int(expected_max_classes)} actual_max_classes={actual_max_classes}"
+            )
+    else:
+        issues.append("default anchor benchmark manifest did not report class-count distribution")
+    return issues
 
 
 def _winner_from_rows(rows: Sequence[Any]) -> dict[str, Any] | None:
@@ -235,6 +291,11 @@ def validate_sweep_contract(
                 f"{sweep_id}: anchor_context.run_id {anchor_context_run_id!r} does not match "
                 f"anchor_run_id {queue_anchor_run_id!r}"
             )
+    benchmark_manifest_path = Path(str(queue["benchmark_manifest_path"]))
+    issues.extend(
+        f"{sweep_id}: {issue}"
+        for issue in _default_anchor_manifest_contract_issues(benchmark_manifest_path)
+    )
     return issues
 
 
@@ -254,6 +315,11 @@ def build_sweep_navigation_payload(
         ),
         "contract": {
             "benchmark_manifest_path": str(queue["benchmark_manifest_path"]),
+            "default_anchor_benchmark": _default_anchor_benchmark_contract(),
+            "uses_default_anchor_benchmark": (
+                Path(str(queue["benchmark_manifest_path"])).expanduser().resolve()
+                == default_benchmark_manifest_path().expanduser().resolve()
+            ),
             "control_baseline_id": str(queue["control_baseline_id"]),
             "external_benchmarks": list(cast(Sequence[Any], queue.get("external_benchmarks", []))),
             "training_experiment": str(queue["training_experiment"]),
@@ -325,6 +391,9 @@ def build_scaling_navigation_payload(
         if corpus_ref is not None
     }
     issues: list[str] = []
+    for sweep_ref in config.sweeps:
+        queue = queues[sweep_ref.sweep_id]
+        issues.extend(validate_sweep_contract(queue=queue, index_path=index_path))
     if len(benchmark_paths) != 1:
         issues.append(f"scaling study {config.study_id}: benchmark manifest mismatch across sweeps {sorted(benchmark_paths)!r}")
     if len(control_baselines) != 1:
@@ -396,6 +465,12 @@ def build_scaling_navigation_payload(
         "linked_sweeps": linked_sweeps,
         "contract": {
             "benchmark_manifest_path": next(iter(benchmark_paths)) if len(benchmark_paths) == 1 else None,
+            "default_anchor_benchmark": _default_anchor_benchmark_contract(),
+            "uses_default_anchor_benchmark": (
+                len(benchmark_paths) == 1
+                and Path(next(iter(benchmark_paths))).expanduser().resolve()
+                == default_benchmark_manifest_path().expanduser().resolve()
+            ),
             "control_baseline_id": next(iter(control_baselines)) if len(control_baselines) == 1 else None,
             "training_experiment": next(iter(training_experiments)) if len(training_experiments) == 1 else None,
             "training_config_profile": next(iter(training_profiles)) if len(training_profiles) == 1 else None,

--- a/src/tab_foundry/research/sweep/inspection_render.py
+++ b/src/tab_foundry/research/sweep/inspection_render.py
@@ -11,6 +11,8 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
     row = cast(Mapping[str, Any], payload["row"])
     target = cast(Mapping[str, Any], payload["target"])
     navigation = cast(Mapping[str, Any] | None, payload.get("navigation"))
+    row_summary = cast(Mapping[str, Any] | None, payload.get("row_summary"))
+    selector_summary = cast(Mapping[str, Any] | None, payload.get("selector_summary"))
     resolved = cast(Mapping[str, Any], target["resolved"])
     model = cast(Mapping[str, Any], resolved["model"])
     data = cast(Mapping[str, Any] | None, resolved.get("data"))
@@ -75,6 +77,65 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
                 "linked_scaling_studies="
                 + ", ".join(str(value) for value in linked_scaling_studies)
             )
+    if row_summary is not None:
+        lines.append(
+            "pareto_admissible="
+            + (
+                "yes"
+                if row_summary.get("pareto_admissible") is True
+                else ("no" if row_summary.get("pareto_admissible") is False else "n/a")
+            )
+        )
+        lines.append(
+            "geometry_pareto_admissible="
+            + (
+                "yes"
+                if row_summary.get("geometry_pareto_admissible") is True
+                else (
+                    "no"
+                    if row_summary.get("geometry_pareto_admissible") is False
+                    else "n/a"
+                )
+            )
+        )
+        lines.append(
+            f"selector_geometry_label={row_summary.get('selector_geometry_label') or 'n/a'}"
+        )
+        lines.append(
+            f"selector_prescription_label={row_summary.get('selector_prescription_label') or 'n/a'}"
+        )
+        if row_summary.get("end_to_end_wall_seconds") is not None:
+            lines.append(
+                "end_to_end_wall_seconds="
+                f"{float(row_summary['end_to_end_wall_seconds']):.1f}"
+            )
+        if row_summary.get("throughput_tokens_per_second") is not None:
+            lines.append(
+                "throughput_tokens_per_second="
+                f"{float(row_summary['throughput_tokens_per_second']):.1f}"
+            )
+    if selector_summary is not None:
+        best_row = selector_summary.get("best_row")
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "selector_best_row="
+                f"order {int(best_row['order']):02d}, "
+                f"geometry={best_row.get('geometry_label') or 'n/a'}, "
+                f"prescription={best_row.get('prescription_label') or 'n/a'}, "
+                f"log_loss={float(best_row['final_log_loss']):.6f}, "
+                f"wall={float(best_row['end_to_end_wall_seconds']):.1f}s"
+            )
+        kept_contract = selector_summary.get("kept_contract")
+        if isinstance(kept_contract, Mapping):
+            lines.append(
+                "selector_kept_contract="
+                f"{kept_contract['prescription_label']} "
+                f"(frontier_geometries={int(kept_contract['geometry_count'])}, "
+                f"mean_wall={float(kept_contract['mean_end_to_end_wall_seconds']):.1f}s, "
+                f"mean_log_loss={float(kept_contract['mean_benchmark_log_loss']):.6f})"
+            )
+        elif selector_summary.get("no_universal_kept_contract") is True:
+            lines.append("selector_kept_contract=none")
     if data is not None:
         lines.append(f"data.surface_label={data.get('surface_label')}")
         if data.get("corpus_ref") is not None:

--- a/src/tab_foundry/research/sweep/inspection_render.py
+++ b/src/tab_foundry/research/sweep/inspection_render.py
@@ -13,6 +13,7 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
     navigation = cast(Mapping[str, Any] | None, payload.get("navigation"))
     row_summary = cast(Mapping[str, Any] | None, payload.get("row_summary"))
     selector_summary = cast(Mapping[str, Any] | None, payload.get("selector_summary"))
+    transfer_summary = cast(Mapping[str, Any] | None, payload.get("transfer_summary"))
     resolved = cast(Mapping[str, Any], target["resolved"])
     model = cast(Mapping[str, Any], resolved["model"])
     data = cast(Mapping[str, Any] | None, resolved.get("data"))
@@ -125,6 +126,57 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
                 "throughput_tokens_per_second="
                 f"{float(row_summary['throughput_tokens_per_second']):.1f}"
             )
+        if row_summary.get("transfer_regime_label") is not None:
+            lines.append(
+                f"transfer_regime_label={row_summary.get('transfer_regime_label')}"
+            )
+        if row_summary.get("transfer_phase") is not None:
+            lines.append(f"transfer_phase={row_summary.get('transfer_phase')}")
+        if row_summary.get("transfer_formula_label") is not None:
+            lines.append(
+                "transfer_formula_label="
+                f"{row_summary.get('transfer_formula_label')}"
+            )
+        if row_summary.get("transfer_target_budget_label") is not None:
+            lines.append(
+                "transfer_target_budget_label="
+                f"{row_summary.get('transfer_target_budget_label')}"
+            )
+        if row_summary.get("transfer_candidate_label") is not None:
+            lines.append(
+                "transfer_candidate_label="
+                f"{row_summary.get('transfer_candidate_label')}"
+            )
+        if row_summary.get("target_effective_batch") is not None:
+            lines.append(
+                "target_effective_batch="
+                f"{float(row_summary['target_effective_batch']):.1f}"
+            )
+        if row_summary.get("realized_effective_batch") is not None:
+            lines.append(
+                "realized_effective_batch="
+                f"{int(row_summary['realized_effective_batch'])}"
+            )
+        if row_summary.get("target_effective_budget") is not None:
+            lines.append(
+                "target_effective_budget="
+                f"{int(row_summary['target_effective_budget'])}"
+            )
+        if row_summary.get("realized_effective_budget") is not None:
+            lines.append(
+                "realized_effective_budget="
+                f"{int(row_summary['realized_effective_budget'])}"
+            )
+        if row_summary.get("budget_drift") is not None:
+            lines.append(f"budget_drift={float(row_summary['budget_drift']):+.6f}")
+        if row_summary.get("batch_drift") is not None:
+            lines.append(f"batch_drift={float(row_summary['batch_drift']):+.6f}")
+        imported_baseline = row_summary.get("imported_baseline_provenance")
+        if isinstance(imported_baseline, Mapping):
+            lines.append(
+                "imported_baseline_provenance="
+                + json.dumps(dict(imported_baseline), sort_keys=True)
+            )
     if selector_summary is not None:
         best_row = selector_summary.get("best_row")
         if isinstance(best_row, Mapping):
@@ -147,6 +199,33 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
             )
         elif selector_summary.get("no_universal_kept_contract") is True:
             lines.append("selector_kept_contract=none")
+    if transfer_summary is not None:
+        best_row = transfer_summary.get("best_row")
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "transfer_best_row="
+                f"order {int(best_row['order']):02d}, "
+                f"regime={best_row.get('regime_label') or 'n/a'}, "
+                f"log_loss={float(best_row['final_log_loss']):.6f}, "
+                f"budget={best_row.get('target_budget_label') or 'n/a'}"
+            )
+        fastest_row = transfer_summary.get("fastest_row")
+        if isinstance(fastest_row, Mapping):
+            lines.append(
+                "transfer_fastest_row="
+                f"order {int(fastest_row['order']):02d}, "
+                f"regime={fastest_row.get('regime_label') or 'n/a'}, "
+                f"wall={float(fastest_row['end_to_end_wall_seconds']):.1f}s"
+            )
+        regime_leaderboard = transfer_summary.get("regime_leaderboard")
+        if isinstance(regime_leaderboard, list) and regime_leaderboard:
+            lines.append(
+                "transfer_regime_leaderboard="
+                + json.dumps(
+                    [dict(cast(Mapping[str, Any], item)) for item in regime_leaderboard if isinstance(item, Mapping)],
+                    sort_keys=True,
+                )
+            )
     if data is not None:
         lines.append(f"data.surface_label={data.get('surface_label')}")
         if data.get("corpus_ref") is not None:

--- a/src/tab_foundry/research/sweep/inspection_render.py
+++ b/src/tab_foundry/research/sweep/inspection_render.py
@@ -46,6 +46,17 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
         contract = navigation.get("contract")
         if isinstance(contract, Mapping):
             lines.append(f"benchmark_manifest_path={contract.get('benchmark_manifest_path')}")
+            if contract.get("uses_default_anchor_benchmark") is not None:
+                lines.append(
+                    "uses_default_anchor_benchmark="
+                    + ("yes" if contract.get("uses_default_anchor_benchmark") else "no")
+                )
+            default_anchor_benchmark = contract.get("default_anchor_benchmark")
+            if isinstance(default_anchor_benchmark, Mapping):
+                lines.append(
+                    "default_anchor_benchmark_manifest_path="
+                    f"{default_anchor_benchmark.get('benchmark_manifest_path')}"
+                )
             lines.append(f"control_baseline_id={contract.get('control_baseline_id')}")
             lines.append(f"carried_in_family_baseline_run_id={contract.get('carried_in_family_baseline_run_id')}")
             if contract.get("corpus_ref") is not None:

--- a/src/tab_foundry/research/sweep/inspection_render.py
+++ b/src/tab_foundry/research/sweep/inspection_render.py
@@ -177,6 +177,12 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
                 "imported_baseline_provenance="
                 + json.dumps(dict(imported_baseline), sort_keys=True)
             )
+        shared_anchor = row_summary.get("shared_anchor_provenance")
+        if isinstance(shared_anchor, Mapping):
+            lines.append(
+                "shared_anchor_provenance="
+                + json.dumps(dict(shared_anchor), sort_keys=True)
+            )
     if selector_summary is not None:
         best_row = selector_summary.get("best_row")
         if isinstance(best_row, Mapping):
@@ -225,6 +231,19 @@ def render_sweep_row_text(payload: Mapping[str, Any]) -> str:
                     [dict(cast(Mapping[str, Any], item)) for item in regime_leaderboard if isinstance(item, Mapping)],
                     sort_keys=True,
                 )
+            )
+        kept_regime = transfer_summary.get("kept_regime")
+        if isinstance(kept_regime, Mapping):
+            lines.append(
+                "transfer_kept_regime="
+                f"{kept_regime.get('regime_label')}@T2(order {int(kept_regime['t2_order']):02d}, "
+                f"log_loss={float(kept_regime['t2_log_loss']):.6f})"
+            )
+        t2_vs_highbatch = transfer_summary.get("t2_vs_carried_highbatch")
+        if isinstance(t2_vs_highbatch, Mapping):
+            lines.append(
+                "transfer_t2_vs_carried_highbatch="
+                f"delta_log_loss={float(t2_vs_highbatch['delta_log_loss']):+.6f}"
             )
     if data is not None:
         lines.append(f"data.surface_label={data.get('surface_label')}")

--- a/src/tab_foundry/research/sweep/inspection_targets.py
+++ b/src/tab_foundry/research/sweep/inspection_targets.py
@@ -20,6 +20,7 @@ from .inspection_artifacts import (
 )
 from .paths_io import _copy_jsonable, default_registry_path
 from . import surface_resolution as surface_resolution_module
+from .summarize import build_sweep_summary_payload
 
 
 def _anchor_metrics_payload(registry_run: Mapping[str, Any] | None) -> dict[str, Any] | None:
@@ -220,9 +221,20 @@ def inspect_sweep_row(
         raise RuntimeError(
             "sweep inspection contract validation failed:\n- " + "\n- ".join(str(issue) for issue in contract_issues)
         )
+    summary_payload = build_sweep_summary_payload(queue=queue, include_screened=True)
+    row_summary = next(
+        (
+            candidate
+            for candidate in cast(list[dict[str, Any]], summary_payload["rows"])
+            if int(candidate["order"]) == int(order)
+        ),
+        None,
+    )
     return {
         "queue": queue_metadata,
         "row": dict(cast(dict[str, Any], _copy_jsonable(row))),
         "target": target,
         "navigation": navigation,
+        "row_summary": row_summary,
+        "selector_summary": summary_payload.get("selector_summary"),
     }

--- a/src/tab_foundry/research/sweep/inspection_targets.py
+++ b/src/tab_foundry/research/sweep/inspection_targets.py
@@ -237,4 +237,5 @@ def inspect_sweep_row(
         "navigation": navigation,
         "row_summary": row_summary,
         "selector_summary": summary_payload.get("selector_summary"),
+        "transfer_summary": summary_payload.get("transfer_summary"),
     }

--- a/src/tab_foundry/research/sweep/matrix.py
+++ b/src/tab_foundry/research/sweep/matrix.py
@@ -595,6 +595,14 @@ def render_system_delta_matrix(
             )
         elif queue_row["dimension_family"] == "training":
             lines.append(f"- Training overrides: `{queue_row['training'].get('overrides', {})}`")
+            dynamic_training_overrides = queue_row.get("dynamic_training_overrides")
+            if isinstance(dynamic_training_overrides, Mapping) and dynamic_training_overrides:
+                lines.append(f"- Dynamic training overrides: `{dict(dynamic_training_overrides)}`")
+            dynamic_reuse_train_artifact = queue_row.get("dynamic_reuse_train_artifact")
+            if isinstance(dynamic_reuse_train_artifact, Mapping) and dynamic_reuse_train_artifact:
+                lines.append(
+                    f"- Dynamic reuse train artifact: `{dict(dynamic_reuse_train_artifact)}`"
+                )
         else:
             lines.append(f"- Preprocessing overrides: `{queue_row['preprocessing'].get('overrides', {})}`")
         reuse_train_artifact = queue_row.get("reuse_train_artifact")
@@ -604,6 +612,15 @@ def render_system_delta_matrix(
                 "- Reuse training surface fingerprint: "
                 f"`{reuse_train_artifact.get('training_surface_fingerprint')}`"
             )
+        transfer_context = queue_row.get("transfer_context")
+        if isinstance(transfer_context, Mapping) and transfer_context:
+            lines.append(f"- Transfer context: `{dict(transfer_context)}`")
+        transfer_resolution = queue_row.get("transfer_resolution")
+        if isinstance(transfer_resolution, Mapping) and transfer_resolution:
+            lines.append(f"- Transfer resolution: `{dict(transfer_resolution)}`")
+        imported_baseline = queue_row.get("imported_baseline_provenance")
+        if isinstance(imported_baseline, Mapping) and imported_baseline:
+            lines.append(f"- Imported baseline provenance: `{dict(imported_baseline)}`")
         lines.append("- Parameter adequacy plan:")
         for plan_item in cast(list[str], queue_row.get("parameter_adequacy_plan", [])):
             lines.append(f"  - {plan_item}")
@@ -825,22 +842,32 @@ def render_and_write_system_delta_matrix(
 ) -> Path:
     from .reporting import refresh_result_cards_for_queue
 
-    resolved_queue = (
-        queue
-        if queue is not None
-        else load_system_delta_queue(
-            path=write_resolved_system_delta_queue(
+    if queue is not None:
+        resolved_queue = queue
+    else:
+        try:
+            resolved_queue = load_system_delta_queue(
+                path=write_resolved_system_delta_queue(
+                    sweep_id=sweep_id,
+                    index_path=index_path,
+                    catalog_path=catalog_path,
+                    sweeps_root=sweeps_root,
+                ),
                 sweep_id=sweep_id,
                 index_path=index_path,
                 catalog_path=catalog_path,
                 sweeps_root=sweeps_root,
-            ),
-            sweep_id=sweep_id,
-            index_path=index_path,
-            catalog_path=catalog_path,
-            sweeps_root=sweeps_root,
-        )
-    )
+            )
+        except RuntimeError as exc:
+            message = str(exc)
+            if "missing screen_metrics" not in message:
+                raise
+            resolved_queue = load_system_delta_queue(
+                sweep_id=sweep_id,
+                index_path=index_path,
+                catalog_path=catalog_path,
+                sweeps_root=sweeps_root,
+            )
     resolved_sweep_id = _require_non_empty_string(
         sweep_id if sweep_id is not None else resolved_queue.get("sweep_id"),
         context="sweep_id",

--- a/src/tab_foundry/research/sweep/matrix.py
+++ b/src/tab_foundry/research/sweep/matrix.py
@@ -823,6 +823,8 @@ def render_and_write_system_delta_matrix(
     sweeps_root: Path | None = None,
     out_path: Path | None = None,
 ) -> Path:
+    from .reporting import refresh_result_cards_for_queue
+
     resolved_queue = (
         queue
         if queue is not None
@@ -850,4 +852,5 @@ def render_and_write_system_delta_matrix(
     )
     contents = render_system_delta_matrix(resolved_queue, registry_path=registry_path)
     write_text(resolved_out_path, contents)
+    refresh_result_cards_for_queue(queue=resolved_queue, registry_path=registry_path)
     return resolved_out_path

--- a/src/tab_foundry/research/sweep/pareto.py
+++ b/src/tab_foundry/research/sweep/pareto.py
@@ -1,0 +1,213 @@
+"""Pareto reporting helpers for sweep summaries and selector interpretation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import re
+from typing import Any, Mapping, Sequence, cast
+
+
+_MIN_KEPT_CONTRACT_FRONTIER_GEOMETRIES = 2
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _geometry_label(row: Mapping[str, Any]) -> str | None:
+    existing = row.get("selector_geometry_label")
+    if isinstance(existing, str) and existing.strip():
+        return str(existing).strip()
+    model = row.get("model")
+    if not isinstance(model, Mapping):
+        return None
+    d_icl = model.get("d_icl")
+    layers = model.get("sandwich_layers")
+    if d_icl is None or layers is None:
+        return None
+    return f"{int(d_icl)}x{int(layers)}"
+
+
+def _prescription_label(row: Mapping[str, Any]) -> str | None:
+    existing = row.get("selector_prescription_label")
+    if isinstance(existing, str) and existing.strip():
+        return str(existing).strip()
+    for key in ("delta_id", "delta_ref"):
+        raw = row.get(key)
+        if not isinstance(raw, str) or "_muon_" not in raw:
+            continue
+        suffix = raw.rsplit("_muon_", 1)[1]
+        suffix = re.sub(r"_v\d+$", "", suffix)
+        return suffix or None
+    return None
+
+
+def _pareto_orders(rows: Sequence[Mapping[str, Any]]) -> set[int]:
+    eligible: list[tuple[int, float, float]] = []
+    for row in rows:
+        loss = _optional_float(row.get("final_log_loss"))
+        wall = _optional_float(row.get("end_to_end_wall_seconds"))
+        if loss is None or wall is None:
+            continue
+        eligible.append((int(row["order"]), loss, wall))
+    frontier: set[int] = set()
+    for order, loss, wall in eligible:
+        dominated = False
+        for other_order, other_loss, other_wall in eligible:
+            if other_order == order:
+                continue
+            if (
+                other_loss <= loss
+                and other_wall <= wall
+                and (other_loss < loss or other_wall < wall)
+            ):
+                dominated = True
+                break
+        if not dominated:
+            frontier.add(order)
+    return frontier
+
+
+def _row_descriptor(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "order": int(row["order"]),
+        "delta_id": str(row["delta_id"]),
+        "geometry_label": _geometry_label(row),
+        "prescription_label": _prescription_label(row),
+        "final_log_loss": _optional_float(row.get("final_log_loss")),
+        "end_to_end_wall_seconds": _optional_float(row.get("end_to_end_wall_seconds")),
+    }
+
+
+def annotate_rows_with_pareto(
+    *,
+    rows: list[dict[str, Any]],
+    surface_role: str | None = None,
+) -> dict[str, Any] | None:
+    global_frontier = _pareto_orders(rows)
+    geometry_groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        geometry_label = _geometry_label(row)
+        prescription_label = _prescription_label(row)
+        row["pareto_admissible"] = (
+            None
+            if _optional_float(row.get("final_log_loss")) is None
+            or _optional_float(row.get("end_to_end_wall_seconds")) is None
+            else int(row["order"]) in global_frontier
+        )
+        row["selector_geometry_label"] = geometry_label
+        row["selector_prescription_label"] = prescription_label
+        row["geometry_pareto_admissible"] = None
+        if geometry_label is not None:
+            geometry_groups[geometry_label].append(row)
+
+    geometry_frontiers: dict[str, set[int]] = {
+        geometry_label: _pareto_orders(group_rows)
+        for geometry_label, group_rows in geometry_groups.items()
+    }
+    for row in rows:
+        geometry_label = cast(str | None, row.get("selector_geometry_label"))
+        if geometry_label is None:
+            continue
+        row["geometry_pareto_admissible"] = (
+            None
+            if _optional_float(row.get("final_log_loss")) is None
+            or _optional_float(row.get("end_to_end_wall_seconds")) is None
+            else int(row["order"]) in geometry_frontiers.get(geometry_label, set())
+        )
+
+    if surface_role != "classification_training_dynamics_selector":
+        return None
+
+    eligible_rows = [
+        row
+        for row in rows
+        if row.get("selector_geometry_label") is not None
+        and row.get("selector_prescription_label") is not None
+        and _optional_float(row.get("final_log_loss")) is not None
+        and _optional_float(row.get("end_to_end_wall_seconds")) is not None
+    ]
+    if not eligible_rows:
+        return {
+            "eligible_row_count": 0,
+            "global_frontier_orders": [],
+            "per_geometry_frontiers": {},
+            "best_row": None,
+            "kept_contract": None,
+            "no_universal_kept_contract": True,
+        }
+
+    best_row_payload = _row_descriptor(
+        min(
+            eligible_rows,
+            key=lambda row: (
+                float(row["final_log_loss"]),
+                float(row["end_to_end_wall_seconds"]),
+                int(row["order"]),
+            ),
+        )
+    )
+
+    per_geometry_frontiers: dict[str, list[dict[str, Any]]] = {}
+    prescription_rows: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for geometry_label, frontier_orders in geometry_frontiers.items():
+        frontier_rows = [
+            row
+            for row in eligible_rows
+            if row.get("selector_geometry_label") == geometry_label
+            and int(row["order"]) in frontier_orders
+        ]
+        sorted_rows = sorted(frontier_rows, key=lambda row: int(row["order"]))
+        per_geometry_frontiers[geometry_label] = [_row_descriptor(row) for row in sorted_rows]
+        for row in sorted_rows:
+            prescription_rows[str(row["selector_prescription_label"])].append(row)
+
+    coverage: list[dict[str, Any]] = []
+    for prescription_label, rows_for_prescription in prescription_rows.items():
+        geometry_labels = sorted(
+            {str(row["selector_geometry_label"]) for row in rows_for_prescription}
+        )
+        coverage.append(
+            {
+                "prescription_label": prescription_label,
+                "geometry_count": len(geometry_labels),
+                "geometry_labels": geometry_labels,
+                "mean_end_to_end_wall_seconds": sum(
+                    float(row["end_to_end_wall_seconds"]) for row in rows_for_prescription
+                )
+                / float(len(rows_for_prescription)),
+                "mean_benchmark_log_loss": sum(
+                    float(row["final_log_loss"]) for row in rows_for_prescription
+                )
+                / float(len(rows_for_prescription)),
+                "orders": sorted(int(row["order"]) for row in rows_for_prescription),
+            }
+        )
+    coverage.sort(
+        key=lambda item: (
+            -int(item["geometry_count"]),
+            float(item["mean_end_to_end_wall_seconds"]),
+            float(item["mean_benchmark_log_loss"]),
+            str(item["prescription_label"]),
+        )
+    )
+
+    kept_contract = None
+    if (
+        coverage
+        and int(coverage[0]["geometry_count"])
+        >= _MIN_KEPT_CONTRACT_FRONTIER_GEOMETRIES
+    ):
+        kept_contract = dict(coverage[0])
+
+    return {
+        "eligible_row_count": len(eligible_rows),
+        "global_frontier_orders": sorted(global_frontier),
+        "per_geometry_frontiers": per_geometry_frontiers,
+        "best_row": best_row_payload,
+        "prescription_coverage": coverage,
+        "kept_contract": kept_contract,
+        "no_universal_kept_contract": kept_contract is None,
+    }

--- a/src/tab_foundry/research/sweep/queue_materialization.py
+++ b/src/tab_foundry/research/sweep/queue_materialization.py
@@ -140,6 +140,16 @@ def _reuse_train_artifact_payload(
     return None
 
 
+def _optional_extra_payload(
+    queue_row: QueueRowPayload | Mapping[str, Any],
+    key: str,
+) -> Any:
+    raw_payload = queue_row.get(key)
+    if raw_payload is None:
+        return None
+    return _copy_jsonable(raw_payload) if isinstance(raw_payload, (dict, list)) else raw_payload
+
+
 def _json_fingerprint(payload: Mapping[str, Any]) -> str:
     return sha256_text(json.dumps(_copy_jsonable(payload), sort_keys=True, separators=(",", ":")))
 
@@ -335,6 +345,16 @@ def inspection_row(
             _copy_jsonable(queue_row.get("benchmark_metrics")) if queue_row.get("benchmark_metrics") else None,
         ),
     }
+    for extra_key in (
+        "dynamic_training_overrides",
+        "dynamic_reuse_train_artifact",
+        "transfer_context",
+        "transfer_resolution",
+        "imported_baseline_provenance",
+    ):
+        extra_payload = _optional_extra_payload(queue_row, extra_key)
+        if extra_payload is not None:
+            payload[extra_key] = extra_payload
     reuse_train_artifact = _reuse_train_artifact_payload(queue_row)
     if reuse_train_artifact is not None:
         payload["reuse_train_artifact"] = reuse_train_artifact
@@ -555,6 +575,16 @@ def materialize_row(
             _copy_jsonable(queue_row.get("benchmark_metrics")) if queue_row.get("benchmark_metrics") else None,
         ),
     }
+    for extra_key in (
+        "dynamic_training_overrides",
+        "dynamic_reuse_train_artifact",
+        "transfer_context",
+        "transfer_resolution",
+        "imported_baseline_provenance",
+    ):
+        extra_payload = _optional_extra_payload(queue_row, extra_key)
+        if extra_payload is not None:
+            payload[extra_key] = extra_payload
     reuse_train_artifact = _reuse_train_artifact_payload(queue_row)
     if reuse_train_artifact is not None:
         payload["reuse_train_artifact"] = reuse_train_artifact
@@ -640,6 +670,8 @@ def materialize_resolved_system_delta_queue(
     catalog_path: Path | None = None,
     sweeps_root: Path | None = None,
 ) -> ResolvedQueuePayload:
+    from . import row_dependencies as _row_dependencies
+
     materialized = materialize_system_delta_queue(
         catalog=catalog,
         sweep=sweep,
@@ -649,21 +681,48 @@ def materialize_resolved_system_delta_queue(
     )
     resolved_repo_root = _resolved_repo_root(catalog_path=catalog_path, sweeps_root=sweeps_root)
     training_experiment = resolve_sweep_semantics(sweep).training_surface.training_experiment
+    materialized_payload = materialized.to_payload_dict()
+    queue_rows_payload = cast(list[dict[str, Any]], materialized_payload["rows"])
+    queue_for_resolution = {
+        "sweep_id": sweep.sweep_id,
+        "training_experiment": training_experiment,
+        "rows": queue_rows_payload,
+    }
     resolved_rows: list[dict[str, Any]] = []
-    for row in materialized.rows:
+    for row_payload in queue_rows_payload:
+        _row_dependencies.resolve_dynamic_model_overrides(
+            queue=queue_for_resolution,
+            queue_row=row_payload,
+            materialized_row=row_payload,
+        )
+        _row_dependencies.resolve_dynamic_training_overrides(
+            queue=queue_for_resolution,
+            queue_row=row_payload,
+            materialized_row=row_payload,
+        )
+        _row_dependencies.resolve_dynamic_reuse_train_artifact(
+            queue=queue_for_resolution,
+            queue_row=row_payload,
+            materialized_row=row_payload,
+        )
+        validate_one_epoch_contract(
+            row_payload,
+            repo_root=resolved_repo_root,
+            sweep_id=sweep.sweep_id,
+            sweeps_root=sweeps_root,
+        )
         resolved_surface, resolved_surface_fingerprint = _resolved_surface_payload(
-            row=row.to_payload_dict(),
+            row=row_payload,
             sweep_id=sweep.sweep_id,
             training_experiment=training_experiment,
             repo_root=resolved_repo_root,
             sweeps_root=sweeps_root,
         )
-        row_payload = row.to_payload_dict()
         row_payload["resolved_surface"] = resolved_surface
         row_payload["resolved_surface_fingerprint"] = resolved_surface_fingerprint
-        resolved_rows.append(row_payload)
+        resolved_rows.append(dict(row_payload))
     resolved_sweeps_root = sweeps_root or default_sweeps_root()
-    payload = materialized.to_payload_dict()
+    payload = materialized_payload
     payload.update(
         {
             "schema": RESOLVED_QUEUE_SCHEMA,

--- a/src/tab_foundry/research/sweep/reporting.py
+++ b/src/tab_foundry/research/sweep/reporting.py
@@ -327,6 +327,94 @@ def _selector_interpretation_lines(
     return lines
 
 
+def _transfer_interpretation_lines(
+    transfer_context: Mapping[str, Any] | None,
+) -> list[str]:
+    if not isinstance(transfer_context, Mapping):
+        return []
+    row_summary = transfer_context.get("row_summary")
+    transfer_summary = transfer_context.get("summary")
+    if not isinstance(row_summary, Mapping) and not isinstance(transfer_summary, Mapping):
+        return []
+    lines = ["", "## Transfer interpretation", ""]
+    if isinstance(row_summary, Mapping):
+        if row_summary.get("transfer_regime_label") is not None:
+            lines.append(f"- Transfer regime: `{row_summary['transfer_regime_label']}`")
+        if row_summary.get("transfer_phase") is not None:
+            lines.append(f"- Transfer phase: `{row_summary['transfer_phase']}`")
+        if row_summary.get("transfer_formula_label") is not None:
+            lines.append(f"- Transfer formula: `{row_summary['transfer_formula_label']}`")
+        if row_summary.get("transfer_target_budget_label") is not None:
+            lines.append(
+                f"- Target budget label: `{row_summary['transfer_target_budget_label']}`"
+            )
+        if row_summary.get("target_effective_batch") is not None:
+            lines.append(
+                f"- Target effective batch: `{float(row_summary['target_effective_batch']):.1f}`"
+            )
+        if row_summary.get("realized_effective_batch") is not None:
+            lines.append(
+                f"- Realized effective batch: `{int(row_summary['realized_effective_batch'])}`"
+            )
+        if row_summary.get("target_effective_budget") is not None:
+            lines.append(
+                f"- Target effective budget: `{int(row_summary['target_effective_budget'])}`"
+            )
+        if row_summary.get("realized_effective_budget") is not None:
+            lines.append(
+                f"- Realized effective budget: `{int(row_summary['realized_effective_budget'])}`"
+            )
+        if row_summary.get("budget_drift") is not None:
+            lines.append(f"- Budget drift: `{float(row_summary['budget_drift']):+.6f}`")
+        if row_summary.get("batch_drift") is not None:
+            lines.append(f"- Batch drift: `{float(row_summary['batch_drift']):+.6f}`")
+        imported_baseline = row_summary.get("imported_baseline_provenance")
+        if isinstance(imported_baseline, Mapping):
+            source_sweep_id = imported_baseline.get("source_sweep_id")
+            source_order = imported_baseline.get("source_order")
+            source_run_id = imported_baseline.get("source_run_id")
+            rendered_parts = []
+            if source_sweep_id is not None:
+                rendered_parts.append(f"sweep `{source_sweep_id}`")
+            if source_order is not None:
+                rendered_parts.append(f"order `{int(source_order):02d}`")
+            if source_run_id is not None:
+                rendered_parts.append(f"run `{source_run_id}`")
+            if rendered_parts:
+                lines.append("- Imported baseline provenance: " + ", ".join(rendered_parts))
+    if isinstance(transfer_summary, Mapping):
+        best_row = transfer_summary.get("best_row")
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "- Best transfer row: "
+                f"order `{int(best_row['order']):02d}` "
+                f"(regime `{best_row.get('regime_label') or 'n/a'}`, "
+                f"log loss `{float(best_row['final_log_loss']):.6f}`, "
+                f"budget `{best_row.get('target_budget_label') or 'n/a'}`)"
+            )
+        fastest_row = transfer_summary.get("fastest_row")
+        if isinstance(fastest_row, Mapping):
+            lines.append(
+                "- Fastest transfer row: "
+                f"order `{int(fastest_row['order']):02d}` "
+                f"(regime `{fastest_row.get('regime_label') or 'n/a'}`, "
+                f"wall `{float(fastest_row['end_to_end_wall_seconds']):.1f}s`)"
+            )
+        leaderboard = transfer_summary.get("regime_leaderboard")
+        if isinstance(leaderboard, list) and leaderboard:
+            rendered = "; ".join(
+                (
+                    f"{str(cast(Mapping[str, Any], item)['regime_label'])}: "
+                    f"mean log loss `{float(cast(Mapping[str, Any], item)['mean_benchmark_log_loss']):.6f}`"
+                )
+                for item in leaderboard
+                if isinstance(item, Mapping)
+            )
+            if rendered:
+                lines.append(f"- Regime leaderboard: {rendered}")
+    return lines
+
+
 def result_card_text(
     *,
     row: Mapping[str, Any],
@@ -337,6 +425,7 @@ def result_card_text(
     decision: str,
     conclusion: str,
     selector_context: Mapping[str, Any] | None = None,
+    transfer_context: Mapping[str, Any] | None = None,
 ) -> str:
     primary_external_name, primary_external_summary = _primary_external_summary(summary)
     objective_metric = objective_metric_from_queue_metrics(queue_metrics)
@@ -662,6 +751,7 @@ def result_card_text(
         lines.extend(["", "## Stage-local stability", ""])
         lines.extend(stage_local_lines)
     lines.extend(_selector_interpretation_lines(selector_context))
+    lines.extend(_transfer_interpretation_lines(transfer_context))
 
     lines.extend(
         [
@@ -717,6 +807,10 @@ def refresh_result_cards_for_queue(
         Mapping[str, Any] | None,
         summary_payload.get("selector_summary"),
     )
+    transfer_context_summary = cast(
+        Mapping[str, Any] | None,
+        summary_payload.get("transfer_summary"),
+    )
     for row in ordered_rows(queue):
         if str(row.get("status", "")).strip().lower() != "completed":
             continue
@@ -764,6 +858,10 @@ def refresh_result_cards_for_queue(
                 selector_context={
                     "row_summary": row_summaries.get(int(row["order"])),
                     "summary": selector_context_summary,
+                },
+                transfer_context={
+                    "row_summary": row_summaries.get(int(row["order"])),
+                    "summary": transfer_context_summary,
                 },
             ),
             encoding="utf-8",

--- a/src/tab_foundry/research/sweep/reporting.py
+++ b/src/tab_foundry/research/sweep/reporting.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Mapping, cast
 
+from tab_foundry.benchmark_registry import load_benchmark_run_registry, resolve_registry_path_value
 from tab_foundry.external_benchmarks import (
     EXTERNAL_BENCHMARK_LABELS,
     EXTERNAL_BENCHMARK_NANOTABPFN,
@@ -23,6 +25,8 @@ from .objective_metrics import (
     is_classification_objective_metric,
     objective_metric_from_queue_metrics,
 )
+from .paths_io import default_registry_path, repo_root
+from .queue_loading import ordered_rows
 
 
 def research_card_text(
@@ -261,6 +265,68 @@ def _runtime_and_regime_lines(queue_metrics: Mapping[str, Any]) -> list[str]:
     return lines
 
 
+def _selector_interpretation_lines(
+    selector_context: Mapping[str, Any] | None,
+) -> list[str]:
+    if not isinstance(selector_context, Mapping):
+        return []
+    row_summary = selector_context.get("row_summary")
+    selector_summary = selector_context.get("summary")
+    if not isinstance(row_summary, Mapping) and not isinstance(selector_summary, Mapping):
+        return []
+    lines = ["", "## Selector interpretation", ""]
+    if isinstance(row_summary, Mapping):
+        pareto_status = (
+            "yes"
+            if row_summary.get("pareto_admissible") is True
+            else ("no" if row_summary.get("pareto_admissible") is False else "n/a")
+        )
+        geometry_pareto_status = (
+            "yes"
+            if row_summary.get("geometry_pareto_admissible") is True
+            else (
+                "no"
+                if row_summary.get("geometry_pareto_admissible") is False
+                else "n/a"
+            )
+        )
+        lines.append(f"- Quality/time Pareto admissible: `{pareto_status}`")
+        lines.append(f"- Geometry-local Pareto admissible: `{geometry_pareto_status}`")
+        if row_summary.get("selector_geometry_label") is not None:
+            lines.append(
+                f"- Selector geometry: `{row_summary['selector_geometry_label']}`"
+            )
+        if row_summary.get("selector_prescription_label") is not None:
+            lines.append(
+                f"- Selector prescription: `{row_summary['selector_prescription_label']}`"
+            )
+    if isinstance(selector_summary, Mapping):
+        best_row = selector_summary.get("best_row")
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "- Best single selector row: "
+                f"order `{int(best_row['order']):02d}` "
+                f"({best_row.get('geometry_label') or 'n/a'}, "
+                f"{best_row.get('prescription_label') or 'n/a'}, "
+                f"log loss `{float(best_row['final_log_loss']):.6f}`, "
+                f"wall `{float(best_row['end_to_end_wall_seconds']):.1f}s`)"
+            )
+        kept_contract = selector_summary.get("kept_contract")
+        if isinstance(kept_contract, Mapping):
+            lines.append(
+                "- Kept contract: "
+                f"`{kept_contract['prescription_label']}` "
+                f"(frontier geometries `{int(kept_contract['geometry_count'])}`, "
+                f"mean wall `{float(kept_contract['mean_end_to_end_wall_seconds']):.1f}s`, "
+                f"mean log loss `{float(kept_contract['mean_benchmark_log_loss']):.6f}`)"
+            )
+        elif selector_summary.get("no_universal_kept_contract") is True:
+            lines.append(
+                "- Kept contract: none; no prescription reached the required majority frontier coverage."
+            )
+    return lines
+
+
 def result_card_text(
     *,
     row: Mapping[str, Any],
@@ -270,6 +336,7 @@ def result_card_text(
     queue_metrics: Mapping[str, Any],
     decision: str,
     conclusion: str,
+    selector_context: Mapping[str, Any] | None = None,
 ) -> str:
     primary_external_name, primary_external_summary = _primary_external_summary(summary)
     objective_metric = objective_metric_from_queue_metrics(queue_metrics)
@@ -594,6 +661,7 @@ def result_card_text(
     if stage_local_lines:
         lines.extend(["", "## Stage-local stability", ""])
         lines.extend(stage_local_lines)
+    lines.extend(_selector_interpretation_lines(selector_context))
 
     lines.extend(
         [
@@ -620,3 +688,83 @@ def result_card_text(
         ]
     )
     return "\n".join(lines)
+
+
+def refresh_result_cards_for_queue(
+    *,
+    queue: Mapping[str, Any],
+    registry_path: Path | None = None,
+) -> None:
+    from .summarize import build_sweep_summary_payload
+
+    resolved_registry_path = registry_path or default_registry_path()
+    registry = load_benchmark_run_registry(resolved_registry_path)
+    runs = registry.get("runs")
+    if not isinstance(runs, Mapping):
+        return
+    sweep_id = str(queue["sweep_id"])
+    anchor_run_id = (
+        str(queue["anchor_run_id"])
+        if isinstance(queue.get("anchor_run_id"), str) and str(queue["anchor_run_id"]).strip()
+        else None
+    )
+    summary_payload = build_sweep_summary_payload(queue=queue, include_screened=True)
+    row_summaries = {
+        int(cast(Mapping[str, Any], row)["order"]): cast(Mapping[str, Any], row)
+        for row in cast(list[dict[str, Any]], summary_payload["rows"])
+    }
+    selector_context_summary = cast(
+        Mapping[str, Any] | None,
+        summary_payload.get("selector_summary"),
+    )
+    for row in ordered_rows(queue):
+        if str(row.get("status", "")).strip().lower() != "completed":
+            continue
+        run_id = row.get("run_id")
+        if not isinstance(run_id, str) or not run_id.strip():
+            continue
+        run = runs.get(run_id)
+        if not isinstance(run, Mapping):
+            continue
+        artifacts = run.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            continue
+        raw_summary_path = artifacts.get("comparison_summary_path")
+        if not isinstance(raw_summary_path, str) or not raw_summary_path.strip():
+            continue
+        summary_path = resolve_registry_path_value(raw_summary_path)
+        if not summary_path.exists():
+            continue
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        if not isinstance(summary, dict):
+            continue
+        queue_metrics = row.get("benchmark_metrics")
+        if not isinstance(queue_metrics, Mapping):
+            queue_metrics = row.get("screen_metrics")
+        if not isinstance(queue_metrics, Mapping):
+            continue
+        delta_root = (
+            repo_root()
+            / "outputs"
+            / "staged_ladder"
+            / "research"
+            / sweep_id
+            / str(row["delta_id"])
+        )
+        delta_root.mkdir(parents=True, exist_ok=True)
+        (delta_root / "result_card.md").write_text(
+            result_card_text(
+                row=row,
+                run_id=run_id,
+                anchor_run_id=anchor_run_id,
+                summary=summary,
+                queue_metrics=cast(Mapping[str, Any], queue_metrics),
+                decision=str(row.get("decision") or "defer"),
+                conclusion=str(row.get("conclusion") or "pending"),
+                selector_context={
+                    "row_summary": row_summaries.get(int(row["order"])),
+                    "summary": selector_context_summary,
+                },
+            ),
+            encoding="utf-8",
+        )

--- a/src/tab_foundry/research/sweep/reporting.py
+++ b/src/tab_foundry/research/sweep/reporting.py
@@ -382,6 +382,20 @@ def _transfer_interpretation_lines(
                 rendered_parts.append(f"run `{source_run_id}`")
             if rendered_parts:
                 lines.append("- Imported baseline provenance: " + ", ".join(rendered_parts))
+        shared_anchor = row_summary.get("shared_anchor_provenance")
+        if isinstance(shared_anchor, Mapping):
+            anchor_sweep_id = shared_anchor.get("anchor_sweep_id")
+            anchor_order = shared_anchor.get("anchor_order")
+            anchor_run_dir = shared_anchor.get("anchor_run_dir")
+            rendered_parts = []
+            if anchor_sweep_id is not None:
+                rendered_parts.append(f"sweep `{anchor_sweep_id}`")
+            if anchor_order is not None:
+                rendered_parts.append(f"order `{int(anchor_order):02d}`")
+            if anchor_run_dir is not None:
+                rendered_parts.append(f"run dir `{anchor_run_dir}`")
+            if rendered_parts:
+                lines.append("- Shared anchor provenance: " + ", ".join(rendered_parts))
     if isinstance(transfer_summary, Mapping):
         best_row = transfer_summary.get("best_row")
         if isinstance(best_row, Mapping):
@@ -412,6 +426,22 @@ def _transfer_interpretation_lines(
             )
             if rendered:
                 lines.append(f"- Regime leaderboard: {rendered}")
+        kept_regime = transfer_summary.get("kept_regime")
+        if isinstance(kept_regime, Mapping):
+            lines.append(
+                "- Kept regime (`T2` then `T1`): "
+                f"`{kept_regime['regime_label']}` "
+                f"(T2 order `{int(kept_regime['t2_order']):02d}`, "
+                f"log loss `{float(kept_regime['t2_log_loss']):.6f}`)"
+            )
+        t2_vs_highbatch = transfer_summary.get("t2_vs_carried_highbatch")
+        if isinstance(t2_vs_highbatch, Mapping):
+            lines.append(
+                "- T2 vs carried high-batch: "
+                f"winning regime `{t2_vs_highbatch['winning_regime_label']}` "
+                f"minus carried high-batch delta log loss "
+                f"`{float(t2_vs_highbatch['delta_log_loss']):+.6f}`"
+            )
     return lines
 
 

--- a/src/tab_foundry/research/sweep/row_dependencies.py
+++ b/src/tab_foundry/research/sweep/row_dependencies.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Mapping, cast
 
+from .paths_io import repo_root as shared_repo_root
+from .queue_loading import load_system_delta_queue_for_inspection
 from .queue_updates import append_note
 from .screening import pick_screen_winner
+from .surface_resolution import (
+    build_lightweight_training_surface_record,
+    resolve_queue_row_cfg_mapping,
+)
+from .training_state import training_surface_record_fingerprint
+from .transfer import resolve_transfer_schedule
 
 
 def _optional_non_empty_string(value: Any, *, context: str) -> str | None:
@@ -14,6 +23,208 @@ def _optional_non_empty_string(value: Any, *, context: str) -> str | None:
     if not isinstance(value, str) or not value.strip():
         raise RuntimeError(f"{context} must be a non-empty string when provided")
     return str(value.strip())
+
+
+def _optional_positive_int(value: Any, *, context: str) -> int | None:
+    if value is None:
+        return None
+    numeric = int(value)
+    if numeric <= 0:
+        raise RuntimeError(f"{context} must be a positive int when provided")
+    return numeric
+
+
+def _mapping_value(payload: Mapping[str, Any], key: str, *, context: str) -> Mapping[str, Any]:
+    raw_value = payload.get(key)
+    if not isinstance(raw_value, Mapping):
+        raise RuntimeError(f"{context}.{key} must be a mapping")
+    return cast(Mapping[str, Any], raw_value)
+
+
+def _rows_from_queue(queue: Mapping[str, Any], *, context: str) -> list[Mapping[str, Any]]:
+    rows_raw = queue.get("rows")
+    if not isinstance(rows_raw, list):
+        raise RuntimeError(f"{context}.rows must be a list")
+    return [cast(Mapping[str, Any], row) for row in rows_raw if isinstance(row, Mapping)]
+
+
+def _queue_for_sweep(
+    *,
+    queue: Mapping[str, Any],
+    sweep_id: str,
+) -> tuple[Mapping[str, Any], list[Mapping[str, Any]]]:
+    current_sweep_id = str(queue.get("sweep_id", "")).strip()
+    if sweep_id == current_sweep_id:
+        rows = _rows_from_queue(queue, context=f"sweep {sweep_id}")
+        return queue, rows
+    source_queue = load_system_delta_queue_for_inspection(sweep_id=sweep_id)
+    rows = _rows_from_queue(source_queue, context=f"sweep {sweep_id}")
+    return source_queue, rows
+
+
+def _find_row_by_order(
+    *,
+    rows: list[Mapping[str, Any]],
+    order: int,
+    context: str,
+) -> Mapping[str, Any]:
+    for row in rows:
+        if int(row["order"]) == int(order):
+            return row
+    raise RuntimeError(f"{context} order {order} is missing")
+
+
+def _candidate_label(
+    *,
+    candidate: Mapping[str, Any],
+    row: Mapping[str, Any],
+) -> str:
+    for key in ("value", "candidate_label", "label"):
+        value = candidate.get(key)
+        if isinstance(value, str) and value.strip():
+            return str(value).strip()
+    for field_name in ("transfer_context", "transfer_resolution"):
+        payload = row.get(field_name)
+        if isinstance(payload, Mapping):
+            raw_label = payload.get("candidate_label")
+            if isinstance(raw_label, str) and raw_label.strip():
+                return str(raw_label).strip()
+    delta_id = row.get("delta_id", row.get("delta_ref"))
+    if isinstance(delta_id, str) and delta_id.strip():
+        return str(delta_id).strip()
+    return f"order_{int(row['order']):02d}"
+
+
+def _resolve_screen_winner(
+    *,
+    queue: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> tuple[dict[str, Any], Mapping[str, Any], Mapping[str, Any], str]:
+    compare_orders = policy.get("compare_orders")
+    if not isinstance(compare_orders, list) or not compare_orders:
+        raise RuntimeError("screen winner policy compare_orders must be a non-empty list")
+
+    source_sweep_ids = {
+        _optional_non_empty_string(
+            cast(Mapping[str, Any], candidate).get("sweep_id"),
+            context="screen winner compare_orders[].sweep_id",
+        )
+        or str(queue.get("sweep_id", "")).strip()
+        for candidate in compare_orders
+        if isinstance(candidate, Mapping)
+    }
+    if not source_sweep_ids:
+        raise RuntimeError("screen winner compare_orders did not contain any candidates")
+    if len(source_sweep_ids) != 1:
+        raise RuntimeError(
+            "screen winner policies currently require candidates from exactly one sweep; "
+            f"got {sorted(source_sweep_ids)}"
+        )
+    source_sweep_id = next(iter(source_sweep_ids))
+    source_queue, source_rows = _queue_for_sweep(queue=queue, sweep_id=source_sweep_id)
+
+    candidates: list[dict[str, Any]] = []
+    for candidate_raw in compare_orders:
+        if not isinstance(candidate_raw, Mapping):
+            raise RuntimeError("screen winner compare_orders entries must be mappings")
+        order = int(candidate_raw["order"])
+        candidate_row = _find_row_by_order(
+            rows=source_rows,
+            order=order,
+            context=f"screen winner sweep {source_sweep_id}",
+        )
+        candidates.append(
+            {
+                "order": order,
+                "value": _candidate_label(candidate=candidate_raw, row=candidate_row),
+                "screen_metrics": candidate_row.get("screen_metrics"),
+            }
+        )
+
+    tie_break_preference = str(
+        policy.get("tie_break_preference", candidates[0]["value"])
+    )
+    resolution = pick_screen_winner(
+        candidates=candidates,
+        tie_break_preference=tie_break_preference,
+    )
+    winning_order = int(resolution["winning_order"])
+    winning_row = _find_row_by_order(
+        rows=source_rows,
+        order=winning_order,
+        context=f"screen winner sweep {source_sweep_id}",
+    )
+    winning_candidate = next(
+        candidate for candidate in candidates if int(candidate["order"]) == winning_order
+    )
+    return resolution, winning_row, source_queue, str(winning_candidate["value"])
+
+
+def _first_schedule_stage(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    training = _mapping_value(row, "training", context=f"row {int(row['order'])}")
+    overrides = _mapping_value(training, "overrides", context=f"row {int(row['order'])} training")
+    schedule = _mapping_value(overrides, "schedule", context=f"row {int(row['order'])} training.overrides")
+    stages = schedule.get("stages")
+    if not isinstance(stages, list) or not stages or not isinstance(stages[0], Mapping):
+        raise RuntimeError(f"row {int(row['order'])} training.overrides.schedule.stages must start with a mapping")
+    return cast(Mapping[str, Any], stages[0])
+
+
+def _training_overrides(row: Mapping[str, Any]) -> tuple[Mapping[str, Any], Mapping[str, Any], Mapping[str, Any], int]:
+    training = _mapping_value(row, "training", context=f"row {int(row['order'])}")
+    task_batch_size = _optional_positive_int(
+        training.get("task_batch_size"),
+        context=f"row {int(row['order'])}.training.task_batch_size",
+    )
+    if task_batch_size is None:
+        raise RuntimeError(f"row {int(row['order'])} is missing training.task_batch_size")
+    overrides = _mapping_value(training, "overrides", context=f"row {int(row['order'])} training")
+    runtime = _mapping_value(overrides, "runtime", context=f"row {int(row['order'])} training.overrides")
+    optimizer = _mapping_value(overrides, "optimizer", context=f"row {int(row['order'])} training.overrides")
+    stage = _first_schedule_stage(row)
+    return runtime, optimizer, stage, int(task_batch_size)
+
+
+def _mutable_overrides(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], int]:
+    training = cast(dict[str, Any], row.setdefault("training", {}))
+    task_batch_size = _optional_positive_int(
+        training.get("task_batch_size"),
+        context=f"row {int(row['order'])}.training.task_batch_size",
+    )
+    if task_batch_size is None:
+        raise RuntimeError(f"row {int(row['order'])} is missing training.task_batch_size")
+    overrides = cast(dict[str, Any], training.setdefault("overrides", {}))
+    runtime = cast(dict[str, Any], overrides.setdefault("runtime", {}))
+    optimizer = cast(dict[str, Any], overrides.setdefault("optimizer", {}))
+    schedule = cast(dict[str, Any], overrides.setdefault("schedule", {}))
+    stages = schedule.setdefault("stages", [])
+    if not isinstance(stages, list):
+        raise RuntimeError(f"row {int(row['order'])} training.overrides.schedule.stages must be a list")
+    if not stages:
+        stages.append({})
+    if not isinstance(stages[0], dict):
+        raise RuntimeError(f"row {int(row['order'])} training.overrides.schedule.stages[0] must be a mapping")
+    return runtime, optimizer, cast(dict[str, Any], stages[0]), int(task_batch_size)
+
+
+def _resolved_train_dir(
+    *,
+    sweep_id: str,
+    delta_id: str,
+    run_id: str,
+) -> tuple[str, Path]:
+    repo_root = shared_repo_root()
+    absolute = (
+        repo_root
+        / "outputs"
+        / "staged_ladder"
+        / "research"
+        / str(sweep_id)
+        / str(delta_id)
+        / str(run_id)
+        / "train"
+    )
+    return absolute.relative_to(repo_root).as_posix(), absolute
 
 
 def _resolve_parent_row(
@@ -148,6 +359,185 @@ def resolve_dynamic_model_overrides(
         resolution_note = (
             f"Resolved `{override_key}` to `{winning_value}` from screen row "
             f"`{int(resolution['winning_order'])}` ({resolution['reason']})."
+        )
+        queue_row["notes"] = append_note(queue_notes, resolution_note)
+        materialized_row["notes"] = append_note(materialized_notes, resolution_note)
+
+
+def resolve_dynamic_training_overrides(
+    *,
+    queue: Mapping[str, Any],
+    queue_row: dict[str, Any],
+    materialized_row: dict[str, Any],
+) -> None:
+    dynamic_overrides = queue_row.get("dynamic_training_overrides")
+    if not isinstance(dynamic_overrides, Mapping):
+        return
+    queue_notes = cast(list[str], queue_row.setdefault("notes", []))
+    materialized_notes = cast(list[str], materialized_row.setdefault("notes", []))
+
+    for override_key, policy_raw in dynamic_overrides.items():
+        if not isinstance(policy_raw, Mapping):
+            raise RuntimeError(f"dynamic_training_overrides.{override_key} must be a mapping")
+        policy = cast(dict[str, Any], policy_raw)
+        kind = str(policy.get("kind", "")).strip()
+        if kind != "screen_winner_transfer":
+            raise RuntimeError(f"unsupported dynamic training override policy kind: {kind!r}")
+
+        resolution, winning_row, source_queue, winning_value = _resolve_screen_winner(
+            queue=queue,
+            policy=policy,
+        )
+        runtime, optimizer, schedule_stage, task_batch_size = _training_overrides(winning_row)
+        base_grad_accum_steps = _optional_positive_int(
+            runtime.get("grad_accum_steps"),
+            context=f"row {int(winning_row['order'])} runtime.grad_accum_steps",
+        )
+        base_max_steps = _optional_positive_int(
+            runtime.get("max_steps"),
+            context=f"row {int(winning_row['order'])} runtime.max_steps",
+        )
+        if base_grad_accum_steps is None or base_max_steps is None:
+            raise RuntimeError(
+                f"screen winner row {int(winning_row['order'])} omitted grad_accum_steps or max_steps"
+            )
+        base_effective_batch = int(task_batch_size * base_grad_accum_steps)
+        base_effective_budget = int(base_max_steps * base_effective_batch)
+        resolved_schedule = resolve_transfer_schedule(
+            regime_label=str(policy["regime_label"]),
+            base_lr_max=float(schedule_stage["lr_max"]),
+            base_momentum=float(optimizer.get("momentum", 0.95)),
+            base_effective_batch=base_effective_batch,
+            base_effective_budget=int(
+                _optional_positive_int(
+                    policy.get("base_effective_budget"),
+                    context=f"dynamic_training_overrides.{override_key}.base_effective_budget",
+                )
+                or base_effective_budget
+            ),
+            target_effective_budget=int(
+                _optional_positive_int(
+                    policy.get("target_effective_budget"),
+                    context=f"dynamic_training_overrides.{override_key}.target_effective_budget",
+                )
+                or 0
+            ),
+            task_batch_size=task_batch_size,
+            fixed_effective_batch=_optional_positive_int(
+                policy.get("fixed_effective_batch"),
+                context=f"dynamic_training_overrides.{override_key}.fixed_effective_batch",
+            ),
+            min_lr_ratio=float(policy.get("min_lr_ratio", 1.0e-3)),
+            max_budget_drift=float(policy.get("max_budget_drift", 0.02)),
+        )
+
+        for target_row in (queue_row, materialized_row):
+            target_runtime, target_optimizer, target_stage, target_task_batch_size = _mutable_overrides(target_row)
+            if int(target_task_batch_size) != int(task_batch_size):
+                raise RuntimeError(
+                    "transfer rows must keep task_batch_size fixed relative to the T0 winner: "
+                    f"source={task_batch_size}, target={target_task_batch_size}"
+                )
+            target_runtime["grad_accum_steps"] = int(resolved_schedule["grad_accum_steps"])
+            target_runtime["max_steps"] = int(resolved_schedule["max_steps"])
+            target_stage["steps"] = int(resolved_schedule["max_steps"])
+            target_stage["lr_max"] = float(resolved_schedule["target_lr_max"])
+            target_optimizer["min_lr"] = float(resolved_schedule["min_lr"])
+            target_optimizer["momentum"] = float(resolved_schedule["target_momentum"])
+            target_row["transfer_resolution"] = {
+                **(
+                    cast(dict[str, Any], target_row.get("transfer_context"))
+                    if isinstance(target_row.get("transfer_context"), Mapping)
+                    else {}
+                ),
+                **resolved_schedule,
+                "resolved_from_order": int(resolution["winning_order"]),
+                "resolved_from_sweep_id": str(source_queue["sweep_id"]),
+                "resolved_candidate_label": str(winning_value),
+                "resolution_reason": str(resolution["reason"]),
+            }
+
+        policy["resolved_from_order"] = int(resolution["winning_order"])
+        policy["resolved_from_sweep_id"] = str(source_queue["sweep_id"])
+        policy["resolved_candidate_label"] = str(winning_value)
+        policy["resolution_reason"] = str(resolution["reason"])
+        resolution_note = (
+            f"Resolved transfer training overrides `{override_key}` from screen row "
+            f"`{int(resolution['winning_order'])}` in `{source_queue['sweep_id']}` "
+            f"({resolution['reason']})."
+        )
+        queue_row["notes"] = append_note(queue_notes, resolution_note)
+        materialized_row["notes"] = append_note(materialized_notes, resolution_note)
+
+
+def resolve_dynamic_reuse_train_artifact(
+    *,
+    queue: Mapping[str, Any],
+    queue_row: dict[str, Any],
+    materialized_row: dict[str, Any],
+) -> None:
+    dynamic_reuse = queue_row.get("dynamic_reuse_train_artifact")
+    if not isinstance(dynamic_reuse, Mapping):
+        return
+    queue_notes = cast(list[str], queue_row.setdefault("notes", []))
+    materialized_notes = cast(list[str], materialized_row.setdefault("notes", []))
+
+    for override_key, policy_raw in dynamic_reuse.items():
+        if not isinstance(policy_raw, Mapping):
+            raise RuntimeError(f"dynamic_reuse_train_artifact.{override_key} must be a mapping")
+        policy = cast(dict[str, Any], policy_raw)
+        kind = str(policy.get("kind", "")).strip()
+        if kind != "screen_winner_artifact":
+            raise RuntimeError(f"unsupported dynamic reuse policy kind: {kind!r}")
+
+        resolution, winning_row, source_queue, winning_value = _resolve_screen_winner(
+            queue=queue,
+            policy=policy,
+        )
+        run_id = _optional_non_empty_string(
+            winning_row.get("run_id"),
+            context=f"screen winner row {int(winning_row['order'])}.run_id",
+        )
+        if run_id is None:
+            raise RuntimeError(
+                f"screen winner row {int(winning_row['order'])} in `{source_queue['sweep_id']}` "
+                "does not have a completed run_id yet"
+            )
+        delta_id = _optional_non_empty_string(
+            winning_row.get("delta_id", winning_row.get("delta_ref")),
+            context=f"screen winner row {int(winning_row['order'])}.delta_id",
+        )
+        if delta_id is None:
+            raise RuntimeError(f"screen winner row {int(winning_row['order'])} is missing delta_id/delta_ref")
+        configured_run_dir, absolute_train_dir = _resolved_train_dir(
+            sweep_id=str(source_queue["sweep_id"]),
+            delta_id=delta_id,
+            run_id=run_id,
+        )
+        raw_cfg = resolve_queue_row_cfg_mapping(
+            winning_row,
+            run_dir=absolute_train_dir,
+            training_experiment=str(source_queue["training_experiment"]),
+            sweep_id=str(source_queue["sweep_id"]),
+        )
+        record = build_lightweight_training_surface_record(
+            raw_cfg=raw_cfg,
+            run_dir=absolute_train_dir,
+        )
+        reuse_payload = {
+            "run_dir": configured_run_dir,
+            "training_surface_fingerprint": training_surface_record_fingerprint(record),
+        }
+        for target_row in (queue_row, materialized_row):
+            target_row["reuse_train_artifact"] = dict(reuse_payload)
+
+        policy["resolved_from_order"] = int(resolution["winning_order"])
+        policy["resolved_from_sweep_id"] = str(source_queue["sweep_id"])
+        policy["resolved_candidate_label"] = str(winning_value)
+        policy["resolution_reason"] = str(resolution["reason"])
+        resolution_note = (
+            f"Resolved reusable train artifact `{override_key}` from screen row "
+            f"`{int(resolution['winning_order'])}` in `{source_queue['sweep_id']}`."
         )
         queue_row["notes"] = append_note(queue_notes, resolution_note)
         materialized_row["notes"] = append_note(materialized_notes, resolution_note)

--- a/src/tab_foundry/research/sweep/row_dependencies.py
+++ b/src/tab_foundry/research/sweep/row_dependencies.py
@@ -160,6 +160,68 @@ def _resolve_screen_winner(
     return resolution, winning_row, source_queue, str(winning_candidate["value"])
 
 
+def _resolve_shared_anchor(
+    *,
+    queue: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    anchor_order = _optional_positive_int(
+        policy.get("anchor_order"),
+        context="shared anchor policy anchor_order",
+    )
+    if anchor_order is None:
+        raise RuntimeError("shared anchor policy anchor_order must be provided")
+    source_sweep_id = (
+        _optional_non_empty_string(
+            policy.get("anchor_sweep_id"),
+            context="shared anchor policy anchor_sweep_id",
+        )
+        or str(queue.get("sweep_id", "")).strip()
+    )
+    source_queue, source_rows = _queue_for_sweep(queue=queue, sweep_id=source_sweep_id)
+    anchor_row = _find_row_by_order(
+        rows=source_rows,
+        order=int(anchor_order),
+        context=f"shared anchor sweep {source_sweep_id}",
+    )
+    return anchor_row, source_queue
+
+
+def _shared_anchor_provenance(
+    *,
+    anchor_row: Mapping[str, Any],
+    source_queue: Mapping[str, Any],
+) -> dict[str, Any]:
+    provenance: dict[str, Any] = {
+        "anchor_sweep_id": str(source_queue["sweep_id"]),
+        "anchor_order": int(anchor_row["order"]),
+    }
+    delta_id = _optional_non_empty_string(
+        anchor_row.get("delta_id", anchor_row.get("delta_ref")),
+        context=f"shared anchor row {int(anchor_row['order'])}.delta_id",
+    )
+    if delta_id is not None:
+        provenance["anchor_delta_id"] = delta_id
+    reuse_artifact = anchor_row.get("reuse_train_artifact")
+    if isinstance(reuse_artifact, Mapping):
+        anchor_run_dir = _optional_non_empty_string(
+            reuse_artifact.get("run_dir"),
+            context=f"shared anchor row {int(anchor_row['order'])}.reuse_train_artifact.run_dir",
+        )
+        if anchor_run_dir is not None:
+            provenance["anchor_run_dir"] = anchor_run_dir
+    imported_baseline = anchor_row.get("imported_baseline_provenance")
+    if isinstance(imported_baseline, Mapping):
+        provenance["anchor_imported_baseline_provenance"] = dict(cast(Mapping[str, Any], imported_baseline))
+    run_id = _optional_non_empty_string(
+        anchor_row.get("run_id"),
+        context=f"shared anchor row {int(anchor_row['order'])}.run_id",
+    )
+    if run_id is not None:
+        provenance["anchor_run_id"] = run_id
+    return provenance
+
+
 def _first_schedule_stage(row: Mapping[str, Any]) -> Mapping[str, Any]:
     training = _mapping_value(row, "training", context=f"row {int(row['order'])}")
     overrides = _mapping_value(training, "overrides", context=f"row {int(row['order'])} training")
@@ -381,25 +443,60 @@ def resolve_dynamic_training_overrides(
             raise RuntimeError(f"dynamic_training_overrides.{override_key} must be a mapping")
         policy = cast(dict[str, Any], policy_raw)
         kind = str(policy.get("kind", "")).strip()
-        if kind != "screen_winner_transfer":
+        if kind not in {"screen_winner_transfer", "shared_anchor_transfer"}:
             raise RuntimeError(f"unsupported dynamic training override policy kind: {kind!r}")
 
-        resolution, winning_row, source_queue, winning_value = _resolve_screen_winner(
-            queue=queue,
-            policy=policy,
-        )
-        runtime, optimizer, schedule_stage, task_batch_size = _training_overrides(winning_row)
+        if kind == "screen_winner_transfer":
+            resolution, anchor_row, source_queue, anchor_label = _resolve_screen_winner(
+                queue=queue,
+                policy=policy,
+            )
+            resolution_note = (
+                f"Resolved transfer training overrides `{override_key}` from screen row "
+                f"`{int(resolution['winning_order'])}` in `{source_queue['sweep_id']}` "
+                f"({resolution['reason']})."
+            )
+            shared_anchor_provenance = _shared_anchor_provenance(
+                anchor_row=anchor_row,
+                source_queue=source_queue,
+            )
+            shared_anchor_provenance["anchor_candidate_label"] = str(anchor_label)
+            shared_anchor_provenance["resolution_reason"] = str(resolution["reason"])
+        else:
+            anchor_row, source_queue = _resolve_shared_anchor(
+                queue=queue,
+                policy=policy,
+            )
+            anchor_label = _optional_non_empty_string(
+                policy.get("anchor_label"),
+                context=f"dynamic_training_overrides.{override_key}.anchor_label",
+            ) or f"order_{int(anchor_row['order']):02d}"
+            resolution = {
+                "winning_order": int(anchor_row["order"]),
+                "reason": "shared_anchor",
+            }
+            resolution_note = (
+                f"Resolved transfer training overrides `{override_key}` from shared anchor row "
+                f"`{int(anchor_row['order'])}` in `{source_queue['sweep_id']}`."
+            )
+            shared_anchor_provenance = _shared_anchor_provenance(
+                anchor_row=anchor_row,
+                source_queue=source_queue,
+            )
+            shared_anchor_provenance["anchor_candidate_label"] = str(anchor_label)
+
+        runtime, optimizer, schedule_stage, task_batch_size = _training_overrides(anchor_row)
         base_grad_accum_steps = _optional_positive_int(
             runtime.get("grad_accum_steps"),
-            context=f"row {int(winning_row['order'])} runtime.grad_accum_steps",
+            context=f"row {int(anchor_row['order'])} runtime.grad_accum_steps",
         )
         base_max_steps = _optional_positive_int(
             runtime.get("max_steps"),
-            context=f"row {int(winning_row['order'])} runtime.max_steps",
+            context=f"row {int(anchor_row['order'])} runtime.max_steps",
         )
         if base_grad_accum_steps is None or base_max_steps is None:
             raise RuntimeError(
-                f"screen winner row {int(winning_row['order'])} omitted grad_accum_steps or max_steps"
+                f"anchor row {int(anchor_row['order'])} omitted grad_accum_steps or max_steps"
             )
         base_effective_batch = int(task_batch_size * base_grad_accum_steps)
         base_effective_budget = int(base_max_steps * base_effective_batch)
@@ -453,19 +550,15 @@ def resolve_dynamic_training_overrides(
                 **resolved_schedule,
                 "resolved_from_order": int(resolution["winning_order"]),
                 "resolved_from_sweep_id": str(source_queue["sweep_id"]),
-                "resolved_candidate_label": str(winning_value),
+                "resolved_candidate_label": str(anchor_label),
                 "resolution_reason": str(resolution["reason"]),
+                "shared_anchor_provenance": dict(shared_anchor_provenance),
             }
 
         policy["resolved_from_order"] = int(resolution["winning_order"])
         policy["resolved_from_sweep_id"] = str(source_queue["sweep_id"])
-        policy["resolved_candidate_label"] = str(winning_value)
+        policy["resolved_candidate_label"] = str(anchor_label)
         policy["resolution_reason"] = str(resolution["reason"])
-        resolution_note = (
-            f"Resolved transfer training overrides `{override_key}` from screen row "
-            f"`{int(resolution['winning_order'])}` in `{source_queue['sweep_id']}` "
-            f"({resolution['reason']})."
-        )
         queue_row["notes"] = append_note(queue_notes, resolution_note)
         materialized_row["notes"] = append_note(materialized_notes, resolution_note)
 

--- a/src/tab_foundry/research/sweep/row_execution.py
+++ b/src/tab_foundry/research/sweep/row_execution.py
@@ -252,6 +252,16 @@ def run_row(
         queue_row=queue_row,
         materialized_row=materialized_row,
     )
+    _row_dependencies.resolve_dynamic_training_overrides(
+        queue=queue,
+        queue_row=queue_row,
+        materialized_row=materialized_row,
+    )
+    _row_dependencies.resolve_dynamic_reuse_train_artifact(
+        queue=queue,
+        queue_row=queue_row,
+        materialized_row=materialized_row,
+    )
     resolved_sweep_meta = sweep if sweep is not None else sweep_meta
     sweep_semantics = resolve_sweep_semantics(resolved_sweep_meta)
     training_surface = sweep_semantics.training_surface

--- a/src/tab_foundry/research/sweep/summarize.py
+++ b/src/tab_foundry/research/sweep/summarize.py
@@ -408,6 +408,21 @@ def render_sweep_summary_table(payload: Mapping[str, Any]) -> str:
             )
             if rendered_leaderboard:
                 lines.append(f"- regime leaderboard: {rendered_leaderboard}")
+        kept_regime = transfer_summary.get("kept_regime")
+        if isinstance(kept_regime, Mapping):
+            lines.append(
+                "- kept regime (T2 then T1): "
+                f"{kept_regime['regime_label']} "
+                f"(T2 order {int(kept_regime['t2_order']):02d}, "
+                f"log_loss={float(kept_regime['t2_log_loss']):.6f})"
+            )
+        t2_vs_highbatch = transfer_summary.get("t2_vs_carried_highbatch")
+        if isinstance(t2_vs_highbatch, Mapping):
+            lines.append(
+                "- T2 vs carried high-batch: "
+                f"{t2_vs_highbatch['winning_regime_label']} "
+                f"delta_log_loss={float(t2_vs_highbatch['delta_log_loss']):+.6f}"
+            )
         if isinstance(imported_orders, list) and imported_orders:
             lines.append(
                 "- imported baseline orders: "

--- a/src/tab_foundry/research/sweep/summarize.py
+++ b/src/tab_foundry/research/sweep/summarize.py
@@ -11,6 +11,7 @@ from .objective_metrics import (
     objective_metric_from_queue_metrics,
 )
 from .pareto import annotate_rows_with_pareto
+from .transfer import annotate_rows_with_transfer_context
 
 
 _WARN_CLIPPED_STEP_FRACTION = 0.05
@@ -131,6 +132,21 @@ def build_sweep_summary_payload(
                 "stability": _stability_verdict(row, metrics),
                 "objective_metric": objective_metric,
                 "model": None if not isinstance(row.get("model"), Mapping) else dict(cast(Mapping[str, Any], row["model"])),
+                "transfer_context": (
+                    dict(cast(Mapping[str, Any], row["transfer_context"]))
+                    if isinstance(row.get("transfer_context"), Mapping)
+                    else None
+                ),
+                "transfer_resolution": (
+                    dict(cast(Mapping[str, Any], row["transfer_resolution"]))
+                    if isinstance(row.get("transfer_resolution"), Mapping)
+                    else None
+                ),
+                "imported_baseline_provenance": (
+                    dict(cast(Mapping[str, Any], row["imported_baseline_provenance"]))
+                    if isinstance(row.get("imported_baseline_provenance"), Mapping)
+                    else None
+                ),
                 "final_roc_auc": _optional_float(metrics.get("final_roc_auc")),
                 "delta_final_roc_auc": _optional_float(metrics.get("delta_final_roc_auc")),
                 "final_bpc": _optional_float(metrics.get("final_bpc")),
@@ -190,6 +206,10 @@ def build_sweep_summary_payload(
         rows=rows_payload,
         surface_role=(str(queue.get("surface_role")) if queue.get("surface_role") is not None else None),
     )
+    transfer_summary = annotate_rows_with_transfer_context(
+        rows=rows_payload,
+        surface_role=(str(queue.get("surface_role")) if queue.get("surface_role") is not None else None),
+    )
     return {
         "sweep_id": str(queue["sweep_id"]),
         "row_count": len(rows_payload),
@@ -197,6 +217,7 @@ def build_sweep_summary_payload(
         "surface_role": str(queue.get("surface_role") or ""),
         "rows": rows_payload,
         "selector_summary": selector_summary,
+        "transfer_summary": transfer_summary,
     }
 
 
@@ -346,4 +367,50 @@ def render_sweep_summary_table(payload: Mapping[str, Any]) -> str:
                         if isinstance(geometry_row, Mapping)
                     )
                 )
+    transfer_summary = payload.get("transfer_summary")
+    if isinstance(transfer_summary, Mapping):
+        best_row = transfer_summary.get("best_row")
+        fastest_row = transfer_summary.get("fastest_row")
+        leaderboard = transfer_summary.get("regime_leaderboard")
+        imported_orders = transfer_summary.get("imported_baseline_orders")
+        if best_row or fastest_row or leaderboard or imported_orders:
+            lines.extend(["", "Transfer summary:"])
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "- best transfer row: "
+                f"order {int(best_row['order']):02d}, "
+                f"regime={best_row.get('regime_label') or 'n/a'}, "
+                f"log_loss={float(best_row['final_log_loss']):.6f}, "
+                f"budget={best_row.get('target_budget_label') or 'n/a'}"
+            )
+        if isinstance(fastest_row, Mapping):
+            lines.append(
+                "- fastest transfer row: "
+                f"order {int(fastest_row['order']):02d}, "
+                f"regime={fastest_row.get('regime_label') or 'n/a'}, "
+                f"wall={float(fastest_row['end_to_end_wall_seconds']):.1f}s, "
+                f"log_loss={float(fastest_row['final_log_loss']):.6f}"
+            )
+        if isinstance(leaderboard, list) and leaderboard:
+            rendered_leaderboard = ", ".join(
+                (
+                    f"{str(cast(Mapping[str, Any], item)['regime_label'])} "
+                    f"(mean_log_loss={float(cast(Mapping[str, Any], item)['mean_benchmark_log_loss']):.6f}"
+                    + (
+                        ""
+                        if cast(Mapping[str, Any], item).get("mean_end_to_end_wall_seconds") is None
+                        else f", mean_wall={float(cast(Mapping[str, Any], item)['mean_end_to_end_wall_seconds']):.1f}s"
+                    )
+                    + ")"
+                )
+                for item in leaderboard
+                if isinstance(item, Mapping)
+            )
+            if rendered_leaderboard:
+                lines.append(f"- regime leaderboard: {rendered_leaderboard}")
+        if isinstance(imported_orders, list) and imported_orders:
+            lines.append(
+                "- imported baseline orders: "
+                + ", ".join(f"{int(value):02d}" for value in imported_orders)
+            )
     return "\n".join(lines)

--- a/src/tab_foundry/research/sweep/summarize.py
+++ b/src/tab_foundry/research/sweep/summarize.py
@@ -10,6 +10,7 @@ from .objective_metrics import (
     is_classification_objective_metric,
     objective_metric_from_queue_metrics,
 )
+from .pareto import annotate_rows_with_pareto
 
 
 _WARN_CLIPPED_STEP_FRACTION = 0.05
@@ -108,20 +109,11 @@ def _regime_budget_excerpt(metrics: Mapping[str, Any]) -> dict[str, Any] | None:
     return payload if any(value is not None for value in payload.values()) else None
 
 
-def summarize_sweep(
+def build_sweep_summary_payload(
     *,
-    sweep_id: str | None = None,
+    queue: Mapping[str, Any],
     include_screened: bool = False,
-    index_path: Path | None = None,
-    catalog_path: Path | None = None,
-    sweeps_root: Path | None = None,
 ) -> dict[str, Any]:
-    queue = load_system_delta_queue_for_inspection(
-        sweep_id=sweep_id,
-        index_path=index_path,
-        catalog_path=catalog_path,
-        sweeps_root=sweeps_root,
-    )
     rows_payload: list[dict[str, Any]] = []
     for row in ordered_rows(queue):
         status = str(row.get("status", "")).strip().lower()
@@ -138,6 +130,7 @@ def summarize_sweep(
                 "run_id": None if row.get("run_id") is None else str(row["run_id"]),
                 "stability": _stability_verdict(row, metrics),
                 "objective_metric": objective_metric,
+                "model": None if not isinstance(row.get("model"), Mapping) else dict(cast(Mapping[str, Any], row["model"])),
                 "final_roc_auc": _optional_float(metrics.get("final_roc_auc")),
                 "delta_final_roc_auc": _optional_float(metrics.get("delta_final_roc_auc")),
                 "final_bpc": _optional_float(metrics.get("final_bpc")),
@@ -193,12 +186,35 @@ def summarize_sweep(
                 "regime_budget": _regime_budget_excerpt(metrics),
             }
         )
+    selector_summary = annotate_rows_with_pareto(
+        rows=rows_payload,
+        surface_role=(str(queue.get("surface_role")) if queue.get("surface_role") is not None else None),
+    )
     return {
         "sweep_id": str(queue["sweep_id"]),
         "row_count": len(rows_payload),
         "include_screened": bool(include_screened),
+        "surface_role": str(queue.get("surface_role") or ""),
         "rows": rows_payload,
+        "selector_summary": selector_summary,
     }
+
+
+def summarize_sweep(
+    *,
+    sweep_id: str | None = None,
+    include_screened: bool = False,
+    index_path: Path | None = None,
+    catalog_path: Path | None = None,
+    sweeps_root: Path | None = None,
+) -> dict[str, Any]:
+    queue = load_system_delta_queue_for_inspection(
+        sweep_id=sweep_id,
+        index_path=index_path,
+        catalog_path=catalog_path,
+        sweeps_root=sweeps_root,
+    )
+    return build_sweep_summary_payload(queue=queue, include_screened=include_screened)
 
 
 def _format_float(value: float | None, *, signed: bool = False) -> str:
@@ -229,6 +245,7 @@ def render_sweep_summary_table(payload: Mapping[str, Any]) -> str:
         "status",
         "decision",
         "stability",
+        "pareto",
         "d_primary",
         "d_roc_auc",
         "tok/s",
@@ -255,6 +272,11 @@ def render_sweep_summary_table(payload: Mapping[str, Any]) -> str:
                 str(row["status"]),
                 str(row["decision"] or "n/a"),
                 str(row["stability"]),
+                (
+                    "Y"
+                    if row.get("pareto_admissible") is True
+                    else ("N" if row.get("pareto_admissible") is False else "n/a")
+                ),
                 _format_float(primary_delta, signed=True),
                 _format_float(cast(float | None, row["delta_final_roc_auc"]), signed=True),
                 _format_float(cast(float | None, row.get("throughput_tokens_per_second"))),
@@ -278,4 +300,50 @@ def render_sweep_summary_table(payload: Mapping[str, Any]) -> str:
         lines.append(
             "  ".join(value.ljust(widths[index]) for index, value in enumerate(rendered_row))
         )
+    selector_summary = payload.get("selector_summary")
+    if isinstance(selector_summary, Mapping):
+        global_frontier_orders = selector_summary.get("global_frontier_orders")
+        if isinstance(global_frontier_orders, list) and global_frontier_orders:
+            lines.extend(
+                [
+                    "",
+                    "Pareto frontier:",
+                    "- global quality/time admissible rows: "
+                    + ", ".join(f"{int(value):02d}" for value in global_frontier_orders),
+                ]
+            )
+        best_row = selector_summary.get("best_row")
+        if isinstance(best_row, Mapping):
+            lines.append(
+                "- best row: "
+                f"order {int(best_row['order']):02d}, "
+                f"geometry={best_row.get('geometry_label') or 'n/a'}, "
+                f"prescription={best_row.get('prescription_label') or 'n/a'}, "
+                f"log_loss={float(best_row['final_log_loss']):.6f}, "
+                f"wall={float(best_row['end_to_end_wall_seconds']):.1f}s"
+            )
+        kept_contract = selector_summary.get("kept_contract")
+        if isinstance(kept_contract, Mapping):
+            lines.append(
+                "- kept contract: "
+                f"{kept_contract['prescription_label']} "
+                f"(frontier_geometries={int(kept_contract['geometry_count'])}, "
+                f"mean_wall={float(kept_contract['mean_end_to_end_wall_seconds']):.1f}s, "
+                f"mean_log_loss={float(kept_contract['mean_benchmark_log_loss']):.6f})"
+            )
+        elif selector_summary.get("no_universal_kept_contract") is True:
+            lines.append("- kept contract: none (no prescription reached majority frontier coverage)")
+        per_geometry_frontiers = selector_summary.get("per_geometry_frontiers")
+        if isinstance(per_geometry_frontiers, Mapping) and per_geometry_frontiers:
+            for geometry_label, geometry_rows in sorted(per_geometry_frontiers.items()):
+                if not isinstance(geometry_rows, list) or not geometry_rows:
+                    continue
+                lines.append(
+                    f"- {geometry_label} frontier: "
+                    + ", ".join(
+                        f"{cast(Mapping[str, Any], geometry_row).get('prescription_label')}@{int(cast(Mapping[str, Any], geometry_row)['order']):02d}"
+                        for geometry_row in geometry_rows
+                        if isinstance(geometry_row, Mapping)
+                    )
+                )
     return "\n".join(lines)

--- a/src/tab_foundry/research/sweep/transfer.py
+++ b/src/tab_foundry/research/sweep/transfer.py
@@ -1,0 +1,347 @@
+"""Faithful training-dynamics transfer helpers for sweep execution and reporting."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, cast
+
+
+TRANSFER_SCREEN_SURFACE_ROLE = "classification_training_dynamics_transfer_screen"
+TRANSFER_SURFACE_ROLE = "classification_training_dynamics_transfer"
+TRANSFER_REGIME_B = "B"
+TRANSFER_REGIME_D = "D"
+SUPPORTED_TRANSFER_REGIMES = frozenset({TRANSFER_REGIME_B, TRANSFER_REGIME_D})
+DEFAULT_TRANSFER_MIN_LR_RATIO = 1.0e-3
+DEFAULT_MAX_TRANSFER_DRIFT = 0.02
+DEFAULT_FIXED_BATCH_REGIME_B = 64
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _optional_string(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return str(value).strip()
+
+
+def is_transfer_surface_role(surface_role: str | None) -> bool:
+    return str(surface_role or "").strip() in {
+        TRANSFER_SCREEN_SURFACE_ROLE,
+        TRANSFER_SURFACE_ROLE,
+    }
+
+
+def round_half_up(value: float) -> int:
+    if not math.isfinite(value):
+        raise RuntimeError(f"round_half_up requires a finite value, got {value!r}")
+    if value < 0:
+        raise RuntimeError(f"round_half_up requires a non-negative value, got {value!r}")
+    return int(math.floor(value + 0.5))
+
+
+def nearest_realizable_effective_batch(
+    *,
+    target_effective_batch: float,
+    task_batch_size: int,
+) -> int:
+    if task_batch_size <= 0:
+        raise RuntimeError(f"task_batch_size must be > 0, got {task_batch_size}")
+    if not math.isfinite(target_effective_batch) or target_effective_batch <= 0.0:
+        raise RuntimeError(
+            "target_effective_batch must be a finite positive float, "
+            f"got {target_effective_batch!r}"
+        )
+    grad_accum_steps = max(1, round_half_up(float(target_effective_batch) / float(task_batch_size)))
+    return int(task_batch_size * grad_accum_steps)
+
+
+def resolve_transfer_schedule(
+    *,
+    regime_label: str,
+    base_lr_max: float,
+    base_momentum: float,
+    base_effective_batch: int,
+    base_effective_budget: int,
+    target_effective_budget: int,
+    task_batch_size: int,
+    fixed_effective_batch: int | None = None,
+    min_lr_ratio: float = DEFAULT_TRANSFER_MIN_LR_RATIO,
+    max_budget_drift: float = DEFAULT_MAX_TRANSFER_DRIFT,
+) -> dict[str, Any]:
+    normalized_regime = str(regime_label).strip().upper()
+    if normalized_regime not in SUPPORTED_TRANSFER_REGIMES:
+        raise RuntimeError(
+            f"unsupported transfer regime {regime_label!r}; expected one of {sorted(SUPPORTED_TRANSFER_REGIMES)}"
+        )
+    if base_effective_budget <= 0 or target_effective_budget <= 0:
+        raise RuntimeError(
+            "effective budgets must be positive ints; "
+            f"got base={base_effective_budget}, target={target_effective_budget}"
+        )
+    if base_effective_batch <= 0:
+        raise RuntimeError(f"base_effective_batch must be > 0, got {base_effective_batch}")
+    if not (0.0 < float(base_momentum) < 1.0):
+        raise RuntimeError(f"base_momentum must lie in (0, 1), got {base_momentum}")
+    if float(base_lr_max) <= 0.0:
+        raise RuntimeError(f"base_lr_max must be > 0, got {base_lr_max}")
+    if float(min_lr_ratio) <= 0.0:
+        raise RuntimeError(f"min_lr_ratio must be > 0, got {min_lr_ratio}")
+
+    ratio = float(target_effective_budget) / float(base_effective_budget)
+    alpha0 = 1.0 - float(base_momentum)
+    if normalized_regime == TRANSFER_REGIME_B:
+        target_alpha = alpha0 * (ratio ** -0.5)
+        target_lr_max = float(base_lr_max) * (ratio ** -0.75)
+        target_effective_batch = float(
+            DEFAULT_FIXED_BATCH_REGIME_B if fixed_effective_batch is None else fixed_effective_batch
+        )
+        formula_label = "Theorem 2 fixed-batch transfer"
+    else:
+        target_alpha = alpha0 * (ratio ** (-1.0 / 3.0))
+        target_lr_max = float(base_lr_max) * (ratio ** (-7.0 / 12.0))
+        target_effective_batch = float(base_effective_batch) * (ratio ** (1.0 / 6.0))
+        formula_label = "Theorem 3 joint-transfer proxy"
+
+    if not (0.0 < target_alpha < 1.0):
+        raise RuntimeError(
+            f"derived alpha must lie in (0, 1), got alpha={target_alpha} for regime {normalized_regime}"
+        )
+    target_momentum = 1.0 - target_alpha
+    if not (0.0 < target_momentum < 1.0):
+        raise RuntimeError(
+            "derived momentum must lie in (0, 1), "
+            f"got momentum={target_momentum} for regime {normalized_regime}"
+        )
+    realized_effective_batch = nearest_realizable_effective_batch(
+        target_effective_batch=target_effective_batch,
+        task_batch_size=int(task_batch_size),
+    )
+    grad_accum_steps = int(realized_effective_batch // int(task_batch_size))
+    max_steps = round_half_up(float(target_effective_budget) / float(realized_effective_batch))
+    realized_effective_budget = int(max_steps * realized_effective_batch)
+    budget_drift = float(realized_effective_budget) / float(target_effective_budget) - 1.0
+    batch_drift = float(realized_effective_batch) / float(target_effective_batch) - 1.0
+    if abs(budget_drift) > float(max_budget_drift):
+        raise RuntimeError(
+            "derived transfer row exceeded the allowed effective-budget drift: "
+            f"target={target_effective_budget}, realized={realized_effective_budget}, "
+            f"drift={budget_drift:+.6f}, limit={max_budget_drift:.6f}"
+        )
+
+    return {
+        "regime_label": normalized_regime,
+        "formula_label": formula_label,
+        "base_effective_budget": int(base_effective_budget),
+        "target_effective_budget": int(target_effective_budget),
+        "realized_effective_budget": int(realized_effective_budget),
+        "base_effective_batch": int(base_effective_batch),
+        "target_effective_batch": float(target_effective_batch),
+        "realized_effective_batch": int(realized_effective_batch),
+        "base_lr_max": float(base_lr_max),
+        "target_lr_max": float(target_lr_max),
+        "base_momentum": float(base_momentum),
+        "target_momentum": float(target_momentum),
+        "base_alpha": float(alpha0),
+        "target_alpha": float(target_alpha),
+        "grad_accum_steps": int(grad_accum_steps),
+        "max_steps": int(max_steps),
+        "min_lr": float(target_lr_max) * float(min_lr_ratio),
+        "budget_drift": float(budget_drift),
+        "batch_drift": float(batch_drift),
+    }
+
+
+def row_transfer_context(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {}
+    for key in ("transfer_context", "transfer_resolution"):
+        raw_payload = row.get(key)
+        if isinstance(raw_payload, Mapping):
+            payload.update(dict(cast(Mapping[str, Any], raw_payload)))
+    return payload or None
+
+
+def imported_baseline_provenance(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    raw_payload = row.get("imported_baseline_provenance")
+    if not isinstance(raw_payload, Mapping):
+        return None
+    return dict(cast(Mapping[str, Any], raw_payload))
+
+
+def annotate_rows_with_transfer_context(
+    *,
+    rows: list[dict[str, Any]],
+    surface_role: str | None = None,
+) -> dict[str, Any] | None:
+    if not is_transfer_surface_role(surface_role):
+        return None
+
+    for row in rows:
+        context = row_transfer_context(row)
+        provenance = imported_baseline_provenance(row)
+        row["transfer_regime_label"] = None if context is None else _optional_string(context.get("regime_label"))
+        row["transfer_phase"] = None if context is None else _optional_string(context.get("phase"))
+        row["transfer_formula_label"] = None if context is None else _optional_string(context.get("formula_label"))
+        row["transfer_base_budget_label"] = None if context is None else _optional_string(
+            context.get("base_budget_label")
+        )
+        row["transfer_target_budget_label"] = None if context is None else _optional_string(
+            context.get("target_budget_label")
+        )
+        row["transfer_candidate_label"] = None if context is None else _optional_string(
+            context.get("candidate_label")
+        )
+        row["target_effective_batch"] = None if context is None else _optional_float(
+            context.get("target_effective_batch")
+        )
+        row["realized_effective_batch"] = None if context is None else _optional_int(
+            context.get("realized_effective_batch")
+        )
+        row["target_effective_budget"] = None if context is None else _optional_int(
+            context.get("target_effective_budget")
+        )
+        row["realized_effective_budget"] = None if context is None else _optional_int(
+            context.get("realized_effective_budget")
+        )
+        row["budget_drift"] = None if context is None else _optional_float(context.get("budget_drift"))
+        row["batch_drift"] = None if context is None else _optional_float(context.get("batch_drift"))
+        row["imported_baseline_provenance"] = provenance
+
+    eligible_rows = [
+        row
+        for row in rows
+        if row.get("transfer_regime_label") is not None and _optional_float(row.get("final_log_loss")) is not None
+    ]
+    if not eligible_rows:
+        return {
+            "eligible_row_count": 0,
+            "best_row": None,
+            "fastest_row": None,
+            "regime_leaderboard": [],
+            "imported_baseline_orders": sorted(
+                int(row["order"])
+                for row in rows
+                if imported_baseline_provenance(row) is not None
+            ),
+        }
+
+    best_row = min(
+        eligible_rows,
+        key=lambda row: (
+            float(row["final_log_loss"]),
+            float(row["end_to_end_wall_seconds"])
+            if row.get("end_to_end_wall_seconds") is not None
+            else math.inf,
+            int(row["order"]),
+        ),
+    )
+    fastest_candidates = [
+        row for row in eligible_rows if _optional_float(row.get("end_to_end_wall_seconds")) is not None
+    ]
+    fastest_row = (
+        None
+        if not fastest_candidates
+        else min(
+            fastest_candidates,
+            key=lambda row: (
+                float(row["end_to_end_wall_seconds"]),
+                float(row["final_log_loss"]),
+                int(row["order"]),
+            ),
+        )
+    )
+    regimes: dict[str, list[Mapping[str, Any]]] = {}
+    for row in eligible_rows:
+        regime_label = str(row["transfer_regime_label"])
+        regimes.setdefault(regime_label, []).append(row)
+    regime_leaderboard: list[dict[str, Any]] = []
+    for regime_label, regime_rows in regimes.items():
+        benchmark_rows = [
+            row
+            for row in regime_rows
+            if str(row.get("status", "")).strip().lower() == "completed"
+        ]
+        if not benchmark_rows:
+            continue
+        best_regime_row = min(
+            benchmark_rows,
+            key=lambda row: (
+                float(row["final_log_loss"]),
+                float(row["end_to_end_wall_seconds"])
+                if row.get("end_to_end_wall_seconds") is not None
+                else math.inf,
+                int(row["order"]),
+            ),
+        )
+        mean_log_loss = sum(float(row["final_log_loss"]) for row in benchmark_rows) / float(
+            len(benchmark_rows)
+        )
+        mean_wall = (
+            sum(
+                float(row["end_to_end_wall_seconds"])
+                for row in benchmark_rows
+                if row.get("end_to_end_wall_seconds") is not None
+            )
+            / float(
+                sum(1 for row in benchmark_rows if row.get("end_to_end_wall_seconds") is not None)
+            )
+            if any(row.get("end_to_end_wall_seconds") is not None for row in benchmark_rows)
+            else None
+        )
+        regime_leaderboard.append(
+            {
+                "regime_label": regime_label,
+                "row_count": len(benchmark_rows),
+                "orders": sorted(int(row["order"]) for row in benchmark_rows),
+                "best_row_order": int(best_regime_row["order"]),
+                "best_log_loss": float(best_regime_row["final_log_loss"]),
+                "mean_benchmark_log_loss": float(mean_log_loss),
+                "mean_end_to_end_wall_seconds": None if mean_wall is None else float(mean_wall),
+                "imported_baseline": all(imported_baseline_provenance(row) is not None for row in benchmark_rows),
+            }
+        )
+    regime_leaderboard.sort(
+        key=lambda payload: (
+            float(payload["mean_benchmark_log_loss"]),
+            math.inf
+            if payload["mean_end_to_end_wall_seconds"] is None
+            else float(payload["mean_end_to_end_wall_seconds"]),
+            str(payload["regime_label"]),
+        )
+    )
+    return {
+        "eligible_row_count": len(eligible_rows),
+        "best_row": {
+            "order": int(best_row["order"]),
+            "regime_label": str(best_row["transfer_regime_label"]),
+            "final_log_loss": float(best_row["final_log_loss"]),
+            "end_to_end_wall_seconds": _optional_float(best_row.get("end_to_end_wall_seconds")),
+            "target_budget_label": _optional_string(best_row.get("transfer_target_budget_label")),
+        },
+        "fastest_row": (
+            None
+            if fastest_row is None
+            else {
+                "order": int(fastest_row["order"]),
+                "regime_label": str(fastest_row["transfer_regime_label"]),
+                "final_log_loss": float(fastest_row["final_log_loss"]),
+                "end_to_end_wall_seconds": float(fastest_row["end_to_end_wall_seconds"]),
+                "target_budget_label": _optional_string(fastest_row.get("transfer_target_budget_label")),
+            }
+        ),
+        "regime_leaderboard": regime_leaderboard,
+        "imported_baseline_orders": sorted(
+            int(row["order"])
+            for row in rows
+            if imported_baseline_provenance(row) is not None
+        ),
+    }

--- a/src/tab_foundry/research/sweep/transfer.py
+++ b/src/tab_foundry/research/sweep/transfer.py
@@ -177,6 +177,16 @@ def imported_baseline_provenance(row: Mapping[str, Any]) -> dict[str, Any] | Non
     return dict(cast(Mapping[str, Any], raw_payload))
 
 
+def _shared_anchor_provenance(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    context = row_transfer_context(row)
+    if not isinstance(context, Mapping):
+        return None
+    raw_payload = context.get("shared_anchor_provenance")
+    if not isinstance(raw_payload, Mapping):
+        return None
+    return dict(cast(Mapping[str, Any], raw_payload))
+
+
 def annotate_rows_with_transfer_context(
     *,
     rows: list[dict[str, Any]],
@@ -215,6 +225,7 @@ def annotate_rows_with_transfer_context(
         row["budget_drift"] = None if context is None else _optional_float(context.get("budget_drift"))
         row["batch_drift"] = None if context is None else _optional_float(context.get("batch_drift"))
         row["imported_baseline_provenance"] = provenance
+        row["shared_anchor_provenance"] = _shared_anchor_provenance(row)
 
     eligible_rows = [
         row
@@ -318,6 +329,102 @@ def annotate_rows_with_transfer_context(
             str(payload["regime_label"]),
         )
     )
+    completed_rows = [
+        row
+        for row in eligible_rows
+        if str(row.get("status", "")).strip().lower() == "completed"
+    ]
+
+    def _best_completed_row(regime_label: str, budget_label: str) -> Mapping[str, Any] | None:
+        budget_rows = [
+            row
+            for row in completed_rows
+            if str(row.get("transfer_regime_label")) == regime_label
+            and str(row.get("transfer_target_budget_label")) == budget_label
+        ]
+        if not budget_rows:
+            return None
+        return min(
+            budget_rows,
+            key=lambda row: (
+                float(row["final_log_loss"]),
+                float(row["end_to_end_wall_seconds"])
+                if row.get("end_to_end_wall_seconds") is not None
+                else math.inf,
+                int(row["order"]),
+            ),
+        )
+
+    kept_regime: dict[str, Any] | None = None
+    regime_budget_comparison: list[dict[str, Any]] = []
+    t2_vs_carried_highbatch: dict[str, Any] | None = None
+    regime_b_t2 = _best_completed_row(TRANSFER_REGIME_B, "T2")
+    regime_d_t2 = _best_completed_row(TRANSFER_REGIME_D, "T2")
+    if regime_b_t2 is not None and regime_d_t2 is not None:
+        regime_b_t1 = _best_completed_row(TRANSFER_REGIME_B, "T1")
+        regime_d_t1 = _best_completed_row(TRANSFER_REGIME_D, "T1")
+        for regime_label, t1_row, t2_row in (
+            (TRANSFER_REGIME_B, regime_b_t1, regime_b_t2),
+            (TRANSFER_REGIME_D, regime_d_t1, regime_d_t2),
+        ):
+            regime_budget_comparison.append(
+                {
+                    "regime_label": regime_label,
+                    "t1_order": None if t1_row is None else int(t1_row["order"]),
+                    "t1_log_loss": None if t1_row is None else float(t1_row["final_log_loss"]),
+                    "t2_order": int(t2_row["order"]),
+                    "t2_log_loss": float(t2_row["final_log_loss"]),
+                }
+            )
+        winning_t1 = regime_b_t1
+        winning_t2 = regime_b_t2
+        winning_regime = TRANSFER_REGIME_B
+        losing_t1 = regime_d_t1
+        losing_t2 = regime_d_t2
+        if (
+            float(regime_d_t2["final_log_loss"]),
+            math.inf if regime_d_t1 is None else float(regime_d_t1["final_log_loss"]),
+            float(regime_d_t2["end_to_end_wall_seconds"])
+            if regime_d_t2.get("end_to_end_wall_seconds") is not None
+            else math.inf,
+            TRANSFER_REGIME_D,
+        ) < (
+            float(regime_b_t2["final_log_loss"]),
+            math.inf if regime_b_t1 is None else float(regime_b_t1["final_log_loss"]),
+            float(regime_b_t2["end_to_end_wall_seconds"])
+            if regime_b_t2.get("end_to_end_wall_seconds") is not None
+            else math.inf,
+            TRANSFER_REGIME_B,
+        ):
+            winning_t1 = regime_d_t1
+            winning_t2 = regime_d_t2
+            winning_regime = TRANSFER_REGIME_D
+            losing_t1 = regime_b_t1
+            losing_t2 = regime_b_t2
+        kept_regime = {
+            "winner_rule": "T2_then_T1",
+            "regime_label": winning_regime,
+            "t1_order": None if winning_t1 is None else int(winning_t1["order"]),
+            "t1_log_loss": None if winning_t1 is None else float(winning_t1["final_log_loss"]),
+            "t2_order": int(winning_t2["order"]),
+            "t2_log_loss": float(winning_t2["final_log_loss"]),
+            "runner_up_regime_label": TRANSFER_REGIME_D if winning_regime == TRANSFER_REGIME_B else TRANSFER_REGIME_B,
+            "runner_up_t1_order": None if losing_t1 is None else int(losing_t1["order"]),
+            "runner_up_t1_log_loss": None if losing_t1 is None else float(losing_t1["final_log_loss"]),
+            "runner_up_t2_order": int(losing_t2["order"]),
+            "runner_up_t2_log_loss": float(losing_t2["final_log_loss"]),
+        }
+        carried_highbatch_t2 = _best_completed_row("carry_highbatch", "T2")
+        if carried_highbatch_t2 is not None:
+            t2_vs_carried_highbatch = {
+                "winning_regime_label": winning_regime,
+                "winning_regime_order": int(winning_t2["order"]),
+                "winning_regime_t2_log_loss": float(winning_t2["final_log_loss"]),
+                "carried_highbatch_order": int(carried_highbatch_t2["order"]),
+                "carried_highbatch_t2_log_loss": float(carried_highbatch_t2["final_log_loss"]),
+                "delta_log_loss": float(winning_t2["final_log_loss"])
+                - float(carried_highbatch_t2["final_log_loss"]),
+            }
     return {
         "eligible_row_count": len(eligible_rows),
         "best_row": {
@@ -339,6 +446,9 @@ def annotate_rows_with_transfer_context(
             }
         ),
         "regime_leaderboard": regime_leaderboard,
+        "kept_regime": kept_regime,
+        "regime_budget_comparison": regime_budget_comparison,
+        "t2_vs_carried_highbatch": t2_vs_carried_highbatch,
         "imported_baseline_orders": sorted(
             int(row["order"])
             for row in rows

--- a/src/tab_foundry/training/optimizer.py
+++ b/src/tab_foundry/training/optimizer.py
@@ -345,11 +345,12 @@ def build_optimizer(
                 lr=lr,
                 weight_decay=weight_decay,
             )
+            adamw_tail_extra_kwargs = {k: v for k, v in extra_kwargs.items() if k != "momentum"}
             adamw_tail = torch.optim.AdamW(
                 adamw_tail_groups,
                 lr=lr,
                 weight_decay=weight_decay,
-                **extra_kwargs,
+                **adamw_tail_extra_kwargs,
             )
             optimizers.append(("adamw", adamw_tail))
         resolved = "muon+adamw" if len(optimizers) == 2 else "muon"

--- a/src/tab_foundry/training/optimizer.py
+++ b/src/tab_foundry/training/optimizer.py
@@ -199,6 +199,11 @@ def build_optimizer(
     params = [p for p in model.parameters() if p.requires_grad]
     adamw_params = _build_adamw_param_groups(model, params, lr=lr, weight_decay=weight_decay)
     requested = name.strip().lower()
+    if requested != "muon" and "momentum" in extra_kwargs:
+        raise ValueError(
+            "optimizer.momentum is only supported for the requested optimizer 'muon'; "
+            f"got requested optimizer {requested!r}"
+        )
 
     if requested == "adamw":
         opt = torch.optim.AdamW(adamw_params, lr=lr, weight_decay=weight_decay, **extra_kwargs)
@@ -253,11 +258,12 @@ def build_optimizer(
                     "Requested optimizer 'muon' is unavailable and optimizer.require_requested=true."
                 ) from exc
             fallback_reason = "muon_unavailable"
+            fallback_extra_kwargs = {k: v for k, v in extra_kwargs.items() if k != "momentum"}
             opt = torch.optim.AdamW(
                 adamw_params,
                 lr=lr,
                 weight_decay=weight_decay,
-                **extra_kwargs,
+                **fallback_extra_kwargs,
             )
             return OptimizerSelection(
                 optimizers=[("adamw", opt)],
@@ -274,18 +280,19 @@ def build_optimizer(
         adamw_tail_params: list[nn.Parameter] = []
         if muon_partition_non2d:
             muon_source_params, adamw_tail_params = _partition_muon_params(model, params)
-        if not muon_source_params:
-            fallback_reason = "muon_no_eligible_params"
-            opt = torch.optim.AdamW(
-                adamw_params,
-                lr=lr,
-                weight_decay=weight_decay,
-                **extra_kwargs,
-            )
-            return OptimizerSelection(
-                optimizers=[("adamw", opt)],
-                requested_name=requested,
-                resolved_name="adamw",
+            if not muon_source_params:
+                fallback_reason = "muon_no_eligible_params"
+                fallback_extra_kwargs = {k: v for k, v in extra_kwargs.items() if k != "momentum"}
+                opt = torch.optim.AdamW(
+                    adamw_params,
+                    lr=lr,
+                    weight_decay=weight_decay,
+                    **fallback_extra_kwargs,
+                )
+                return OptimizerSelection(
+                    optimizers=[("adamw", opt)],
+                    requested_name=requested,
+                    resolved_name="adamw",
                 fallback_reason=fallback_reason,
             )
         dist_ready = torch.distributed.is_available() and torch.distributed.is_initialized()
@@ -300,11 +307,12 @@ def build_optimizer(
                         "process group is initialized."
                     )
                 fallback_reason = "muon_single_device_unavailable"
+                fallback_extra_kwargs = {k: v for k, v in extra_kwargs.items() if k != "momentum"}
                 opt = torch.optim.AdamW(
                     adamw_params,
                     lr=lr,
                     weight_decay=weight_decay,
-                    **extra_kwargs,
+                    **fallback_extra_kwargs,
                 )
                 return OptimizerSelection(
                     optimizers=[("adamw", opt)],

--- a/src/tab_foundry/training/prior/config.py
+++ b/src/tab_foundry/training/prior/config.py
@@ -231,6 +231,9 @@ def _optimizer_kwargs(cfg: DictConfig) -> dict[str, object]:
     raw_betas = getattr(cfg.optimizer, "betas", None)
     if raw_betas is not None:
         kwargs["betas"] = tuple(float(value) for value in raw_betas)
+    raw_momentum = getattr(cfg.optimizer, "momentum", None)
+    if raw_momentum is not None:
+        kwargs["momentum"] = float(raw_momentum)
     return kwargs
 
 

--- a/src/tab_foundry/training/trainer.py
+++ b/src/tab_foundry/training/trainer.py
@@ -346,7 +346,14 @@ def train(cfg: DictConfig, *, profiler: Any | None = None) -> TrainResult:
             name=optimizer_requested_name,
             lr=first_stage.lr_max,
             weight_decay=float(cfg.optimizer.weight_decay),
-            extra_kwargs={"betas": tuple(cfg.optimizer.betas)},
+            extra_kwargs={
+                "betas": tuple(cfg.optimizer.betas),
+                **(
+                    {"momentum": float(cfg.optimizer.momentum)}
+                    if getattr(cfg.optimizer, "momentum", None) is not None
+                    else {}
+                ),
+            },
             require_requested=bool(cfg.optimizer.require_requested),
             muon_per_parameter_lr=bool(cfg.optimizer.muon_per_parameter_lr),
             muon_lr_scale_base=float(cfg.optimizer.muon_lr_scale_base),

--- a/src/tab_foundry/training/wandb.py
+++ b/src/tab_foundry/training/wandb.py
@@ -17,6 +17,7 @@ from tab_foundry.hashing import sha256_text
 
 _WANDB_ARTIFACT_NAME_MAXLEN = 128
 _WANDB_ARTIFACT_NAME_HASH_HEX = 12
+_WANDB_ARTIFACT_INIT_TIMEOUT_SECONDS = 300
 
 
 @dataclass(frozen=True, slots=True)
@@ -368,6 +369,9 @@ def publish_checkpoint_artifact(
         init_kwargs["entity"] = normalized_entity
     if normalized_run_name is not None:
         init_kwargs["name"] = normalized_run_name
+    settings_ctor = getattr(wandb, "Settings", None)
+    if callable(settings_ctor):
+        init_kwargs["settings"] = settings_ctor(init_timeout=_WANDB_ARTIFACT_INIT_TIMEOUT_SECONDS)
 
     run = wandb.init(**init_kwargs)
     if run is None:  # pragma: no cover - defensive branch

--- a/src/tab_foundry/training/wandb.py
+++ b/src/tab_foundry/training/wandb.py
@@ -12,6 +12,11 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from omegaconf import DictConfig, OmegaConf
+from tab_foundry.hashing import sha256_text
+
+
+_WANDB_ARTIFACT_NAME_MAXLEN = 128
+_WANDB_ARTIFACT_NAME_HASH_HEX = 12
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,6 +75,19 @@ def _jsonable_mapping(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         return None
     return {str(key): item for key, item in value.items()}
+
+
+def _normalize_artifact_name_for_wandb(name: str) -> str:
+    normalized_name = str(name).strip()
+    if not normalized_name:
+        raise RuntimeError("artifact_name must be a non-empty string for W&B checkpoint publication")
+    if len(normalized_name) <= _WANDB_ARTIFACT_NAME_MAXLEN:
+        return normalized_name
+    hash_suffix = sha256_text(normalized_name)[:_WANDB_ARTIFACT_NAME_HASH_HEX]
+    max_prefix_chars = _WANDB_ARTIFACT_NAME_MAXLEN - 1 - len(hash_suffix)
+    if max_prefix_chars <= 0:  # pragma: no cover - defensive guard
+        raise RuntimeError("W&B artifact name budget is too small to encode a checkpoint artifact")
+    return f"{normalized_name[:max_prefix_chars]}-{hash_suffix}"
 
 
 def _wandb_public_path_parts(run: Any | None) -> tuple[str | None, str | None, str | None]:
@@ -327,13 +345,11 @@ def publish_checkpoint_artifact(
         raise RuntimeError(f"checkpoint path does not exist: {resolved_checkpoint}")
     normalized_project = str(project).strip()
     normalized_run_id = str(run_id).strip()
-    normalized_artifact_name = str(artifact_name).strip()
+    normalized_artifact_name = _normalize_artifact_name_for_wandb(artifact_name)
     if not normalized_project:
         raise RuntimeError("project must be a non-empty string for W&B checkpoint publication")
     if not normalized_run_id:
         raise RuntimeError("run_id must be a non-empty string for W&B checkpoint publication")
-    if not normalized_artifact_name:
-        raise RuntimeError("artifact_name must be a non-empty string for W&B checkpoint publication")
     normalized_entity = None if entity is None else str(entity).strip() or None
     normalized_run_name = None if run_name is None else str(run_name).strip() or None
     normalized_aliases = [str(value).strip() for value in (aliases or ["best"]) if str(value).strip()]

--- a/tests/benchmark/test_checkpoint_artifacts.py
+++ b/tests/benchmark/test_checkpoint_artifacts.py
@@ -84,6 +84,71 @@ def test_publish_checkpoint_artifact_returns_waited_ref(
     assert captured["finished"] is True
 
 
+def test_publish_checkpoint_artifact_shortens_long_artifact_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    checkpoint_path = tmp_path / "best.pt"
+    checkpoint_path.write_bytes(b"checkpoint")
+    captured: dict[str, object] = {}
+
+    class FakeArtifact:
+        def __init__(self, name: str, type: str, metadata=None, **_: object) -> None:
+            captured["artifact_name"] = name
+            captured["artifact_type"] = type
+            captured["artifact_metadata"] = metadata
+
+        def add_file(self, path: str, name: str | None = None) -> None:
+            captured["file"] = (path, name)
+
+    class FakeLoggedArtifact:
+        name = "benchmark-checkpoint-shortened:v1"
+
+        def wait(self, timeout: int | None = None):
+            captured["wait_timeout"] = timeout
+            return self
+
+    class FakeRun:
+        def log_artifact(self, artifact: FakeArtifact, aliases=None):
+            captured["aliases"] = list(aliases or [])
+            captured["logged_artifact"] = artifact
+            return FakeLoggedArtifact()
+
+        def finish(self) -> None:
+            captured["finished"] = True
+
+    class FakeWandb:
+        Artifact = FakeArtifact
+
+        @staticmethod
+        def init(**kwargs):
+            captured["init_kwargs"] = kwargs
+            return FakeRun()
+
+    monkeypatch.setattr(wandb_module, "_require_wandb_sdk", lambda: FakeWandb)
+
+    long_name = (
+        "benchmark-checkpoint-"
+        "sd_tf_rd_009_muon_training_dynamics_endpoint_medium_v1_01_"
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1_v1"
+    )
+    published = wandb_module.publish_checkpoint_artifact(
+        checkpoint_path=checkpoint_path,
+        artifact_name=long_name,
+        entity="bensonlee55-none",
+        project="tab-foundry",
+        run_id="bbmhj6c4",
+        run_name="run_001",
+        metadata={"benchmark_run_id": "run_001"},
+        aliases=["best"],
+    )
+
+    assert len(captured["artifact_name"]) <= 128
+    assert str(captured["artifact_name"]).startswith("benchmark-checkpoint-sd_tf_rd_009_muon_training_dynamics_endpoint_medium_v1_01_")
+    assert str(captured["artifact_name"]).endswith("-2d4132350884")
+    assert published.artifact_name == captured["artifact_name"]
+
+
 def test_artifact_name_for_run_id_keeps_short_names_stable() -> None:
     assert checkpoint_artifacts_module.artifact_name_for_run_id("run_001") == "benchmark-checkpoint-run_001"
 

--- a/tests/benchmark/test_checkpoint_artifacts.py
+++ b/tests/benchmark/test_checkpoint_artifacts.py
@@ -84,6 +84,26 @@ def test_publish_checkpoint_artifact_returns_waited_ref(
     assert captured["finished"] is True
 
 
+def test_artifact_name_for_run_id_keeps_short_names_stable() -> None:
+    assert checkpoint_artifacts_module.artifact_name_for_run_id("run_001") == "benchmark-checkpoint-run_001"
+
+
+def test_artifact_name_for_run_id_shortens_long_names_deterministically() -> None:
+    run_id = (
+        "sd_tf_rd_009_muon_training_dynamics_endpoint_medium_v1_01_"
+        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1_v1"
+    )
+
+    artifact_name = checkpoint_artifacts_module.artifact_name_for_run_id(run_id)
+
+    assert len(artifact_name) <= 128
+    assert artifact_name.startswith(
+        "benchmark-checkpoint-sd_tf_rd_009_muon_training_dynamics_endpoint_medium_v1_01_"
+    )
+    assert artifact_name.endswith("-aee36847774b")
+    assert checkpoint_artifacts_module.artifact_name_for_run_id(run_id) == artifact_name
+
+
 def test_download_checkpoint_artifact_downloads_best_pt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/benchmark/test_checkpoint_artifacts.py
+++ b/tests/benchmark/test_checkpoint_artifacts.py
@@ -51,6 +51,10 @@ def test_publish_checkpoint_artifact_returns_waited_ref(
         Artifact = FakeArtifact
 
         @staticmethod
+        def Settings(**kwargs):
+            return {"kind": "settings", **kwargs}
+
+        @staticmethod
         def init(**kwargs):
             captured["init_kwargs"] = kwargs
             return FakeRun()
@@ -78,6 +82,10 @@ def test_publish_checkpoint_artifact_returns_waited_ref(
         "job_type": "benchmark-checkpoint-publish",
         "mode": "online",
         "name": "run_001",
+        "settings": {
+            "kind": "settings",
+            "init_timeout": 300,
+        },
     }
     assert captured["aliases"] == ["best"]
     assert captured["files"] == [(str(checkpoint_path.resolve()), "best.pt")]
@@ -119,6 +127,10 @@ def test_publish_checkpoint_artifact_shortens_long_artifact_names(
 
     class FakeWandb:
         Artifact = FakeArtifact
+
+        @staticmethod
+        def Settings(**kwargs):
+            return {"kind": "settings", **kwargs}
 
         @staticmethod
         def init(**kwargs):

--- a/tests/benchmark/test_control_baseline.py
+++ b/tests/benchmark/test_control_baseline.py
@@ -8,10 +8,15 @@ import torch
 
 import tab_foundry.bench.control_baseline_freeze as control_baseline_module
 import tab_foundry.control_baseline_registry as read_control_baseline_registry
+from tab_foundry.bench.openml_benchmark import default_anchor_control_baseline_id
 from tab_foundry.data.surface import DataSurfaceConfig
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_control_baseline_default_id_tracks_default_anchor_contract() -> None:
+    assert control_baseline_module.DEFAULT_BASELINE_ID == default_anchor_control_baseline_id()
 
 
 def _write_checkpoint(

--- a/tests/benchmark/test_openml_benchmark_bundle.py
+++ b/tests/benchmark/test_openml_benchmark_bundle.py
@@ -7,16 +7,19 @@ from pathlib import Path
 from tab_foundry.bench.openml_benchmark.bundle import (
     benchmark_bundle_summary,
     canonical_benchmark_bundle_source_path,
+    default_anchor_benchmark_summary,
+    default_anchor_control_baseline_id,
+    validate_default_anchor_benchmark_summary,
 )
 from tests.support.openml_benchmark_compare_cases import (
-    test_default_benchmark_manifest_path_resolves_to_medium_binary_bundle,
-    test_explicit_benchmark_manifest_paths_accept_checked_in_legacy_and_medium_binary_bundles,
+    test_default_benchmark_manifest_path_resolves_to_medium_multiclass_bundle,
+    test_explicit_benchmark_manifest_paths_accept_checked_in_legacy_and_medium_multiclass_bundles,
     test_load_benchmark_bundle_requires_full_selection,
 )
 
 
 def test_benchmark_bundle_summary_persists_repo_relative_source_path() -> None:
-    source_path = Path(__file__).resolve().parents[2] / "src" / "tab_foundry" / "bench" / "openml_binary_medium_v1.json"
+    source_path = Path(__file__).resolve().parents[2] / "src" / "tab_foundry" / "bench" / "openml_classification_medium_v1.json"
     summary = benchmark_bundle_summary(
         {
             "name": "bundle",
@@ -25,25 +28,25 @@ def test_benchmark_bundle_summary_persists_repo_relative_source_path() -> None:
                 "new_instances": 200,
                 "task_type": "supervised_classification",
                 "max_features": 10,
-                "max_classes": 2,
-                "max_missing_pct": 0.0,
-                "min_minority_class_pct": 2.5,
+                "max_classes": 10,
+                "max_missing_pct": 20.0,
+                "min_minority_class_pct": 1.0,
             },
             "task_ids": [1],
         },
         source_path=source_path,
     )
 
-    assert summary["source_path"] == "src/tab_foundry/bench/openml_binary_medium_v1.json"
+    assert summary["source_path"] == "src/tab_foundry/bench/openml_classification_medium_v1.json"
 
 
 def test_canonical_benchmark_bundle_source_path_matches_foreign_checkout_repo_tracked_bundle(
     tmp_path: Path,
 ) -> None:
-    foreign_bundle_path = tmp_path / "foreign_checkout" / "src" / "tab_foundry" / "bench" / "openml_binary_medium_v1.json"
+    foreign_bundle_path = tmp_path / "foreign_checkout" / "src" / "tab_foundry" / "bench" / "openml_classification_medium_v1.json"
 
     assert canonical_benchmark_bundle_source_path(foreign_bundle_path) == (
-        "src/tab_foundry/bench/openml_binary_medium_v1.json"
+        "src/tab_foundry/bench/openml_classification_medium_v1.json"
     )
 
 
@@ -62,3 +65,38 @@ def test_canonical_benchmark_bundle_source_path_uses_known_sibling_relative_form
         sibling_bundle_path,
         repo_root=repo_root,
     ) == "../tab-realdata-hub/src/tab_realdata_hub/bench/openml_classification_medium_v1.json"
+
+
+def test_default_anchor_benchmark_summary_is_medium_multiclass_with_natural_missingness() -> None:
+    summary = default_anchor_benchmark_summary()
+
+    assert summary["name"] == "openml_classification_medium"
+    assert summary["source_path"] == "src/tab_foundry/bench/openml_classification_medium_v1.json"
+    assert summary["task_count"] == 242
+    assert summary["allow_missing_values"] is True
+    assert default_anchor_control_baseline_id() == "cls_benchmark_linear_multiclass_medium_v1"
+
+
+def test_validate_default_anchor_benchmark_summary_rejects_binary_regression() -> None:
+    issues = validate_default_anchor_benchmark_summary(
+        {
+            "name": "openml_binary_medium",
+            "version": 1,
+            "source_path": "src/tab_foundry/bench/openml_binary_medium_v1.json",
+            "task_count": 10,
+            "task_ids": [42, 3638],
+            "selection": {
+                "new_instances": 200,
+                "task_type": "supervised_classification",
+                "max_features": 10,
+                "max_classes": 2,
+                "max_missing_pct": 0.0,
+                "min_minority_class_pct": 2.5,
+            },
+            "allow_missing_values": False,
+            "all_tasks_no_missing": True,
+        }
+    )
+
+    assert issues
+    assert any("openml_classification_medium" in issue for issue in issues)

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -1040,6 +1040,30 @@ def test_bench_env_bootstrap_run_from_args_forwards_tab_realdata_hub_root(
     assert captured["config"].tab_realdata_hub_root == hub_root
 
 
+def test_bench_registry_freeze_baseline_uses_default_anchor_baseline_id_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        control_baseline_freeze_cli_module,
+        "_freeze_baseline_command",
+        capture_handler(captured, {"baseline_id": _str_attr("baseline_id")}),
+    )
+
+    result = CliRunner().invoke(
+        control_baseline_freeze_cli_module.COMMAND,
+        [
+            "--run-dir",
+            "/tmp/run",
+            "--comparison-summary",
+            "/tmp/comparison_summary.json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["baseline_id"] == control_baseline_freeze_library_module.DEFAULT_BASELINE_ID
+
+
 def test_cli_groups_register_expected_commands() -> None:
     assert _command_names(bench_group.GROUP) == [
         "bundle",

--- a/tests/config/test_experiment_resolution.py
+++ b/tests/config/test_experiment_resolution.py
@@ -545,6 +545,7 @@ def test_cls_benchmark_sandwich_classification_evolution_tf_rd_022_policy_v1_res
     assert bool(cfg.optimizer.require_requested) is True
     assert float(cfg.optimizer.weight_decay) == 0.01
     assert list(cfg.optimizer.betas) == [0.9, 0.95]
+    assert float(cfg.optimizer.momentum) == 0.95
     assert str(cfg.runtime.mixed_precision) == "bf16"
     assert float(cfg.runtime.grad_clip) == 0.0
     assert int(cfg.runtime.grad_accum_steps) == 4
@@ -594,6 +595,7 @@ def test_cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v
     assert bool(cfg.optimizer.require_requested) is True
     assert float(cfg.optimizer.weight_decay) == 0.01
     assert list(cfg.optimizer.betas) == [0.9, 0.95]
+    assert float(cfg.optimizer.momentum) == 0.95
     assert float(cfg.optimizer.min_lr) == 1.0e-6
     assert bool(cfg.optimizer.muon_per_parameter_lr) is True
     assert bool(cfg.optimizer.muon_partition_non2d) is True

--- a/tests/research/test_navigation.py
+++ b/tests/research/test_navigation.py
@@ -6,6 +6,33 @@ from types import SimpleNamespace
 import tab_foundry.research.navigation as navigation_module
 
 
+def test_winner_from_rows_includes_imported_baseline_evidence() -> None:
+    winner = navigation_module._winner_from_rows(
+        [
+            {
+                "order": 1,
+                "status": "ready",
+                "delta_id": "imported",
+                "imported_baseline_provenance": {"source_sweep_id": "baseline"},
+                "benchmark_metrics": {"final_log_loss": 0.4, "best_step": 5000},
+                "model": {"d_icl": 144, "sandwich_layers": 4},
+            },
+            {
+                "order": 2,
+                "status": "completed",
+                "delta_id": "executed",
+                "run_id": "run_2",
+                "benchmark_metrics": {"final_log_loss": 0.5, "best_step": 1250},
+                "model": {"d_icl": 144, "sandwich_layers": 4},
+            },
+        ]
+    )
+
+    assert winner is not None
+    assert winner["order"] == 1
+    assert winner["benchmark_log_loss"] == 0.4
+
+
 def test_validate_sweep_contract_reports_missing_default_anchor_manifest(
     monkeypatch,
     tmp_path: Path,
@@ -94,10 +121,23 @@ def test_build_scaling_navigation_payload_marks_default_anchor_only_when_baselin
         output_root_path=lambda: tmp_path / "outputs",
         validation_overlay_resolved_path=lambda: tmp_path / "overlay.json",
     )
+    index_entry = SimpleNamespace(
+        status="draft",
+        parent_sweep_id=None,
+        complexity_level="classification_md",
+        anchor_run_id="anchor_run",
+        benchmark_manifest_path=str(manifest_path),
+        control_baseline_id="cls_benchmark_linear_multiclass_medium_v1",
+    )
 
     monkeypatch.setattr(navigation_module, "default_benchmark_manifest_path", lambda: manifest_path)
     monkeypatch.setattr(navigation_module, "default_anchor_benchmark_summary", lambda: {"name": "bundle"})
     monkeypatch.setattr(navigation_module, "load_system_delta_queue", lambda **_: queue)
+    monkeypatch.setattr(
+        navigation_module,
+        "load_system_delta_index_payload",
+        lambda _index_path=None: SimpleNamespace(sweeps={"test_sweep": index_entry}),
+    )
     monkeypatch.setattr(navigation_module, "validate_sweep_contract", lambda **_: [])
     monkeypatch.setattr(navigation_module, "build_sweep_navigation_payload", lambda **_: {"contract": {"corpus_ref": None}})
     monkeypatch.setattr(navigation_module, "sweep_lineage_entries", lambda **_: [])
@@ -112,3 +152,73 @@ def test_build_scaling_navigation_payload_marks_default_anchor_only_when_baselin
     )
 
     assert payload["contract"]["uses_default_anchor_benchmark"] is True
+
+
+def test_build_scaling_navigation_payload_uses_index_status_for_linked_sweeps(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "data" / "manifests" / "bench" / "openml_classification_medium_v1" / "manifest.parquet"
+    queue = {
+        "sweep_id": "test_sweep",
+        "rows": [
+            {
+                "order": 1,
+                "status": "ready",
+                "delta_id": "imported",
+                "imported_baseline_provenance": {"source_sweep_id": "baseline"},
+                "benchmark_metrics": {"final_log_loss": 0.4, "best_step": 5000},
+                "model": {"d_icl": 144, "sandwich_layers": 4},
+            }
+        ],
+        "benchmark_manifest_path": str(manifest_path),
+        "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+        "anchor_run_id": "anchor_run",
+        "training_experiment": "exp",
+        "training_config_profile": "profile",
+        "upstream_reference": {"name": "paper"},
+    }
+    config = SimpleNamespace(
+        study_id="study",
+        sweeps=[SimpleNamespace(name="lane", family="transfer", sweep_id="test_sweep")],
+        phase1_reference_sweep_id=None,
+        geometry_row_labels=[],
+        step_ladder=[],
+        batch_grad_accum_ladder=[],
+        historical_context_studies=[],
+        primary_fit=None,
+        frozen_contract=None,
+        output_root_path=lambda: tmp_path / "outputs",
+        validation_overlay_resolved_path=lambda: tmp_path / "overlay.json",
+    )
+    index_entry = SimpleNamespace(
+        status="completed",
+        parent_sweep_id=None,
+        complexity_level="classification_md",
+        anchor_run_id="anchor_run",
+        benchmark_manifest_path=str(manifest_path),
+        control_baseline_id="cls_benchmark_linear_multiclass_medium_v1",
+    )
+
+    monkeypatch.setattr(navigation_module, "default_benchmark_manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(navigation_module, "default_anchor_benchmark_summary", lambda: {"name": "bundle"})
+    monkeypatch.setattr(navigation_module, "load_system_delta_queue", lambda **_: queue)
+    monkeypatch.setattr(
+        navigation_module,
+        "load_system_delta_index_payload",
+        lambda _index_path=None: SimpleNamespace(sweeps={"test_sweep": index_entry}),
+    )
+    monkeypatch.setattr(navigation_module, "validate_sweep_contract", lambda **_: [])
+    monkeypatch.setattr(navigation_module, "build_sweep_navigation_payload", lambda **_: {"contract": {"corpus_ref": None}})
+    monkeypatch.setattr(navigation_module, "sweep_lineage_entries", lambda **_: [])
+
+    payload = navigation_module.build_scaling_navigation_payload(
+        config=config,
+        points=[],
+        index_path=tmp_path / "index.yaml",
+        catalog_path=tmp_path / "catalog.yaml",
+        sweeps_root=tmp_path / "sweeps",
+    )
+
+    assert payload["linked_sweeps"][0]["status"] == "completed"
+    assert payload["linked_sweeps"][0]["winner"]["order"] == 1

--- a/tests/research/test_navigation.py
+++ b/tests/research/test_navigation.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import tab_foundry.research.navigation as navigation_module
+
+
+def test_validate_sweep_contract_reports_missing_default_anchor_manifest(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "data" / "manifests" / "bench" / "openml_classification_medium_v1" / "manifest.parquet"
+    queue = {
+        "sweep_id": "test_sweep",
+        "anchor_run_id": "anchor_run",
+        "complexity_level": "classification_md",
+        "benchmark_manifest_path": str(manifest_path),
+        "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+    }
+    index_entry = SimpleNamespace(
+        anchor_run_id="anchor_run",
+        complexity_level="classification_md",
+        benchmark_manifest_path=str(manifest_path),
+        control_baseline_id="cls_benchmark_linear_multiclass_medium_v1",
+    )
+
+    monkeypatch.setattr(navigation_module, "default_benchmark_manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(
+        navigation_module,
+        "load_system_delta_index_payload",
+        lambda _index_path=None: SimpleNamespace(sweeps={"test_sweep": index_entry}),
+    )
+
+    issues = navigation_module.validate_sweep_contract(queue=queue)
+
+    assert issues == ["test_sweep: default anchor benchmark manifest is not materialized locally"]
+
+
+def test_build_sweep_navigation_payload_requires_control_baseline_for_default_anchor(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "data" / "manifests" / "bench" / "openml_classification_medium_v1" / "manifest.parquet"
+    queue = {
+        "sweep_id": "test_sweep",
+        "rows": [],
+        "benchmark_manifest_path": str(manifest_path),
+        "control_baseline_id": "cls_benchmark_linear_v2",
+        "training_experiment": "exp",
+        "training_config_profile": "profile",
+        "surface_role": "classification_training_dynamics_transfer",
+        "comparison_policy": "anchor_only",
+    }
+
+    monkeypatch.setattr(navigation_module, "default_benchmark_manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(navigation_module, "default_anchor_benchmark_summary", lambda: {"name": "bundle"})
+    monkeypatch.setattr(navigation_module, "sweep_lineage_entries", lambda **_: [])
+    monkeypatch.setattr(navigation_module, "_scan_linked_scaling_studies", lambda **_: [])
+    monkeypatch.setattr(navigation_module, "_winner_from_rows", lambda _rows: None)
+    monkeypatch.setattr(navigation_module, "validate_sweep_contract", lambda **_: [])
+
+    payload = navigation_module.build_sweep_navigation_payload(queue=queue)
+
+    assert payload["contract"]["uses_default_anchor_benchmark"] is False
+
+
+def test_build_scaling_navigation_payload_marks_default_anchor_only_when_baseline_matches(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "data" / "manifests" / "bench" / "openml_classification_medium_v1" / "manifest.parquet"
+    queue = {
+        "sweep_id": "test_sweep",
+        "rows": [],
+        "status": "draft",
+        "benchmark_manifest_path": str(manifest_path),
+        "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+        "anchor_run_id": "anchor_run",
+        "training_experiment": "exp",
+        "training_config_profile": "profile",
+        "upstream_reference": {"name": "paper"},
+    }
+    config = SimpleNamespace(
+        study_id="study",
+        sweeps=[SimpleNamespace(name="lane", family="transfer", sweep_id="test_sweep")],
+        phase1_reference_sweep_id=None,
+        geometry_row_labels=[],
+        step_ladder=[],
+        batch_grad_accum_ladder=[],
+        historical_context_studies=[],
+        primary_fit=None,
+        frozen_contract=None,
+        output_root_path=lambda: tmp_path / "outputs",
+        validation_overlay_resolved_path=lambda: tmp_path / "overlay.json",
+    )
+
+    monkeypatch.setattr(navigation_module, "default_benchmark_manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(navigation_module, "default_anchor_benchmark_summary", lambda: {"name": "bundle"})
+    monkeypatch.setattr(navigation_module, "load_system_delta_queue", lambda **_: queue)
+    monkeypatch.setattr(navigation_module, "validate_sweep_contract", lambda **_: [])
+    monkeypatch.setattr(navigation_module, "build_sweep_navigation_payload", lambda **_: {"contract": {"corpus_ref": None}})
+    monkeypatch.setattr(navigation_module, "sweep_lineage_entries", lambda **_: [])
+    monkeypatch.setattr(navigation_module, "_winner_from_rows", lambda _rows: None)
+
+    payload = navigation_module.build_scaling_navigation_payload(
+        config=config,
+        points=[],
+        index_path=tmp_path / "index.yaml",
+        catalog_path=tmp_path / "catalog.yaml",
+        sweeps_root=tmp_path / "sweeps",
+    )
+
+    assert payload["contract"]["uses_default_anchor_benchmark"] is True

--- a/tests/research/test_reporting.py
+++ b/tests/research/test_reporting.py
@@ -171,6 +171,11 @@ def test_result_card_text_includes_transfer_interpretation_when_provided() -> No
                     "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
                     "source_order": 11,
                 },
+                "shared_anchor_provenance": {
+                    "anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+                    "anchor_order": 1,
+                    "anchor_run_dir": "outputs/staged_ladder/research/lmo/anchor/train",
+                },
             },
             "summary": {
                 "best_row": {
@@ -194,6 +199,15 @@ def test_result_card_text_includes_transfer_interpretation_when_provided() -> No
                         "mean_benchmark_log_loss": 0.437,
                     },
                 ],
+                "kept_regime": {
+                    "regime_label": "B",
+                    "t2_order": 8,
+                    "t2_log_loss": 0.412345,
+                },
+                "t2_vs_carried_highbatch": {
+                    "winning_regime_label": "B",
+                    "delta_log_loss": -0.012345,
+                },
             },
         },
     )
@@ -205,9 +219,12 @@ def test_result_card_text_includes_transfer_interpretation_when_provided() -> No
     assert "- Target budget label: `T1`" in text
     assert "- Realized effective budget: `160000`" in text
     assert "- Imported baseline provenance: sweep `tf_rd_009_muon_ns_one_epoch_medium_v1`, order `11`" in text
+    assert "- Shared anchor provenance: sweep `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`, order `01`, run dir `outputs/staged_ladder/research/lmo/anchor/train`" in text
     assert "- Best transfer row: order `08` (regime `B`, log loss `0.412345`, budget `T1`)" in text
     assert "- Fastest transfer row: order `01` (regime `carry_lowbatch`, wall `5400.0s`)" in text
     assert "- Regime leaderboard: B: mean log loss `0.421000`; D: mean log loss `0.437000`" in text
+    assert "- Kept regime (`T2` then `T1`): `B` (T2 order `08`, log loss `0.412345`)" in text
+    assert "- T2 vs carried high-batch: winning regime `B` minus carried high-batch delta log loss `-0.012345`" in text
 
 
 def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_selector_context(
@@ -375,6 +392,10 @@ def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_transfer_c
                     "realized_effective_budget": 160000,
                     "budget_drift": 0.0,
                     "batch_drift": 0.0,
+                    "shared_anchor_provenance": {
+                        "anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+                        "anchor_order": 1,
+                    },
                 }
             ],
             "transfer_summary": {
@@ -395,6 +416,15 @@ def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_transfer_c
                         "mean_benchmark_log_loss": 0.42,
                     }
                 ],
+                "kept_regime": {
+                    "regime_label": "B",
+                    "t2_order": 8,
+                    "t2_log_loss": 0.41,
+                },
+                "t2_vs_carried_highbatch": {
+                    "winning_regime_label": "B",
+                    "delta_log_loss": -0.02,
+                },
             },
         },
     )
@@ -414,3 +444,5 @@ def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_transfer_c
     assert "## Transfer interpretation" in text
     assert "- Transfer regime: `B`" in text
     assert "- Best transfer row: order `08`" in text
+    assert "- Shared anchor provenance: sweep `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1`, order `01`" in text
+    assert "- Kept regime (`T2` then `T1`): `B`" in text

--- a/tests/research/test_reporting.py
+++ b/tests/research/test_reporting.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import tab_foundry.research.sweep.reporting as reporting_module
 from tab_foundry.research.sweep.reporting import result_card_text
 
 
@@ -90,3 +94,147 @@ def test_result_card_text_marks_classification_bpc_metrics_as_legacy_diagnostics
     assert "- Peak VRAM reserved: `2048`" in text
     assert "- Token budget: `38400`" in text
     assert "- Curriculum id: `dagzoo_shape_aware_multi_invocation`" in text
+
+
+def test_result_card_text_includes_selector_interpretation_when_provided() -> None:
+    text = result_card_text(
+        row={
+            "delta_id": "delta",
+            "description": "Use the refreshed benchmark surface.",
+            "anchor_delta": "anchor-only comparison.",
+        },
+        run_id="sd_test_v1",
+        anchor_run_id="anchor_v1",
+        summary=_classification_summary(),
+        queue_metrics=_classification_queue_metrics(),
+        decision="defer",
+        conclusion="Monitor log-loss deltas before promotion.",
+        selector_context={
+            "row_summary": {
+                "pareto_admissible": True,
+                "geometry_pareto_admissible": False,
+                "selector_geometry_label": "144x4",
+                "selector_prescription_label": "linear_lr_batch",
+            },
+            "summary": {
+                "best_row": {
+                    "order": 10,
+                    "geometry_label": "264x6",
+                    "prescription_label": "linear_lr_batch",
+                    "final_log_loss": 0.46,
+                    "end_to_end_wall_seconds": 222.0,
+                },
+                "kept_contract": {
+                    "prescription_label": "carry_lowbatch",
+                    "geometry_count": 3,
+                    "mean_end_to_end_wall_seconds": 115.0,
+                    "mean_benchmark_log_loss": 0.52,
+                },
+            },
+        },
+    )
+
+    assert "## Selector interpretation" in text
+    assert "- Quality/time Pareto admissible: `yes`" in text
+    assert "- Geometry-local Pareto admissible: `no`" in text
+    assert "- Selector geometry: `144x4`" in text
+    assert "- Selector prescription: `linear_lr_batch`" in text
+    assert "- Kept contract: `carry_lowbatch`" in text
+
+
+def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_selector_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    comparison_summary_path = tmp_path / "comparison_summary.json"
+    comparison_summary_path.write_text(
+        json.dumps(_classification_summary()),
+        encoding="utf-8",
+    )
+    queue = {
+        "sweep_id": "selector_sweep",
+        "anchor_run_id": "anchor_v1",
+        "rows": [
+            {
+                "order": 1,
+                "delta_id": "delta_selector",
+                "status": "completed",
+                "run_id": "run_1",
+                "decision": "keep",
+                "conclusion": "Keep the carried low-batch selector contract.",
+                "description": "Selector replay row.",
+                "anchor_delta": "anchor-only comparison.",
+                "benchmark_metrics": _classification_queue_metrics(),
+            }
+        ],
+    }
+
+    monkeypatch.setattr(reporting_module, "repo_root", lambda: repo_root)
+    monkeypatch.setattr(
+        reporting_module,
+        "load_benchmark_run_registry",
+        lambda _path: {
+            "runs": {
+                "run_1": {
+                    "artifacts": {
+                        "comparison_summary_path": str(comparison_summary_path),
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        reporting_module,
+        "resolve_registry_path_value",
+        lambda value: Path(str(value)),
+    )
+
+    import tab_foundry.research.sweep.summarize as summarize_module
+
+    monkeypatch.setattr(
+        summarize_module,
+        "build_sweep_summary_payload",
+        lambda **_: {
+            "rows": [
+                {
+                    "order": 1,
+                    "pareto_admissible": True,
+                    "geometry_pareto_admissible": True,
+                    "selector_geometry_label": "128x2",
+                    "selector_prescription_label": "carry_lowbatch",
+                }
+            ],
+            "selector_summary": {
+                "best_row": {
+                    "order": 1,
+                    "geometry_label": "128x2",
+                    "prescription_label": "carry_lowbatch",
+                    "final_log_loss": 0.50,
+                    "end_to_end_wall_seconds": 100.0,
+                },
+                "kept_contract": {
+                    "prescription_label": "carry_lowbatch",
+                    "geometry_count": 3,
+                    "mean_end_to_end_wall_seconds": 105.0,
+                    "mean_benchmark_log_loss": 0.51,
+                },
+            },
+        },
+    )
+
+    reporting_module.refresh_result_cards_for_queue(queue=queue)
+
+    result_card_path = (
+        repo_root
+        / "outputs"
+        / "staged_ladder"
+        / "research"
+        / "selector_sweep"
+        / "delta_selector"
+        / "result_card.md"
+    )
+    text = result_card_path.read_text(encoding="utf-8")
+    assert "## Selector interpretation" in text
+    assert "- Selector prescription: `carry_lowbatch`" in text
+    assert "- Kept contract: `carry_lowbatch`" in text

--- a/tests/research/test_reporting.py
+++ b/tests/research/test_reporting.py
@@ -142,6 +142,74 @@ def test_result_card_text_includes_selector_interpretation_when_provided() -> No
     assert "- Kept contract: `carry_lowbatch`" in text
 
 
+def test_result_card_text_includes_transfer_interpretation_when_provided() -> None:
+    text = result_card_text(
+        row={
+            "delta_id": "delta",
+            "description": "Use the faithful transfer validation surface.",
+            "anchor_delta": "anchor-only comparison.",
+        },
+        run_id="sd_test_v1",
+        anchor_run_id="anchor_v1",
+        summary=_classification_summary(),
+        queue_metrics=_classification_queue_metrics(),
+        decision="defer",
+        conclusion="Wait for the faithful transfer validation surface.",
+        transfer_context={
+            "row_summary": {
+                "transfer_regime_label": "B",
+                "transfer_phase": "validation",
+                "transfer_formula_label": "Theorem 2 fixed-batch transfer",
+                "transfer_target_budget_label": "T1",
+                "target_effective_batch": 64.0,
+                "realized_effective_batch": 64,
+                "target_effective_budget": 160000,
+                "realized_effective_budget": 160000,
+                "budget_drift": 0.0,
+                "batch_drift": 0.0,
+                "imported_baseline_provenance": {
+                    "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
+                    "source_order": 11,
+                },
+            },
+            "summary": {
+                "best_row": {
+                    "order": 8,
+                    "regime_label": "B",
+                    "final_log_loss": 0.412345,
+                    "target_budget_label": "T1",
+                },
+                "fastest_row": {
+                    "order": 1,
+                    "regime_label": "carry_lowbatch",
+                    "end_to_end_wall_seconds": 5400.0,
+                },
+                "regime_leaderboard": [
+                    {
+                        "regime_label": "B",
+                        "mean_benchmark_log_loss": 0.421,
+                    },
+                    {
+                        "regime_label": "D",
+                        "mean_benchmark_log_loss": 0.437,
+                    },
+                ],
+            },
+        },
+    )
+
+    assert "## Transfer interpretation" in text
+    assert "- Transfer regime: `B`" in text
+    assert "- Transfer phase: `validation`" in text
+    assert "- Transfer formula: `Theorem 2 fixed-batch transfer`" in text
+    assert "- Target budget label: `T1`" in text
+    assert "- Realized effective budget: `160000`" in text
+    assert "- Imported baseline provenance: sweep `tf_rd_009_muon_ns_one_epoch_medium_v1`, order `11`" in text
+    assert "- Best transfer row: order `08` (regime `B`, log loss `0.412345`, budget `T1`)" in text
+    assert "- Fastest transfer row: order `01` (regime `carry_lowbatch`, wall `5400.0s`)" in text
+    assert "- Regime leaderboard: B: mean log loss `0.421000`; D: mean log loss `0.437000`" in text
+
+
 def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_selector_context(
     tmp_path: Path,
     monkeypatch,
@@ -238,3 +306,111 @@ def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_selector_c
     assert "## Selector interpretation" in text
     assert "- Selector prescription: `carry_lowbatch`" in text
     assert "- Kept contract: `carry_lowbatch`" in text
+
+
+def test_refresh_result_cards_for_queue_rewrites_completed_cards_with_transfer_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    comparison_summary_path = tmp_path / "comparison_summary.json"
+    comparison_summary_path.write_text(
+        json.dumps(_classification_summary()),
+        encoding="utf-8",
+    )
+    queue = {
+        "sweep_id": "transfer_sweep",
+        "anchor_run_id": "anchor_v1",
+        "rows": [
+            {
+                "order": 8,
+                "delta_id": "delta_transfer",
+                "status": "completed",
+                "run_id": "run_8",
+                "decision": "keep",
+                "conclusion": "Keep the faithful transfer anchor for T1/T2 extrapolation.",
+                "description": "Faithful transfer row.",
+                "anchor_delta": "anchor-only comparison.",
+                "benchmark_metrics": _classification_queue_metrics(),
+            }
+        ],
+    }
+
+    monkeypatch.setattr(reporting_module, "repo_root", lambda: repo_root)
+    monkeypatch.setattr(
+        reporting_module,
+        "load_benchmark_run_registry",
+        lambda _path: {
+            "runs": {
+                "run_8": {
+                    "artifacts": {
+                        "comparison_summary_path": str(comparison_summary_path),
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        reporting_module,
+        "resolve_registry_path_value",
+        lambda value: Path(str(value)),
+    )
+
+    import tab_foundry.research.sweep.summarize as summarize_module
+
+    monkeypatch.setattr(
+        summarize_module,
+        "build_sweep_summary_payload",
+        lambda **_: {
+            "rows": [
+                {
+                    "order": 8,
+                    "transfer_regime_label": "B",
+                    "transfer_phase": "validation",
+                    "transfer_formula_label": "Theorem 2 fixed-batch transfer",
+                    "transfer_target_budget_label": "T1",
+                    "target_effective_batch": 64.0,
+                    "realized_effective_batch": 64,
+                    "target_effective_budget": 160000,
+                    "realized_effective_budget": 160000,
+                    "budget_drift": 0.0,
+                    "batch_drift": 0.0,
+                }
+            ],
+            "transfer_summary": {
+                "best_row": {
+                    "order": 8,
+                    "regime_label": "B",
+                    "final_log_loss": 0.41,
+                    "target_budget_label": "T1",
+                },
+                "fastest_row": {
+                    "order": 1,
+                    "regime_label": "carry_lowbatch",
+                    "end_to_end_wall_seconds": 5400.0,
+                },
+                "regime_leaderboard": [
+                    {
+                        "regime_label": "B",
+                        "mean_benchmark_log_loss": 0.42,
+                    }
+                ],
+            },
+        },
+    )
+
+    reporting_module.refresh_result_cards_for_queue(queue=queue)
+
+    result_card_path = (
+        repo_root
+        / "outputs"
+        / "staged_ladder"
+        / "research"
+        / "transfer_sweep"
+        / "delta_transfer"
+        / "result_card.md"
+    )
+    text = result_card_path.read_text(encoding="utf-8")
+    assert "## Transfer interpretation" in text
+    assert "- Transfer regime: `B`" in text
+    assert "- Best transfer row: order `08`" in text

--- a/tests/research/test_sweep_inspect.py
+++ b/tests/research/test_sweep_inspect.py
@@ -825,3 +825,85 @@ def test_diff_sweep_row_reports_legacy_prior_override_differences_without_artifa
         "target": "sqrt",
         "against": "none",
     }
+
+
+def test_render_sweep_row_text_surfaces_selector_frontier_context() -> None:
+    text = inspect_module.render_sweep_row_text(
+        {
+            "queue": {
+                "sweep_id": "tf_rd_009_muon_training_dynamics_endpoint_medium_v1",
+                "training_experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
+                "training_config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
+                "surface_role": "classification_training_dynamics_selector",
+            },
+            "row": {
+                "order": 6,
+                "delta_id": "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1",
+                "status": "completed",
+                "decision": "keep",
+                "run_id": "selector_run_06",
+                "parent_delta_ref": None,
+                "benchmark_checkpoint_selection": "best_and_final",
+            },
+            "target": {
+                "resolved": {
+                    "model": {
+                        "stage_label": "tf_rd_009_cls_sandwich_dicl144_layers4_v1",
+                        "arch": "tabfoundry_staged",
+                        "parameter_counts": {"total_params": 1234, "trainable_params": 1234},
+                    }
+                },
+                "artifacts": {},
+                "metrics": {},
+            },
+            "navigation": {
+                "lineage": [
+                    {"sweep_id": "tf_rd_009_muon_width_screen_medium_v1"},
+                    {"sweep_id": "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"},
+                ],
+                "contract": {
+                    "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
+                    "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+                    "carried_in_family_baseline_run_id": "anchor_run",
+                },
+                "winner": {
+                    "order": 10,
+                    "geometry_label": "264x6",
+                    "benchmark_log_loss": 0.46,
+                    "throughput_tokens_per_second": 7000.0,
+                    "end_to_end_wall_seconds": 222.0,
+                },
+                "linked_scaling_study_ids": [],
+            },
+            "row_summary": {
+                "pareto_admissible": True,
+                "geometry_pareto_admissible": True,
+                "selector_geometry_label": "144x4",
+                "selector_prescription_label": "carry_highbatch",
+                "end_to_end_wall_seconds": 180.0,
+                "throughput_tokens_per_second": 6500.0,
+            },
+            "selector_summary": {
+                "best_row": {
+                    "order": 10,
+                    "geometry_label": "264x6",
+                    "prescription_label": "linear_lr_batch",
+                    "final_log_loss": 0.46,
+                    "end_to_end_wall_seconds": 222.0,
+                },
+                "kept_contract": {
+                    "prescription_label": "carry_lowbatch",
+                    "geometry_count": 3,
+                    "mean_end_to_end_wall_seconds": 115.0,
+                    "mean_benchmark_log_loss": 0.52,
+                },
+            },
+        }
+    )
+
+    assert "pareto_admissible=yes" in text
+    assert "geometry_pareto_admissible=yes" in text
+    assert "selector_geometry_label=144x4" in text
+    assert "selector_prescription_label=carry_highbatch" in text
+    assert "selector_best_row=order 10" in text
+    assert "selector_kept_contract=carry_lowbatch" in text

--- a/tests/research/test_sweep_inspect.py
+++ b/tests/research/test_sweep_inspect.py
@@ -907,3 +907,104 @@ def test_render_sweep_row_text_surfaces_selector_frontier_context() -> None:
     assert "selector_prescription_label=carry_highbatch" in text
     assert "selector_best_row=order 10" in text
     assert "selector_kept_contract=carry_lowbatch" in text
+
+
+def test_render_sweep_row_text_surfaces_transfer_context() -> None:
+    text = inspect_module.render_sweep_row_text(
+        {
+            "queue": {
+                "sweep_id": "tf_rd_009_muon_training_dynamics_transfer_medium_v1",
+                "training_experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
+                "training_config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
+                "surface_role": "classification_training_dynamics_transfer",
+            },
+            "row": {
+                "order": 8,
+                "delta_id": "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1",
+                "status": "ready",
+                "decision": "defer",
+                "run_id": None,
+                "parent_delta_ref": None,
+                "benchmark_checkpoint_selection": "best_and_final",
+            },
+            "target": {
+                "resolved": {
+                    "model": {
+                        "stage_label": "tf_rd_009_cls_sandwich_dicl144_layers4_v1",
+                        "arch": "tabfoundry_staged",
+                        "parameter_counts": {"total_params": 1234, "trainable_params": 1234},
+                    }
+                },
+                "artifacts": {},
+                "metrics": {},
+            },
+            "navigation": {
+                "lineage": [
+                    {"sweep_id": "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"},
+                    {"sweep_id": "tf_rd_009_muon_training_dynamics_transfer_medium_v1"},
+                ],
+                "contract": {
+                    "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
+                    "control_baseline_id": "cls_benchmark_linear_multiclass_medium_v1",
+                    "carried_in_family_baseline_run_id": "anchor_run",
+                },
+                "winner": None,
+                "linked_scaling_study_ids": [],
+            },
+            "row_summary": {
+                "transfer_regime_label": "B",
+                "transfer_phase": "validation",
+                "transfer_formula_label": "Theorem 2 fixed-batch transfer",
+                "transfer_target_budget_label": "T1",
+                "transfer_candidate_label": "regime_b_lr0.001_m0.95_beff64",
+                "target_effective_batch": 64,
+                "realized_effective_batch": 64,
+                "target_effective_budget": 160000,
+                "realized_effective_budget": 160000,
+                "budget_drift": 0.0,
+                "batch_drift": 0.0,
+                "imported_baseline_provenance": {
+                    "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
+                    "source_order": 11,
+                },
+            },
+            "transfer_summary": {
+                "best_row": {
+                    "order": 8,
+                    "regime_label": "B",
+                    "final_log_loss": 0.41,
+                    "end_to_end_wall_seconds": 7200.0,
+                    "target_budget_label": "T1",
+                },
+                "fastest_row": {
+                    "order": 1,
+                    "regime_label": "carry_lowbatch",
+                    "final_log_loss": 0.49,
+                    "end_to_end_wall_seconds": 5400.0,
+                    "target_budget_label": "T0",
+                },
+                "regime_leaderboard": [
+                    {
+                        "regime_label": "B",
+                        "row_count": 2,
+                        "best_row_order": 8,
+                        "best_log_loss": 0.41,
+                        "mean_benchmark_log_loss": 0.42,
+                        "mean_end_to_end_wall_seconds": 7150.0,
+                    }
+                ],
+                "imported_baseline_orders": [1, 2, 3],
+            },
+        }
+    )
+
+    assert "transfer_regime_label=B" in text
+    assert "transfer_phase=validation" in text
+    assert "transfer_formula_label=Theorem 2 fixed-batch transfer" in text
+    assert "transfer_target_budget_label=T1" in text
+    assert "target_effective_batch=64" in text
+    assert "realized_effective_budget=160000" in text
+    assert '"source_order": 11' in text
+    assert '"source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1"' in text
+    assert "transfer_best_row=order 08, regime=B" in text
+    assert "transfer_fastest_row=order 01, regime=carry_lowbatch" in text

--- a/tests/research/test_sweep_inspect.py
+++ b/tests/research/test_sweep_inspect.py
@@ -913,7 +913,7 @@ def test_render_sweep_row_text_surfaces_transfer_context() -> None:
     text = inspect_module.render_sweep_row_text(
         {
             "queue": {
-                "sweep_id": "tf_rd_009_muon_training_dynamics_transfer_medium_v1",
+                "sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
                 "training_experiment": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
                 "training_config_profile": "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1",
                 "surface_role": "classification_training_dynamics_transfer",
@@ -940,8 +940,9 @@ def test_render_sweep_row_text_surfaces_transfer_context() -> None:
             },
             "navigation": {
                 "lineage": [
-                    {"sweep_id": "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"},
+                    {"sweep_id": "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"},
                     {"sweep_id": "tf_rd_009_muon_training_dynamics_transfer_medium_v1"},
+                    {"sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1"},
                 ],
                 "contract": {
                     "benchmark_manifest_path": "data/manifests/bench/openml_classification_medium_v1/manifest.parquet",
@@ -966,6 +967,11 @@ def test_render_sweep_row_text_surfaces_transfer_context() -> None:
                 "imported_baseline_provenance": {
                     "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
                     "source_order": 11,
+                },
+                "shared_anchor_provenance": {
+                    "anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+                    "anchor_order": 1,
+                    "anchor_run_dir": "outputs/staged_ladder/research/lmo/anchor/train",
                 },
             },
             "transfer_summary": {
@@ -994,6 +1000,14 @@ def test_render_sweep_row_text_surfaces_transfer_context() -> None:
                     }
                 ],
                 "imported_baseline_orders": [1, 2, 3],
+                "kept_regime": {
+                    "regime_label": "B",
+                    "t2_order": 8,
+                    "t2_log_loss": 0.41,
+                },
+                "t2_vs_carried_highbatch": {
+                    "delta_log_loss": -0.015,
+                },
             },
         }
     )
@@ -1006,5 +1020,9 @@ def test_render_sweep_row_text_surfaces_transfer_context() -> None:
     assert "realized_effective_budget=160000" in text
     assert '"source_order": 11' in text
     assert '"source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1"' in text
+    assert '"anchor_order": 1' in text
+    assert '"anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1"' in text
     assert "transfer_best_row=order 08, regime=B" in text
     assert "transfer_fastest_row=order 01, regime=carry_lowbatch" in text
+    assert "transfer_kept_regime=B@T2(order 08, log_loss=0.410000)" in text
+    assert "transfer_t2_vs_carried_highbatch=delta_log_loss=-0.015000" in text

--- a/tests/research/test_sweep_summarize.py
+++ b/tests/research/test_sweep_summarize.py
@@ -348,3 +348,88 @@ def test_summarize_sweep_reports_no_universal_selector_contract_when_no_majority
         coverage["prescription_label"]
         for coverage in selector_summary["prescription_coverage"]
     ] == ["linear_lr_batch", "momentum_timescale", "carry_highbatch"]
+
+
+def _transfer_row(
+    *,
+    order: int,
+    regime_label: str,
+    target_budget_label: str,
+    final_log_loss: float,
+    end_to_end_wall_seconds: float | None,
+    imported: bool = False,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "order": order,
+        "delta_id": f"delta_transfer_{order}",
+        "status": "completed",
+        "decision": "keep",
+        "run_id": f"transfer_run_{order}",
+        "benchmark_metrics": {
+            "objective_metric": "final_log_loss_at_matched_regime_budget",
+            "final_log_loss": final_log_loss,
+            "delta_final_log_loss": 0.0,
+            "end_to_end_wall_seconds": end_to_end_wall_seconds,
+            "throughput_tokens_per_second": 2000.0 + float(order),
+        },
+        "transfer_context": {
+            "regime_label": regime_label,
+            "phase": "validation",
+            "formula_label": "Theorem 2 fixed-batch transfer" if regime_label == "B" else "baseline import",
+            "base_budget_label": "T0",
+            "target_budget_label": target_budget_label,
+            "target_effective_batch": 64,
+            "realized_effective_batch": 64,
+            "target_effective_budget": {"T0": 40000, "T1": 160000, "T2": 320000}[target_budget_label],
+            "realized_effective_budget": {"T0": 40000, "T1": 160000, "T2": 320000}[target_budget_label],
+            "budget_drift": 0.0,
+            "batch_drift": 0.0,
+        },
+    }
+    if imported:
+        row["imported_baseline_provenance"] = {
+            "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
+            "source_order": order,
+        }
+    return row
+
+
+def test_summarize_sweep_reports_transfer_regime_leaderboard(monkeypatch) -> None:
+    queue = {
+        "sweep_id": "transfer_sweep",
+        "surface_role": "classification_training_dynamics_transfer",
+        "rows": [
+            _transfer_row(order=1, regime_label="carry_lowbatch", target_budget_label="T0", final_log_loss=0.49, end_to_end_wall_seconds=5400.0, imported=True),
+            _transfer_row(order=2, regime_label="carry_lowbatch", target_budget_label="T1", final_log_loss=0.47, end_to_end_wall_seconds=5500.0, imported=True),
+            _transfer_row(order=3, regime_label="B", target_budget_label="T0", final_log_loss=0.45, end_to_end_wall_seconds=7000.0),
+            _transfer_row(order=4, regime_label="B", target_budget_label="T1", final_log_loss=0.43, end_to_end_wall_seconds=7100.0),
+            _transfer_row(order=5, regime_label="D", target_budget_label="T0", final_log_loss=0.46, end_to_end_wall_seconds=6600.0),
+            _transfer_row(order=6, regime_label="D", target_budget_label="T1", final_log_loss=0.44, end_to_end_wall_seconds=6800.0),
+        ],
+    }
+
+    monkeypatch.setattr(
+        summarize_module,
+        "load_system_delta_queue_for_inspection",
+        lambda **_: queue,
+    )
+    monkeypatch.setattr(summarize_module, "ordered_rows", lambda payload: payload["rows"])
+
+    payload = summarize_module.summarize_sweep(sweep_id="transfer_sweep")
+
+    transfer_summary = payload["transfer_summary"]
+    assert transfer_summary is not None
+    assert transfer_summary["best_row"]["order"] == 4
+    assert transfer_summary["best_row"]["regime_label"] == "B"
+    assert transfer_summary["fastest_row"]["order"] == 1
+    assert transfer_summary["imported_baseline_orders"] == [1, 2]
+    assert [entry["regime_label"] for entry in transfer_summary["regime_leaderboard"]] == [
+        "B",
+        "D",
+        "carry_lowbatch",
+    ]
+
+    rendered = summarize_module.render_sweep_summary_table(payload)
+    assert "Transfer summary:" in rendered
+    assert "best transfer row: order 04, regime=B" in rendered
+    assert "imported baseline orders: 01, 02" in rendered

--- a/tests/research/test_sweep_summarize.py
+++ b/tests/research/test_sweep_summarize.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import tab_foundry.research.sweep.summarize as summarize_module
 from tab_foundry.research.sweep.summarize import render_sweep_summary_table, summarize_sweep
 
@@ -358,6 +360,7 @@ def _transfer_row(
     final_log_loss: float,
     end_to_end_wall_seconds: float | None,
     imported: bool = False,
+    shared_anchor: bool = False,
 ) -> dict[str, object]:
     row: dict[str, object] = {
         "order": order,
@@ -391,6 +394,13 @@ def _transfer_row(
             "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
             "source_order": order,
         }
+    if shared_anchor:
+        row["transfer_resolution"] = {
+            "shared_anchor_provenance": {
+                "anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+                "anchor_order": 1,
+            }
+        }
     return row
 
 
@@ -401,10 +411,11 @@ def test_summarize_sweep_reports_transfer_regime_leaderboard(monkeypatch) -> Non
         "rows": [
             _transfer_row(order=1, regime_label="carry_lowbatch", target_budget_label="T0", final_log_loss=0.49, end_to_end_wall_seconds=5400.0, imported=True),
             _transfer_row(order=2, regime_label="carry_lowbatch", target_budget_label="T1", final_log_loss=0.47, end_to_end_wall_seconds=5500.0, imported=True),
-            _transfer_row(order=3, regime_label="B", target_budget_label="T0", final_log_loss=0.45, end_to_end_wall_seconds=7000.0),
-            _transfer_row(order=4, regime_label="B", target_budget_label="T1", final_log_loss=0.43, end_to_end_wall_seconds=7100.0),
-            _transfer_row(order=5, regime_label="D", target_budget_label="T0", final_log_loss=0.46, end_to_end_wall_seconds=6600.0),
-            _transfer_row(order=6, regime_label="D", target_budget_label="T1", final_log_loss=0.44, end_to_end_wall_seconds=6800.0),
+            _transfer_row(order=4, regime_label="carry_highbatch", target_budget_label="T2", final_log_loss=0.44, end_to_end_wall_seconds=6300.0),
+            _transfer_row(order=7, regime_label="B", target_budget_label="T1", final_log_loss=0.43, end_to_end_wall_seconds=7100.0, shared_anchor=True),
+            _transfer_row(order=8, regime_label="B", target_budget_label="T2", final_log_loss=0.41, end_to_end_wall_seconds=7200.0, shared_anchor=True),
+            _transfer_row(order=9, regime_label="D", target_budget_label="T1", final_log_loss=0.435, end_to_end_wall_seconds=6800.0, shared_anchor=True),
+            _transfer_row(order=10, regime_label="D", target_budget_label="T2", final_log_loss=0.425, end_to_end_wall_seconds=6900.0, shared_anchor=True),
         ],
     }
 
@@ -419,17 +430,37 @@ def test_summarize_sweep_reports_transfer_regime_leaderboard(monkeypatch) -> Non
 
     transfer_summary = payload["transfer_summary"]
     assert transfer_summary is not None
-    assert transfer_summary["best_row"]["order"] == 4
+    assert transfer_summary["best_row"]["order"] == 8
     assert transfer_summary["best_row"]["regime_label"] == "B"
     assert transfer_summary["fastest_row"]["order"] == 1
     assert transfer_summary["imported_baseline_orders"] == [1, 2]
     assert [entry["regime_label"] for entry in transfer_summary["regime_leaderboard"]] == [
         "B",
         "D",
+        "carry_highbatch",
         "carry_lowbatch",
     ]
+    assert transfer_summary["kept_regime"]["winner_rule"] == "T2_then_T1"
+    assert transfer_summary["kept_regime"]["regime_label"] == "B"
+    assert transfer_summary["kept_regime"]["t1_order"] == 7
+    assert transfer_summary["kept_regime"]["t1_log_loss"] == pytest.approx(0.43)
+    assert transfer_summary["kept_regime"]["t2_order"] == 8
+    assert transfer_summary["kept_regime"]["t2_log_loss"] == pytest.approx(0.41)
+    assert transfer_summary["kept_regime"]["runner_up_regime_label"] == "D"
+    assert transfer_summary["kept_regime"]["runner_up_t1_order"] == 9
+    assert transfer_summary["kept_regime"]["runner_up_t1_log_loss"] == pytest.approx(0.435)
+    assert transfer_summary["kept_regime"]["runner_up_t2_order"] == 10
+    assert transfer_summary["kept_regime"]["runner_up_t2_log_loss"] == pytest.approx(0.425)
+    assert transfer_summary["t2_vs_carried_highbatch"]["winning_regime_label"] == "B"
+    assert transfer_summary["t2_vs_carried_highbatch"]["winning_regime_order"] == 8
+    assert transfer_summary["t2_vs_carried_highbatch"]["winning_regime_t2_log_loss"] == pytest.approx(0.41)
+    assert transfer_summary["t2_vs_carried_highbatch"]["carried_highbatch_order"] == 4
+    assert transfer_summary["t2_vs_carried_highbatch"]["carried_highbatch_t2_log_loss"] == pytest.approx(0.44)
+    assert transfer_summary["t2_vs_carried_highbatch"]["delta_log_loss"] == pytest.approx(-0.03)
 
     rendered = summarize_module.render_sweep_summary_table(payload)
     assert "Transfer summary:" in rendered
-    assert "best transfer row: order 04, regime=B" in rendered
+    assert "best transfer row: order 08, regime=B" in rendered
     assert "imported baseline orders: 01, 02" in rendered
+    assert "kept regime (T2 then T1): B" in rendered
+    assert "T2 vs carried high-batch: B delta_log_loss=-0.030000" in rendered

--- a/tests/research/test_sweep_summarize.py
+++ b/tests/research/test_sweep_summarize.py
@@ -230,3 +230,121 @@ def test_render_sweep_summary_table_includes_runtime_columns() -> None:
     assert "6400.0000" in rendered
     assert "2.0KiB" in rendered
     assert "512.0000" in rendered
+
+
+def _selector_row(
+    *,
+    order: int,
+    d_icl: int,
+    layers: int,
+    prescription: str,
+    final_log_loss: float,
+    end_to_end_wall_seconds: float | None,
+) -> dict[str, object]:
+    return {
+        "order": order,
+        "delta_id": (
+            f"delta_tf_rd_009_cls_sandwich_dicl{d_icl}_layers{layers}_muon_"
+            f"{prescription}_v1"
+        ),
+        "status": "completed",
+        "decision": "defer",
+        "run_id": f"run_{order}",
+        "model": {
+            "d_icl": d_icl,
+            "sandwich_layers": layers,
+        },
+        "benchmark_metrics": {
+            "objective_metric": "final_log_loss_at_matched_regime_budget",
+            "final_log_loss": final_log_loss,
+            "delta_final_log_loss": 0.0,
+            "end_to_end_wall_seconds": end_to_end_wall_seconds,
+            "throughput_tokens_per_second": 1000.0 + float(order),
+        },
+    }
+
+
+def test_summarize_sweep_reports_selector_kept_contract_with_time_tiebreak(
+    monkeypatch,
+) -> None:
+    queue = {
+        "sweep_id": "selector_sweep",
+        "surface_role": "classification_training_dynamics_selector",
+        "rows": [
+            _selector_row(order=1, d_icl=128, layers=2, prescription="carry_lowbatch", final_log_loss=0.55, end_to_end_wall_seconds=100.0),
+            _selector_row(order=2, d_icl=128, layers=2, prescription="carry_highbatch", final_log_loss=0.53, end_to_end_wall_seconds=160.0),
+            _selector_row(order=3, d_icl=128, layers=2, prescription="linear_lr_batch", final_log_loss=0.50, end_to_end_wall_seconds=150.0),
+            _selector_row(order=4, d_icl=128, layers=2, prescription="momentum_timescale", final_log_loss=0.51, end_to_end_wall_seconds=170.0),
+            _selector_row(order=5, d_icl=144, layers=4, prescription="carry_lowbatch", final_log_loss=0.53, end_to_end_wall_seconds=110.0),
+            _selector_row(order=6, d_icl=144, layers=4, prescription="carry_highbatch", final_log_loss=0.50, end_to_end_wall_seconds=180.0),
+            _selector_row(order=7, d_icl=144, layers=4, prescription="linear_lr_batch", final_log_loss=0.48, end_to_end_wall_seconds=170.0),
+            _selector_row(order=8, d_icl=144, layers=4, prescription="momentum_timescale", final_log_loss=0.49, end_to_end_wall_seconds=190.0),
+            _selector_row(order=9, d_icl=264, layers=6, prescription="carry_lowbatch", final_log_loss=0.51, end_to_end_wall_seconds=130.0),
+            _selector_row(order=10, d_icl=264, layers=6, prescription="carry_highbatch", final_log_loss=0.49, end_to_end_wall_seconds=230.0),
+            _selector_row(order=11, d_icl=264, layers=6, prescription="linear_lr_batch", final_log_loss=0.46, end_to_end_wall_seconds=220.0),
+            _selector_row(order=12, d_icl=264, layers=6, prescription="momentum_timescale", final_log_loss=0.47, end_to_end_wall_seconds=240.0),
+        ],
+    }
+
+    monkeypatch.setattr(
+        summarize_module,
+        "load_system_delta_queue_for_inspection",
+        lambda **_: queue,
+    )
+    monkeypatch.setattr(summarize_module, "ordered_rows", lambda payload: payload["rows"])
+
+    payload = summarize_module.summarize_sweep(sweep_id="selector_sweep")
+
+    selector_summary = payload["selector_summary"]
+    assert selector_summary is not None
+    assert payload["rows"][0]["pareto_admissible"] is True
+    assert payload["rows"][2]["pareto_admissible"] is True
+    assert payload["rows"][1]["pareto_admissible"] is False
+    assert selector_summary["best_row"]["order"] == 11
+    assert selector_summary["kept_contract"]["prescription_label"] == "carry_lowbatch"
+    assert selector_summary["kept_contract"]["geometry_count"] == 3
+    assert selector_summary["prescription_coverage"][0]["prescription_label"] == "carry_lowbatch"
+    rendered = summarize_module.render_sweep_summary_table(payload)
+    assert "Pareto frontier:" in rendered
+    assert "kept contract: carry_lowbatch" in rendered
+
+
+def test_summarize_sweep_reports_no_universal_selector_contract_when_no_majority(
+    monkeypatch,
+) -> None:
+    queue = {
+        "sweep_id": "selector_sweep_fragmented",
+        "surface_role": "classification_training_dynamics_selector",
+        "rows": [
+            _selector_row(order=1, d_icl=128, layers=2, prescription="carry_lowbatch", final_log_loss=0.55, end_to_end_wall_seconds=None),
+            _selector_row(order=2, d_icl=128, layers=2, prescription="carry_highbatch", final_log_loss=0.54, end_to_end_wall_seconds=None),
+            _selector_row(order=3, d_icl=128, layers=2, prescription="linear_lr_batch", final_log_loss=0.50, end_to_end_wall_seconds=150.0),
+            _selector_row(order=4, d_icl=128, layers=2, prescription="momentum_timescale", final_log_loss=0.51, end_to_end_wall_seconds=None),
+            _selector_row(order=5, d_icl=144, layers=4, prescription="carry_lowbatch", final_log_loss=0.53, end_to_end_wall_seconds=None),
+            _selector_row(order=6, d_icl=144, layers=4, prescription="carry_highbatch", final_log_loss=0.52, end_to_end_wall_seconds=None),
+            _selector_row(order=7, d_icl=144, layers=4, prescription="linear_lr_batch", final_log_loss=0.49, end_to_end_wall_seconds=None),
+            _selector_row(order=8, d_icl=144, layers=4, prescription="momentum_timescale", final_log_loss=0.48, end_to_end_wall_seconds=190.0),
+            _selector_row(order=9, d_icl=264, layers=6, prescription="carry_lowbatch", final_log_loss=0.51, end_to_end_wall_seconds=None),
+            _selector_row(order=10, d_icl=264, layers=6, prescription="carry_highbatch", final_log_loss=0.47, end_to_end_wall_seconds=205.0),
+            _selector_row(order=11, d_icl=264, layers=6, prescription="linear_lr_batch", final_log_loss=0.46, end_to_end_wall_seconds=None),
+            _selector_row(order=12, d_icl=264, layers=6, prescription="momentum_timescale", final_log_loss=0.45, end_to_end_wall_seconds=None),
+        ],
+    }
+
+    monkeypatch.setattr(
+        summarize_module,
+        "load_system_delta_queue_for_inspection",
+        lambda **_: queue,
+    )
+    monkeypatch.setattr(summarize_module, "ordered_rows", lambda payload: payload["rows"])
+
+    payload = summarize_module.summarize_sweep(sweep_id="selector_sweep_fragmented")
+
+    selector_summary = payload["selector_summary"]
+    assert selector_summary is not None
+    assert selector_summary["kept_contract"] is None
+    assert selector_summary["no_universal_kept_contract"] is True
+    assert [
+        coverage["prescription_label"]
+        for coverage in selector_summary["prescription_coverage"]
+    ] == ["linear_lr_batch", "momentum_timescale", "carry_highbatch"]

--- a/tests/research/test_transfer.py
+++ b/tests/research/test_transfer.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import math
+from copy import deepcopy
 
 import pytest
 
+from tab_foundry.research.sweep.row_dependencies import resolve_dynamic_training_overrides
 from tab_foundry.research.sweep.transfer import (
     nearest_realizable_effective_batch,
     resolve_transfer_schedule,
@@ -44,29 +46,58 @@ def test_resolve_transfer_schedule_regime_b_scales_fixed_batch_formula_exactly()
     assert schedule["min_lr"] == pytest.approx(schedule["target_lr_max"] * 1.0e-3)
 
 
-def test_resolve_transfer_schedule_regime_d_rounds_batch_and_budget_deterministically() -> None:
+def test_resolve_transfer_schedule_regime_d_t1_from_shared_anchor_rounds_to_80() -> None:
     schedule = resolve_transfer_schedule(
         regime_label="D",
         base_lr_max=1.0e-3,
         base_momentum=0.95,
-        base_effective_batch=80,
+        base_effective_batch=64,
         base_effective_budget=625 * 64,
         target_effective_budget=2500 * 64,
         task_batch_size=16,
     )
 
-    expected_target_batch = 80.0 * (4.0 ** (1.0 / 6.0))
+    expected_target_batch = 64.0 * (4.0 ** (1.0 / 6.0))
     expected_target_alpha = (1.0 - 0.95) * (4.0 ** (-1.0 / 3.0))
     expected_target_lr = 1.0e-3 * (4.0 ** (-7.0 / 12.0))
 
     assert schedule["regime_label"] == "D"
     assert schedule["formula_label"] == "Theorem 3 joint-transfer proxy"
     assert schedule["target_effective_batch"] == pytest.approx(expected_target_batch)
+    assert schedule["realized_effective_batch"] == 80
+    assert schedule["grad_accum_steps"] == 5
+    assert schedule["max_steps"] == 2000
+    assert schedule["realized_effective_budget"] == 160000
+    assert schedule["budget_drift"] == pytest.approx(0.0)
+    assert schedule["batch_drift"] == pytest.approx(80.0 / expected_target_batch - 1.0)
+    assert schedule["target_alpha"] == pytest.approx(expected_target_alpha)
+    assert schedule["target_momentum"] == pytest.approx(1.0 - expected_target_alpha)
+    assert schedule["target_lr_max"] == pytest.approx(expected_target_lr)
+    assert math.isclose(schedule["min_lr"], expected_target_lr * 1.0e-3)
+
+
+def test_resolve_transfer_schedule_regime_d_t2_from_shared_anchor_rounds_to_96() -> None:
+    schedule = resolve_transfer_schedule(
+        regime_label="D",
+        base_lr_max=1.0e-3,
+        base_momentum=0.95,
+        base_effective_batch=64,
+        base_effective_budget=625 * 64,
+        target_effective_budget=5000 * 64,
+        task_batch_size=16,
+    )
+
+    expected_target_batch = 64.0 * (8.0 ** (1.0 / 6.0))
+    expected_target_alpha = (1.0 - 0.95) * (8.0 ** (-1.0 / 3.0))
+    expected_target_lr = 1.0e-3 * (8.0 ** (-7.0 / 12.0))
+
+    assert schedule["regime_label"] == "D"
+    assert schedule["target_effective_batch"] == pytest.approx(expected_target_batch)
     assert schedule["realized_effective_batch"] == 96
     assert schedule["grad_accum_steps"] == 6
-    assert schedule["max_steps"] == 1667
-    assert schedule["realized_effective_budget"] == 160032
-    assert schedule["budget_drift"] == pytest.approx(32.0 / 160000.0)
+    assert schedule["max_steps"] == 3333
+    assert schedule["realized_effective_budget"] == 319968
+    assert schedule["budget_drift"] == pytest.approx(-32.0 / 320000.0)
     assert schedule["batch_drift"] == pytest.approx(96.0 / expected_target_batch - 1.0)
     assert schedule["target_alpha"] == pytest.approx(expected_target_alpha)
     assert schedule["target_momentum"] == pytest.approx(1.0 - expected_target_alpha)
@@ -86,3 +117,130 @@ def test_resolve_transfer_schedule_rejects_excess_effective_budget_drift() -> No
             task_batch_size=16,
             fixed_effective_batch=64,
         )
+
+
+def test_resolve_dynamic_training_overrides_shared_anchor_transfer_resolves_from_anchor_row() -> None:
+    anchor_row = {
+        "order": 1,
+        "delta_ref": "delta_anchor",
+        "delta_id": "delta_anchor",
+        "run_id": "anchor_run",
+        "training": {
+            "task_batch_size": 16,
+            "overrides": {
+                "optimizer": {
+                    "name": "muon",
+                    "momentum": 0.95,
+                    "min_lr": 1.0e-6,
+                },
+                "runtime": {
+                    "grad_accum_steps": 4,
+                    "max_steps": 625,
+                },
+                "schedule": {
+                    "stages": [
+                        {
+                            "steps": 625,
+                            "lr_max": 1.0e-3,
+                        }
+                    ]
+                },
+            },
+        },
+        "reuse_train_artifact": {
+            "run_dir": "outputs/staged_ladder/research/lmo/anchor_run/train",
+        },
+        "imported_baseline_provenance": {
+            "source_sweep_id": "tf_rd_009_muon_ns_one_epoch_medium_v1",
+            "source_order": 9,
+        },
+        "transfer_context": {
+            "regime_label": "carry_lowbatch",
+            "target_budget_label": "T0",
+        },
+    }
+    target_row = {
+        "order": 2,
+        "delta_ref": "delta_target",
+        "delta_id": "delta_target",
+        "training": {
+            "task_batch_size": 16,
+            "overrides": {
+                "optimizer": {
+                    "name": "muon",
+                    "min_lr": 1.0e-6,
+                },
+                "runtime": {
+                    "grad_accum_steps": 4,
+                    "max_steps": 625,
+                },
+                "schedule": {
+                    "stages": [
+                        {
+                            "steps": 625,
+                            "lr_max": 1.0e-3,
+                        }
+                    ]
+                },
+            },
+        },
+        "transfer_context": {
+            "phase": "validation",
+            "regime_label": "D",
+            "formula_label": "Theorem 3 joint-transfer proxy",
+            "base_budget_label": "T0",
+            "target_budget_label": "T1",
+            "candidate_label": "shared_anchor_regime_d",
+        },
+        "dynamic_training_overrides": {
+            "transfer_schedule": {
+                "kind": "shared_anchor_transfer",
+                "anchor_order": 1,
+                "anchor_sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+                "anchor_label": "carry_lowbatch_shared_anchor_t0",
+                "regime_label": "D",
+                "base_effective_budget": 625 * 64,
+                "target_effective_budget": 2500 * 64,
+                "min_lr_ratio": 1.0e-3,
+                "max_budget_drift": 0.02,
+            }
+        },
+        "notes": [],
+    }
+    queue = {
+        "sweep_id": "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1",
+        "rows": [anchor_row, target_row],
+    }
+
+    queue_row = deepcopy(target_row)
+    materialized_row = deepcopy(target_row)
+
+    resolve_dynamic_training_overrides(
+        queue=queue,
+        queue_row=queue_row,
+        materialized_row=materialized_row,
+    )
+
+    for resolved_row in (queue_row, materialized_row):
+        assert resolved_row["training"]["overrides"]["runtime"]["grad_accum_steps"] == 5
+        assert resolved_row["training"]["overrides"]["runtime"]["max_steps"] == 2000
+        assert resolved_row["training"]["overrides"]["schedule"]["stages"][0]["steps"] == 2000
+        assert resolved_row["training"]["overrides"]["schedule"]["stages"][0]["lr_max"] == pytest.approx(
+            1.0e-3 * (4.0 ** (-7.0 / 12.0))
+        )
+        assert resolved_row["training"]["overrides"]["optimizer"]["min_lr"] == pytest.approx(
+            1.0e-6 * (4.0 ** (-7.0 / 12.0))
+        )
+        assert resolved_row["training"]["overrides"]["optimizer"]["momentum"] == pytest.approx(
+            1.0 - ((1.0 - 0.95) * (4.0 ** (-1.0 / 3.0)))
+        )
+        assert resolved_row["transfer_resolution"]["shared_anchor_provenance"]["anchor_order"] == 1
+        assert (
+            resolved_row["transfer_resolution"]["shared_anchor_provenance"]["anchor_sweep_id"]
+            == "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1"
+        )
+        assert (
+            resolved_row["transfer_resolution"]["shared_anchor_provenance"]["anchor_run_dir"]
+            == "outputs/staged_ladder/research/lmo/anchor_run/train"
+        )
+        assert resolved_row["transfer_resolution"]["resolution_reason"] == "shared_anchor"

--- a/tests/research/test_transfer.py
+++ b/tests/research/test_transfer.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tab_foundry.research.sweep.transfer import (
+    nearest_realizable_effective_batch,
+    resolve_transfer_schedule,
+    round_half_up,
+)
+
+
+def test_round_half_up_and_nearest_realizable_effective_batch() -> None:
+    assert round_half_up(625.5) == 626
+    assert round_half_up(625.49) == 625
+    assert nearest_realizable_effective_batch(target_effective_batch=100.79, task_batch_size=16) == 96
+    assert nearest_realizable_effective_batch(target_effective_batch=104.0, task_batch_size=16) == 112
+
+
+def test_resolve_transfer_schedule_regime_b_scales_fixed_batch_formula_exactly() -> None:
+    schedule = resolve_transfer_schedule(
+        regime_label="B",
+        base_lr_max=1.0e-3,
+        base_momentum=0.95,
+        base_effective_batch=64,
+        base_effective_budget=625 * 64,
+        target_effective_budget=2500 * 64,
+        task_batch_size=16,
+        fixed_effective_batch=64,
+    )
+
+    assert schedule["regime_label"] == "B"
+    assert schedule["formula_label"] == "Theorem 2 fixed-batch transfer"
+    assert schedule["realized_effective_batch"] == 64
+    assert schedule["grad_accum_steps"] == 4
+    assert schedule["max_steps"] == 2500
+    assert schedule["realized_effective_budget"] == 2500 * 64
+    assert schedule["budget_drift"] == pytest.approx(0.0)
+    assert schedule["batch_drift"] == pytest.approx(0.0)
+    assert schedule["target_alpha"] == pytest.approx(0.025)
+    assert schedule["target_momentum"] == pytest.approx(0.975)
+    assert schedule["target_lr_max"] == pytest.approx(1.0e-3 * (4.0 ** -0.75))
+    assert schedule["min_lr"] == pytest.approx(schedule["target_lr_max"] * 1.0e-3)
+
+
+def test_resolve_transfer_schedule_regime_d_rounds_batch_and_budget_deterministically() -> None:
+    schedule = resolve_transfer_schedule(
+        regime_label="D",
+        base_lr_max=1.0e-3,
+        base_momentum=0.95,
+        base_effective_batch=80,
+        base_effective_budget=625 * 64,
+        target_effective_budget=2500 * 64,
+        task_batch_size=16,
+    )
+
+    expected_target_batch = 80.0 * (4.0 ** (1.0 / 6.0))
+    expected_target_alpha = (1.0 - 0.95) * (4.0 ** (-1.0 / 3.0))
+    expected_target_lr = 1.0e-3 * (4.0 ** (-7.0 / 12.0))
+
+    assert schedule["regime_label"] == "D"
+    assert schedule["formula_label"] == "Theorem 3 joint-transfer proxy"
+    assert schedule["target_effective_batch"] == pytest.approx(expected_target_batch)
+    assert schedule["realized_effective_batch"] == 96
+    assert schedule["grad_accum_steps"] == 6
+    assert schedule["max_steps"] == 1667
+    assert schedule["realized_effective_budget"] == 160032
+    assert schedule["budget_drift"] == pytest.approx(32.0 / 160000.0)
+    assert schedule["batch_drift"] == pytest.approx(96.0 / expected_target_batch - 1.0)
+    assert schedule["target_alpha"] == pytest.approx(expected_target_alpha)
+    assert schedule["target_momentum"] == pytest.approx(1.0 - expected_target_alpha)
+    assert schedule["target_lr_max"] == pytest.approx(expected_target_lr)
+    assert math.isclose(schedule["min_lr"], expected_target_lr * 1.0e-3)
+
+
+def test_resolve_transfer_schedule_rejects_excess_effective_budget_drift() -> None:
+    with pytest.raises(RuntimeError, match="effective-budget drift"):
+        resolve_transfer_schedule(
+            regime_label="B",
+            base_lr_max=1.0e-3,
+            base_momentum=0.99,
+            base_effective_batch=64,
+            base_effective_budget=625 * 64,
+            target_effective_budget=50,
+            task_batch_size=16,
+            fixed_effective_batch=64,
+        )

--- a/tests/runtime/test_program_contract.py
+++ b/tests/runtime/test_program_contract.py
@@ -119,7 +119,7 @@ def test_workflows_runbook_reflects_system_delta_surface() -> None:
         "Treat [program.md](../program.md) as the policy owner.",
         "`reference/system_delta_catalog.yaml`",
         "`reference/system_delta_sweeps/index.yaml`",
-        "`cls_benchmark_linear_v2`",
+        "`cls_benchmark_linear_multiclass_medium_v1`",
         "`data/manifests/bench/openml_classification_medium_v1/manifest.parquet`",
         "`training_surface_record.json`",
         "`research_card.md`",

--- a/tests/support/openml_benchmark_compare_cases.py
+++ b/tests/support/openml_benchmark_compare_cases.py
@@ -2354,25 +2354,31 @@ def test_run_nanotabpfn_benchmark_propagates_record_derivation_failure(
         )
 
 
-def test_explicit_benchmark_manifest_paths_accept_checked_in_legacy_and_medium_binary_bundles() -> None:
+def test_explicit_benchmark_manifest_paths_accept_checked_in_legacy_and_medium_multiclass_bundles() -> None:
     legacy_bundle_path = (
         REPO_ROOT / "src" / "tab_foundry" / "bench" / "openml_benchmark_v1.json"
     )
     medium_bundle_path = (
-        REPO_ROOT / "src" / "tab_foundry" / "bench" / "openml_binary_medium_v1.json"
+        REPO_ROOT / "src" / "tab_foundry" / "bench" / "openml_classification_medium_v1.json"
     )
 
     legacy_bundle = benchmark_module.load_benchmark_bundle(legacy_bundle_path)
-    medium_bundle = benchmark_module.load_benchmark_bundle(medium_bundle_path)
+    medium_bundle = benchmark_module.load_benchmark_bundle(
+        medium_bundle_path,
+        allow_missing_values=True,
+    )
 
     assert legacy_bundle["name"] == "openml_binary_small"
     assert legacy_bundle["task_ids"] == [363613, 363621, 363629]
-    assert medium_bundle["name"] == "openml_binary_medium"
-    assert len(medium_bundle["task_ids"]) == 10
-    assert all(int(task["n_classes"]) == 2 for task in medium_bundle["tasks"])
+    assert medium_bundle["name"] == "openml_classification_medium"
+    assert len(medium_bundle["task_ids"]) == 242
+    assert medium_bundle["tasks"] == []
+    assert int(medium_bundle["selection"]["min_classes"]) == 2
+    assert int(medium_bundle["selection"]["max_classes"]) == 10
+    assert float(medium_bundle["selection"]["max_missing_pct"]) == 20.0
 
 
-def test_default_benchmark_manifest_path_resolves_to_medium_binary_bundle() -> None:
+def test_default_benchmark_manifest_path_resolves_to_medium_multiclass_bundle() -> None:
     bundle_path = compare_module.default_benchmark_manifest_path()
 
     assert bundle_path == (
@@ -2380,7 +2386,7 @@ def test_default_benchmark_manifest_path_resolves_to_medium_binary_bundle() -> N
         / "data"
         / "manifests"
         / "bench"
-        / "openml_binary_medium_v1"
+        / "openml_classification_medium_v1"
         / "manifest.parquet"
     )
 

--- a/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
+++ b/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
@@ -1,34 +1,29 @@
 from __future__ import annotations
 
-from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from omegaconf import OmegaConf
 
 from tab_foundry.research.scaling.fit import inspect_scaling_study
-from tab_foundry.research.sweep.materialize import load_system_delta_queue
-from tab_foundry.research.navigation import build_sweep_navigation_payload
-from tests.support_research.helpers import assert_training_surface_semantics
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INDEX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml"
-CATALOG_PATH = REPO_ROOT / "reference" / "system_delta_catalog.yaml"
 SWEEPS_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps"
 REGISTRY_PATH = REPO_ROOT / "src" / "tab_foundry" / "bench" / "benchmark_run_registry_v1.json"
 
-WIDTH_SCREEN = "tf_rd_009_muon_width_screen_medium_v1"
-WIDTH_DEPTH = "tf_rd_009_muon_width_depth_medium_v1"
+SELECTOR_SWEEP = "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"
+SCREEN_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"
+TRANSFER_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_medium_v1"
 NS_SWEEP = "tf_rd_009_muon_ns_one_epoch_medium_v1"
 BCRIT_SWEEP = "tf_rd_009_muon_batch_critical_one_epoch_medium_v1"
-SELECTOR_SWEEP = "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"
+WIDTH_DEPTH = "tf_rd_009_muon_width_depth_medium_v1"
 PHASE2_STUDY = "tf_rd_009_muon_phase2_one_epoch_v1"
 ANCHOR_RUN_ID = "sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1"
-MUON_EXPERIMENT = "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1"
-CORPUS_V6 = "tf_rd_010_dagzoo_medium_control_curated_v6"
 BENCHMARK_MANIFEST = "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
 CONTROL_BASELINE = "cls_benchmark_linear_multiclass_medium_v1"
+PAPER_URL = "https://arxiv.org/abs/2603.15958"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -37,158 +32,42 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return payload
 
 
-def test_tf_rd_009_muon_training_dynamics_selector_is_registered() -> None:
+def test_tf_rd_009_muon_endpoint_selector_is_preserved_as_superseded_context() -> None:
     index = _load_yaml(INDEX_PATH)
+    sweep = _load_yaml(SWEEPS_ROOT / SELECTOR_SWEEP / "sweep.yaml")
+    queue = _load_yaml(SWEEPS_ROOT / SELECTOR_SWEEP / "queue.yaml")
 
     assert index["sweeps"][SELECTOR_SWEEP] == {
         "parent_sweep_id": BCRIT_SWEEP,
-        "status": "draft",
+        "status": "superseded",
         "anchor_run_id": ANCHOR_RUN_ID,
         "complexity_level": "classification_md",
         "benchmark_manifest_path": BENCHMARK_MANIFEST,
         "control_baseline_id": CONTROL_BASELINE,
         "external_benchmarks": [],
     }
-
-
-def test_tf_rd_009_muon_training_dynamics_selector_tracks_the_exact_12_row_endpoint_matrix() -> None:
-    sweep_root = SWEEPS_ROOT / SELECTOR_SWEEP
-    sweep = _load_yaml(sweep_root / "sweep.yaml")
-    queue = _load_yaml(sweep_root / "queue.yaml")
-
-    assert sweep["sweep_id"] == SELECTOR_SWEEP
+    assert sweep["status"] == "superseded"
+    assert sweep["surface_role"] == "classification_training_dynamics_selector"
     assert sweep["parent_sweep_id"] == BCRIT_SWEEP
-    assert sweep["anchor_run_id"] == ANCHOR_RUN_ID
-    assert_training_surface_semantics(
-        sweep,
-        training_experiment=MUON_EXPERIMENT,
-        training_config_profile=MUON_EXPERIMENT,
-        surface_role="classification_training_dynamics_selector",
-        comparison_policy="anchor_only",
-        external_benchmarks=[],
-    )
-
-    rows = queue["rows"]
-    assert len(rows) == 12
-    assert {row["status"] for row in rows} == {"ready"}
-    assert {row["interpretation_status"] for row in rows} == {"pending"}
-    assert {row["benchmark_checkpoint_selection"] for row in rows} == {"best_and_final"}
-    assert {row["data"]["corpus_ref"] for row in rows} == {CORPUS_V6}
-    assert {row["training"]["task_batch_size"] for row in rows} == {16}
-    assert {row["training"]["overrides"]["runtime"]["max_steps"] for row in rows} == {5000}
-    assert Counter(f"{row['model']['d_icl']}x{row['model']['sandwich_layers']}" for row in rows) == {
-        "128x2": 4,
-        "144x4": 4,
-        "264x6": 4,
-    }
-    assert Counter(row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in rows) == {
-        4: 3,
-        16: 9,
-    }
-
-    expected_by_suffix = {
-        "carry_lowbatch_v1": {"grad_accum_steps": 4, "lr_max": 0.001, "min_lr": 1e-6, "betas": (0.9, 0.95)},
-        "carry_highbatch_v1": {"grad_accum_steps": 16, "lr_max": 0.001, "min_lr": 1e-6, "betas": (0.9, 0.95)},
-        "linear_lr_batch_v1": {"grad_accum_steps": 16, "lr_max": 0.004, "min_lr": 4e-6, "betas": (0.9, 0.95)},
-        "momentum_timescale_v1": {"grad_accum_steps": 16, "lr_max": 0.004, "min_lr": 4e-6, "betas": (0.975, 0.95)},
-    }
-    for row in rows:
-        delta_ref = str(row["delta_ref"])
-        suffix = next(key for key in expected_by_suffix if delta_ref.endswith(key))
-        expected = expected_by_suffix[suffix]
-        runtime = row["training"]["overrides"]["runtime"]
-        optimizer = row["training"]["overrides"]["optimizer"]
-        schedule = row["training"]["overrides"]["schedule"]["stages"][0]
-        assert runtime["grad_accum_steps"] == expected["grad_accum_steps"]
-        assert schedule["lr_max"] == expected["lr_max"]
-        assert optimizer["min_lr"] == expected["min_lr"]
-        assert tuple(optimizer["betas"]) == expected["betas"]
-        assert optimizer["name"] == "muon"
-        assert optimizer["weight_decay"] == 0.01
+    assert len(queue["rows"]) == 12
+    assert any("Superseded by the faithful paper-derived transfer screen" in note for note in sweep["anchor_surface"]["notes"])
 
 
-def test_tf_rd_009_muon_training_dynamics_selector_materializes_and_exposes_the_active_lineage() -> None:
-    materialized = load_system_delta_queue(
-        sweep_id=SELECTOR_SWEEP,
-        index_path=INDEX_PATH,
-        catalog_path=CATALOG_PATH,
-        sweeps_root=SWEEPS_ROOT,
-    )
-    assert_training_surface_semantics(
-        materialized,
-        training_experiment=MUON_EXPERIMENT,
-        training_config_profile=MUON_EXPERIMENT,
-        surface_role="classification_training_dynamics_selector",
-        comparison_policy="anchor_only",
-        external_benchmarks=[],
-    )
-    assert [row["delta_id"] for row in materialized["rows"]] == [
-        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_lowbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_carry_highbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_linear_lr_batch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl128_layers2_muon_momentum_timescale_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_lowbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_carry_highbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_linear_lr_batch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_momentum_timescale_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_lowbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_carry_highbatch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_linear_lr_batch_v1",
-        "delta_tf_rd_009_cls_sandwich_dicl264_layers6_muon_momentum_timescale_v1",
-    ]
-
-    navigation = build_sweep_navigation_payload(queue=materialized, index_path=INDEX_PATH)
-    assert [entry["sweep_id"] for entry in navigation["lineage"]][-5:] == [
-        WIDTH_SCREEN,
-        WIDTH_DEPTH,
-        NS_SWEEP,
-        BCRIT_SWEEP,
-        SELECTOR_SWEEP,
-    ]
-    assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
-    assert navigation["contract"]["uses_default_anchor_benchmark"] is True
-    assert navigation["contract"]["default_anchor_benchmark"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
-    assert (
-        navigation["contract"]["default_anchor_benchmark"]["benchmark_bundle"]["name"]
-        == "openml_classification_medium"
-    )
-    assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
-    assert navigation["contract"]["corpus_ref"] == CORPUS_V6
-    assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID
-    assert navigation["winner"] is None
-    assert navigation["contract_issues"] == []
-
-    resolved = _load_yaml(SWEEPS_ROOT / SELECTOR_SWEEP / "resolved_queue.yaml")
-    assert [row["delta_id"] for row in resolved["rows"]] == [row["delta_id"] for row in materialized["rows"]]
-    matrix = (SWEEPS_ROOT / SELECTOR_SWEEP / "matrix.md").read_text(encoding="utf-8")
-    assert "quality/time Pareto frontier" in matrix
-    assert "historical schedulefree TF-RD-009 remains preserved context only" in matrix
-
-
-def test_tf_rd_009_muon_phase2_inspection_exposes_the_canonical_active_contract_and_runtime_metrics() -> None:
+def test_tf_rd_009_muon_phase2_inspection_still_points_to_the_corrected_medium_contract() -> None:
     payload = inspect_scaling_study(
         study_id=PHASE2_STUDY,
         registry_path=REGISTRY_PATH,
         index_path=INDEX_PATH,
-        catalog_path=CATALOG_PATH,
+        catalog_path=REPO_ROOT / "reference" / "system_delta_catalog.yaml",
         sweeps_root=SWEEPS_ROOT,
     )
 
     navigation = payload["navigation"]
     assert [entry["sweep_id"] for entry in navigation["linked_sweeps"]] == [NS_SWEEP, BCRIT_SWEEP]
     assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
-    assert navigation["contract"]["uses_default_anchor_benchmark"] is True
-    assert navigation["contract"]["default_anchor_benchmark"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
     assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
-    assert navigation["contract"]["corpus_ref"] == CORPUS_V6
-    assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID
     assert navigation["contract"]["phase1_reference_sweep_id"] == WIDTH_DEPTH
-    assert navigation["contract"]["historical_context_studies"] == ["tf_rd_009_phase2", "tf_rd_009_phase2_one_epoch_v1"]
     assert navigation["winner"]["geometry_label"] == "264x6"
     assert navigation["winner"]["row_order"] == 20
-    assert navigation["winner"]["benchmark_log_loss"] == 0.46464118874262356
-    assert "throughput_tokens_per_second" in navigation["winner"]
-    assert "end_to_end_wall_seconds" in navigation["winner"]
-    assert navigation["completeness"]["all_expected_points_present"] is True
     assert navigation["fit_audit_state"]["full_scope_ready"] is True
     assert navigation["contract_issues"] == []

--- a/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
+++ b/tests/support_research/tf_rd_009_muon_training_dynamics_selector.py
@@ -146,6 +146,12 @@ def test_tf_rd_009_muon_training_dynamics_selector_materializes_and_exposes_the_
         SELECTOR_SWEEP,
     ]
     assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
+    assert navigation["contract"]["uses_default_anchor_benchmark"] is True
+    assert navigation["contract"]["default_anchor_benchmark"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
+    assert (
+        navigation["contract"]["default_anchor_benchmark"]["benchmark_bundle"]["name"]
+        == "openml_classification_medium"
+    )
     assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
     assert navigation["contract"]["corpus_ref"] == CORPUS_V6
     assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID
@@ -171,6 +177,8 @@ def test_tf_rd_009_muon_phase2_inspection_exposes_the_canonical_active_contract_
     navigation = payload["navigation"]
     assert [entry["sweep_id"] for entry in navigation["linked_sweeps"]] == [NS_SWEEP, BCRIT_SWEEP]
     assert navigation["contract"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
+    assert navigation["contract"]["uses_default_anchor_benchmark"] is True
+    assert navigation["contract"]["default_anchor_benchmark"]["benchmark_manifest_path"] == BENCHMARK_MANIFEST
     assert navigation["contract"]["control_baseline_id"] == CONTROL_BASELINE
     assert navigation["contract"]["corpus_ref"] == CORPUS_V6
     assert navigation["contract"]["carried_in_family_baseline_run_id"] == ANCHOR_RUN_ID

--- a/tests/support_research/tf_rd_009_muon_training_dynamics_transfer.py
+++ b/tests/support_research/tf_rd_009_muon_training_dynamics_transfer.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+
+from tab_foundry.research.sweep.materialize import load_system_delta_queue
+from tests.support_research.helpers import assert_training_surface_semantics
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml"
+CATALOG_PATH = REPO_ROOT / "reference" / "system_delta_catalog.yaml"
+SWEEPS_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps"
+
+SCREEN_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"
+TRANSFER_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_medium_v1"
+SELECTOR_SWEEP = "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"
+ANCHOR_RUN_ID = "sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1"
+BENCHMARK_MANIFEST = "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
+CONTROL_BASELINE = "cls_benchmark_linear_multiclass_medium_v1"
+MUON_EXPERIMENT = "cls_benchmark_sandwich_classification_evolution_tf_rd_009_muon_medium_v1"
+CORPUS_V6 = "tf_rd_010_dagzoo_medium_control_curated_v6"
+PAPER_URL = "https://arxiv.org/abs/2603.15958"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tf_rd_009_muon_transfer_screen_is_registered_and_rendered() -> None:
+    index = _load_yaml(INDEX_PATH)
+    sweep_root = SWEEPS_ROOT / SCREEN_SWEEP
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+    resolved = _load_yaml(sweep_root / "resolved_queue.yaml")
+    matrix = (sweep_root / "matrix.md").read_text(encoding="utf-8")
+
+    assert index["sweeps"][SCREEN_SWEEP] == {
+        "parent_sweep_id": "tf_rd_009_muon_batch_critical_one_epoch_medium_v1",
+        "status": "draft",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "classification_md",
+        "benchmark_manifest_path": BENCHMARK_MANIFEST,
+        "control_baseline_id": CONTROL_BASELINE,
+        "external_benchmarks": [],
+    }
+    assert sweep["upstream_reference"]["model_source"] == PAPER_URL
+    assert_training_surface_semantics(
+        sweep,
+        training_experiment=MUON_EXPERIMENT,
+        training_config_profile=MUON_EXPERIMENT,
+        surface_role="classification_training_dynamics_transfer_screen",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+
+    rows = queue["rows"]
+    assert len(rows) == 30
+    assert Counter(row["transfer_context"]["regime_label"] for row in rows) == {"B": 6, "D": 24}
+    assert {row["execution_policy"] for row in rows} == {"screen_only"}
+    assert {row["benchmark_checkpoint_selection"] for row in rows} == {"best_and_final"}
+    assert {row["model"]["d_icl"] for row in rows} == {144}
+    assert {row["model"]["sandwich_layers"] for row in rows} == {4}
+    assert {row["data"]["corpus_ref"] for row in rows} == {CORPUS_V6}
+
+    b_rows = [row for row in rows if row["transfer_context"]["regime_label"] == "B"]
+    assert {row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in b_rows} == {4}
+    assert {row["training"]["overrides"]["runtime"]["max_steps"] for row in b_rows} == {625}
+    d_rows = [row for row in rows if row["transfer_context"]["regime_label"] == "D"]
+    assert Counter(row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in d_rows) == {4: 6, 5: 6, 6: 6, 8: 6}
+    assert [row["delta_id"] for row in resolved["rows"][:6]] == [
+        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1"
+    ] * 6
+    assert "faithful paper-derived transfer screen" in matrix.lower()
+
+
+def test_tf_rd_009_muon_transfer_validation_tracks_the_logical_12_row_surface() -> None:
+    index = _load_yaml(INDEX_PATH)
+    sweep_root = SWEEPS_ROOT / TRANSFER_SWEEP
+    sweep = _load_yaml(sweep_root / "sweep.yaml")
+    queue = _load_yaml(sweep_root / "queue.yaml")
+    matrix = (sweep_root / "matrix.md").read_text(encoding="utf-8")
+
+    assert index["sweeps"][TRANSFER_SWEEP] == {
+        "parent_sweep_id": SCREEN_SWEEP,
+        "status": "draft",
+        "anchor_run_id": ANCHOR_RUN_ID,
+        "complexity_level": "classification_md",
+        "benchmark_manifest_path": BENCHMARK_MANIFEST,
+        "control_baseline_id": CONTROL_BASELINE,
+        "external_benchmarks": [],
+    }
+    assert_training_surface_semantics(
+        sweep,
+        training_experiment=MUON_EXPERIMENT,
+        training_config_profile=MUON_EXPERIMENT,
+        surface_role="classification_training_dynamics_transfer",
+        comparison_policy="anchor_only",
+        external_benchmarks=[],
+    )
+    assert any("superseded" in note.lower() for note in sweep["anchor_surface"]["notes"])
+
+    rows = queue["rows"]
+    assert len(rows) == 12
+    assert [row["transfer_context"]["target_budget_label"] for row in rows] == [
+        "T0",
+        "T1",
+        "T2",
+        "T0",
+        "T1",
+        "T2",
+        "T0",
+        "T1",
+        "T2",
+        "T0",
+        "T1",
+        "T2",
+    ]
+    lowbatch_rows = rows[:3]
+    assert {row["transfer_context"]["regime_label"] for row in lowbatch_rows} == {"carry_lowbatch"}
+    assert all(row["reuse_train_artifact"]["run_dir"].startswith("outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/") for row in lowbatch_rows)
+    assert all(row["imported_baseline_provenance"]["source_sweep_id"] == "tf_rd_009_muon_ns_one_epoch_medium_v1" for row in lowbatch_rows)
+
+    highbatch_rows = rows[3:6]
+    assert {row["transfer_context"]["regime_label"] for row in highbatch_rows} == {"carry_highbatch"}
+    assert Counter(row["training"]["overrides"]["runtime"]["max_steps"] for row in highbatch_rows) == {156: 1, 625: 1, 1250: 1}
+    assert {row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in highbatch_rows} == {16}
+
+    regime_b_rows = rows[6:9]
+    assert {row["transfer_context"]["regime_label"] for row in regime_b_rows} == {"B"}
+    assert all("dynamic_training_overrides" in row for row in regime_b_rows)
+    assert all(row["training"]["overrides"]["runtime"]["grad_accum_steps"] == 4 for row in regime_b_rows)
+    assert regime_b_rows[0]["dynamic_reuse_train_artifact"]["t0_winner"]["kind"] == "screen_winner_artifact"
+
+    regime_d_rows = rows[9:12]
+    assert {row["transfer_context"]["regime_label"] for row in regime_d_rows} == {"D"}
+    assert all("dynamic_training_overrides" in row for row in regime_d_rows)
+    assert regime_d_rows[0]["dynamic_reuse_train_artifact"]["t0_winner"]["kind"] == "screen_winner_artifact"
+
+    materialized = load_system_delta_queue(
+        sweep_id=TRANSFER_SWEEP,
+        index_path=INDEX_PATH,
+        catalog_path=CATALOG_PATH,
+        sweeps_root=SWEEPS_ROOT,
+    )
+    assert materialized["surface_role"] == "classification_training_dynamics_transfer"
+    assert len(materialized["rows"]) == 12
+    assert materialized["rows"][0]["imported_baseline_provenance"]["source_order"] == 9
+    assert materialized["rows"][6]["dynamic_training_overrides"]["transfer_schedule"]["regime_label"] == "B"
+    assert materialized["rows"][9]["dynamic_training_overrides"]["transfer_schedule"]["regime_label"] == "D"
+    assert "faithful transfer study" in matrix.lower()

--- a/tests/support_research/tf_rd_009_muon_training_dynamics_transfer.py
+++ b/tests/support_research/tf_rd_009_muon_training_dynamics_transfer.py
@@ -15,9 +15,10 @@ INDEX_PATH = REPO_ROOT / "reference" / "system_delta_sweeps" / "index.yaml"
 CATALOG_PATH = REPO_ROOT / "reference" / "system_delta_catalog.yaml"
 SWEEPS_ROOT = REPO_ROOT / "reference" / "system_delta_sweeps"
 
-SCREEN_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"
-TRANSFER_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_medium_v1"
 SELECTOR_SWEEP = "tf_rd_009_muon_training_dynamics_endpoint_medium_v1"
+OLD_SCREEN_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_screen_medium_v1"
+OLD_TRANSFER_SWEEP = "tf_rd_009_muon_training_dynamics_transfer_medium_v1"
+LMO_SWEEP = "tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1"
 ANCHOR_RUN_ID = "sd_tf_rd_009_muon_width_screen_medium_v1_04_delta_tf_rd_009_cls_sandwich_dicl128_v1_v1"
 BENCHMARK_MANIFEST = "data/manifests/bench/openml_classification_medium_v1/manifest.parquet"
 CONTROL_BASELINE = "cls_benchmark_linear_multiclass_medium_v1"
@@ -32,15 +33,30 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return payload
 
 
-def test_tf_rd_009_muon_transfer_screen_is_registered_and_rendered() -> None:
+def test_tf_rd_009_muon_screen_based_transfer_sweeps_are_preserved_as_superseded_context() -> None:
     index = _load_yaml(INDEX_PATH)
-    sweep_root = SWEEPS_ROOT / SCREEN_SWEEP
+    screen = _load_yaml(SWEEPS_ROOT / OLD_SCREEN_SWEEP / "sweep.yaml")
+    transfer = _load_yaml(SWEEPS_ROOT / OLD_TRANSFER_SWEEP / "sweep.yaml")
+    selector = _load_yaml(SWEEPS_ROOT / SELECTOR_SWEEP / "sweep.yaml")
+
+    assert index["sweeps"][OLD_SCREEN_SWEEP]["status"] == "superseded"
+    assert index["sweeps"][OLD_TRANSFER_SWEEP]["status"] == "superseded"
+    assert screen["status"] == "superseded"
+    assert transfer["status"] == "superseded"
+    assert any("superseded" in note.lower() for note in screen["anchor_surface"]["notes"])
+    assert any("superseded" in note.lower() for note in transfer["anchor_surface"]["notes"])
+    assert selector["status"] == "superseded"
+
+
+def test_tf_rd_009_muon_lmo_transfer_is_registered_and_rendered() -> None:
+    index = _load_yaml(INDEX_PATH)
+    sweep_root = SWEEPS_ROOT / LMO_SWEEP
     sweep = _load_yaml(sweep_root / "sweep.yaml")
     queue = _load_yaml(sweep_root / "queue.yaml")
     resolved = _load_yaml(sweep_root / "resolved_queue.yaml")
     matrix = (sweep_root / "matrix.md").read_text(encoding="utf-8")
 
-    assert index["sweeps"][SCREEN_SWEEP] == {
+    assert index["sweeps"][LMO_SWEEP] == {
         "parent_sweep_id": "tf_rd_009_muon_batch_critical_one_epoch_medium_v1",
         "status": "draft",
         "anchor_run_id": ANCHOR_RUN_ID,
@@ -54,59 +70,17 @@ def test_tf_rd_009_muon_transfer_screen_is_registered_and_rendered() -> None:
         sweep,
         training_experiment=MUON_EXPERIMENT,
         training_config_profile=MUON_EXPERIMENT,
-        surface_role="classification_training_dynamics_transfer_screen",
-        comparison_policy="anchor_only",
-        external_benchmarks=[],
-    )
-
-    rows = queue["rows"]
-    assert len(rows) == 30
-    assert Counter(row["transfer_context"]["regime_label"] for row in rows) == {"B": 6, "D": 24}
-    assert {row["execution_policy"] for row in rows} == {"screen_only"}
-    assert {row["benchmark_checkpoint_selection"] for row in rows} == {"best_and_final"}
-    assert {row["model"]["d_icl"] for row in rows} == {144}
-    assert {row["model"]["sandwich_layers"] for row in rows} == {4}
-    assert {row["data"]["corpus_ref"] for row in rows} == {CORPUS_V6}
-
-    b_rows = [row for row in rows if row["transfer_context"]["regime_label"] == "B"]
-    assert {row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in b_rows} == {4}
-    assert {row["training"]["overrides"]["runtime"]["max_steps"] for row in b_rows} == {625}
-    d_rows = [row for row in rows if row["transfer_context"]["regime_label"] == "D"]
-    assert Counter(row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in d_rows) == {4: 6, 5: 6, 6: 6, 8: 6}
-    assert [row["delta_id"] for row in resolved["rows"][:6]] == [
-        "delta_tf_rd_009_cls_sandwich_dicl144_layers4_muon_transfer_regime_b_v1"
-    ] * 6
-    assert "faithful paper-derived transfer screen" in matrix.lower()
-
-
-def test_tf_rd_009_muon_transfer_validation_tracks_the_logical_12_row_surface() -> None:
-    index = _load_yaml(INDEX_PATH)
-    sweep_root = SWEEPS_ROOT / TRANSFER_SWEEP
-    sweep = _load_yaml(sweep_root / "sweep.yaml")
-    queue = _load_yaml(sweep_root / "queue.yaml")
-    matrix = (sweep_root / "matrix.md").read_text(encoding="utf-8")
-
-    assert index["sweeps"][TRANSFER_SWEEP] == {
-        "parent_sweep_id": SCREEN_SWEEP,
-        "status": "draft",
-        "anchor_run_id": ANCHOR_RUN_ID,
-        "complexity_level": "classification_md",
-        "benchmark_manifest_path": BENCHMARK_MANIFEST,
-        "control_baseline_id": CONTROL_BASELINE,
-        "external_benchmarks": [],
-    }
-    assert_training_surface_semantics(
-        sweep,
-        training_experiment=MUON_EXPERIMENT,
-        training_config_profile=MUON_EXPERIMENT,
         surface_role="classification_training_dynamics_transfer",
         comparison_policy="anchor_only",
         external_benchmarks=[],
     )
-    assert any("superseded" in note.lower() for note in sweep["anchor_surface"]["notes"])
+    assert any(
+        "strict shared-anchor lmo transfer" in note.lower()
+        for note in sweep["anchor_surface"]["notes"]
+    )
 
     rows = queue["rows"]
-    assert len(rows) == 12
+    assert len(rows) == 10
     assert [row["transfer_context"]["target_budget_label"] for row in rows] == [
         "T0",
         "T1",
@@ -114,43 +88,90 @@ def test_tf_rd_009_muon_transfer_validation_tracks_the_logical_12_row_surface() 
         "T0",
         "T1",
         "T2",
-        "T0",
         "T1",
         "T2",
-        "T0",
         "T1",
         "T2",
     ]
+    assert {row["model"]["d_icl"] for row in rows} == {144}
+    assert {row["model"]["sandwich_layers"] for row in rows} == {4}
+    assert {row["data"]["corpus_ref"] for row in rows} == {CORPUS_V6}
+
     lowbatch_rows = rows[:3]
     assert {row["transfer_context"]["regime_label"] for row in lowbatch_rows} == {"carry_lowbatch"}
-    assert all(row["reuse_train_artifact"]["run_dir"].startswith("outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/") for row in lowbatch_rows)
-    assert all(row["imported_baseline_provenance"]["source_sweep_id"] == "tf_rd_009_muon_ns_one_epoch_medium_v1" for row in lowbatch_rows)
+    assert [row["imported_baseline_provenance"]["source_order"] for row in lowbatch_rows] == [9, 11, 12]
+    assert all(
+        row["reuse_train_artifact"]["run_dir"].startswith(
+            "outputs/staged_ladder/research/tf_rd_009_muon_ns_one_epoch_medium_v1/"
+        )
+        for row in lowbatch_rows
+    )
+    assert all(
+        row["imported_baseline_provenance"]["source_sweep_id"] == "tf_rd_009_muon_ns_one_epoch_medium_v1"
+        for row in lowbatch_rows
+    )
 
     highbatch_rows = rows[3:6]
     assert {row["transfer_context"]["regime_label"] for row in highbatch_rows} == {"carry_highbatch"}
-    assert Counter(row["training"]["overrides"]["runtime"]["max_steps"] for row in highbatch_rows) == {156: 1, 625: 1, 1250: 1}
+    assert Counter(
+        row["training"]["overrides"]["runtime"]["max_steps"] for row in highbatch_rows
+    ) == {156: 1, 625: 1, 1250: 1}
     assert {row["training"]["overrides"]["runtime"]["grad_accum_steps"] for row in highbatch_rows} == {16}
 
-    regime_b_rows = rows[6:9]
+    regime_b_rows = rows[6:8]
     assert {row["transfer_context"]["regime_label"] for row in regime_b_rows} == {"B"}
-    assert all("dynamic_training_overrides" in row for row in regime_b_rows)
-    assert all(row["training"]["overrides"]["runtime"]["grad_accum_steps"] == 4 for row in regime_b_rows)
-    assert regime_b_rows[0]["dynamic_reuse_train_artifact"]["t0_winner"]["kind"] == "screen_winner_artifact"
+    assert [row["transfer_context"]["target_budget_label"] for row in regime_b_rows] == ["T1", "T2"]
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["kind"] == "shared_anchor_transfer"
+        for row in regime_b_rows
+    )
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["anchor_order"] == 1
+        for row in regime_b_rows
+    )
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["anchor_sweep_id"] == LMO_SWEEP
+        for row in regime_b_rows
+    )
+    assert all(row["dynamic_reuse_train_artifact"] is None for row in regime_b_rows)
 
-    regime_d_rows = rows[9:12]
+    regime_d_rows = rows[8:10]
     assert {row["transfer_context"]["regime_label"] for row in regime_d_rows} == {"D"}
-    assert all("dynamic_training_overrides" in row for row in regime_d_rows)
-    assert regime_d_rows[0]["dynamic_reuse_train_artifact"]["t0_winner"]["kind"] == "screen_winner_artifact"
+    assert [row["transfer_context"]["target_budget_label"] for row in regime_d_rows] == ["T1", "T2"]
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["kind"] == "shared_anchor_transfer"
+        for row in regime_d_rows
+    )
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["anchor_order"] == 1
+        for row in regime_d_rows
+    )
+    assert all(
+        row["dynamic_training_overrides"]["transfer_schedule"]["fixed_effective_batch"] is None
+        for row in regime_d_rows
+    )
+    assert all(row["dynamic_reuse_train_artifact"] is None for row in regime_d_rows)
 
     materialized = load_system_delta_queue(
-        sweep_id=TRANSFER_SWEEP,
+        sweep_id=LMO_SWEEP,
         index_path=INDEX_PATH,
         catalog_path=CATALOG_PATH,
         sweeps_root=SWEEPS_ROOT,
     )
     assert materialized["surface_role"] == "classification_training_dynamics_transfer"
-    assert len(materialized["rows"]) == 12
+    assert len(materialized["rows"]) == 10
     assert materialized["rows"][0]["imported_baseline_provenance"]["source_order"] == 9
-    assert materialized["rows"][6]["dynamic_training_overrides"]["transfer_schedule"]["regime_label"] == "B"
-    assert materialized["rows"][9]["dynamic_training_overrides"]["transfer_schedule"]["regime_label"] == "D"
-    assert "faithful transfer study" in matrix.lower()
+    assert materialized["rows"][6]["training"]["overrides"]["runtime"]["grad_accum_steps"] == 4
+    assert materialized["rows"][6]["training"]["overrides"]["runtime"]["max_steps"] == 2500
+    assert materialized["rows"][7]["training"]["overrides"]["runtime"]["grad_accum_steps"] == 4
+    assert materialized["rows"][7]["training"]["overrides"]["runtime"]["max_steps"] == 5000
+    assert materialized["rows"][8]["training"]["overrides"]["runtime"]["grad_accum_steps"] == 5
+    assert materialized["rows"][8]["training"]["overrides"]["runtime"]["max_steps"] == 2000
+    assert materialized["rows"][9]["training"]["overrides"]["runtime"]["grad_accum_steps"] == 6
+    assert materialized["rows"][9]["training"]["overrides"]["runtime"]["max_steps"] == 3333
+    assert materialized["rows"][6]["transfer_resolution"]["shared_anchor_provenance"]["anchor_order"] == 1
+    assert materialized["rows"][8]["transfer_resolution"]["shared_anchor_provenance"]["anchor_order"] == 1
+
+    assert [row["order"] for row in resolved["rows"]] == list(range(1, 11))
+    assert "strict shared-anchor lmo transfer" in matrix.lower()
+    assert "screen_winner_transfer" not in matrix

--- a/tests/training/test_optimizer.py
+++ b/tests/training/test_optimizer.py
@@ -403,6 +403,46 @@ def test_muon_forwards_real_momentum_kwarg_to_muon_constructor(
     assert captured["weight_decay"] == pytest.approx(0.01)
 
 
+def test_muon_momentum_does_not_leak_into_adamw_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeMuon:
+        def __init__(self, params, lr: float, weight_decay: float, momentum: float) -> None:
+            captured["params"] = list(params)
+            captured["lr"] = lr
+            captured["weight_decay"] = weight_decay
+            captured["momentum"] = momentum
+            self.param_groups = [{"params": list(params), "lr": lr, "momentum": momentum}]
+
+        def step(self) -> None:
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "muon",
+        SimpleNamespace(Muon=_FakeMuon, SingleDeviceMuon=_FakeMuon),
+    )
+
+    model = nn.Linear(8, 4, bias=True)
+    selection = build_optimizer(
+        model,
+        name="muon",
+        lr=1e-3,
+        weight_decay=0.01,
+        extra_kwargs={"betas": (0.9, 0.95), "momentum": 0.975},
+        require_requested=True,
+        muon_per_parameter_lr=False,
+        muon_partition_non2d=True,
+    )
+
+    assert selection.resolved_name == "muon+adamw"
+    assert [name for name, _optimizer in selection.optimizers] == ["muon", "adamw"]
+    assert captured["momentum"] == pytest.approx(0.975)
+    assert isinstance(selection.optimizers[1][1], torch.optim.AdamW)
+
+
 def test_partition_muon_params_excludes_embeddings_and_non_2d() -> None:
     class _Toy(nn.Module):
         def __init__(self) -> None:

--- a/tests/training/test_optimizer.py
+++ b/tests/training/test_optimizer.py
@@ -30,6 +30,18 @@ def test_optimizer_unknown_name_raises() -> None:
         )
 
 
+def test_non_muon_optimizer_rejects_momentum_extra_kwarg() -> None:
+    model = nn.Linear(4, 2)
+    with pytest.raises(ValueError, match="optimizer\\.momentum is only supported"):
+        _ = build_optimizer(
+            model,
+            name="adamw",
+            lr=1e-3,
+            weight_decay=0.0,
+            extra_kwargs={"betas": (0.9, 0.95), "momentum": 0.95},
+        )
+
+
 def test_muon_missing_dependency_falls_back_when_not_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -349,6 +361,46 @@ def test_muon_step_is_noop_when_all_muon_params_are_inactive(
     assert selection.resolved_name == "muon+adamw"
     assert muon_opt.seen_param_ids_per_step == []
     assert model.unused.weight not in muon_opt.state
+
+
+def test_muon_forwards_real_momentum_kwarg_to_muon_constructor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeMuon:
+        def __init__(self, params, lr: float, weight_decay: float, momentum: float) -> None:
+            captured["params"] = list(params)
+            captured["lr"] = lr
+            captured["weight_decay"] = weight_decay
+            captured["momentum"] = momentum
+            self.param_groups = [{"params": list(params), "lr": lr, "momentum": momentum}]
+
+        def step(self) -> None:
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "muon",
+        SimpleNamespace(Muon=_FakeMuon, SingleDeviceMuon=_FakeMuon),
+    )
+
+    model = nn.Linear(8, 4, bias=False)
+    selection = build_optimizer(
+        model,
+        name="muon",
+        lr=1e-3,
+        weight_decay=0.01,
+        extra_kwargs={"betas": (0.9, 0.95), "momentum": 0.975},
+        require_requested=True,
+        muon_per_parameter_lr=False,
+        muon_partition_non2d=False,
+    )
+
+    assert selection.resolved_name == "muon"
+    assert captured["momentum"] == pytest.approx(0.975)
+    assert captured["lr"] == pytest.approx(1e-3)
+    assert captured["weight_decay"] == pytest.approx(0.01)
 
 
 def test_partition_muon_params_excludes_embeddings_and_non_2d() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1735,7 +1735,7 @@ wheels = [
 
 [[package]]
 name = "tab-foundry"
-version = "0.17.2"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What changed
- synced the completed `tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1` sweep artifacts back into the repo
- updated the TF-RD-009 roadmap/evidence/workflow docs and sweep index to reflect the executed strict shared-anchor LMO result
- closed out the tracked negative verdict for the LMO transfer study and accepted the shipped `#283` navigation / contract-guard surfaces
- fixed two follow-up navigation bugs found during review:
  - scaling-study linked sweeps now report their real index status instead of `unknown`
  - sweep winner summaries now include imported baseline evidence rows when they carry benchmark metrics

## Why it changed
- the branch had completed the remote LMO study, but the tracked sweep package and planning docs still reflected pre-execution state
- the follow-up review surfaced a real inconsistency in the new navigation surface: `research sweep inspect` could report the wrong winner for sweeps with imported baselines, and `research scaling inspect` hid linked sweep status behind `unknown`

## Impact
- TF-RD-009 now records the executed result consistently in tracked artifacts and docs
- the strict shared-anchor LMO study resolves to: Regime `B` beats `D`, but neither law-derived regime beats carried high-batch at `T2`
- the `#283` inspection/guard surface is now consistent in both sweep- and scaling-level navigation output

## Root cause
- imported baseline rows in the LMO sweep remain `ready` in queue state by design, but the navigation winner helper only considered `status=completed`, so imported evidence was excluded from winner selection
- scaling navigation was reading sweep status from queue payloads, which do not carry a canonical sweep-level `status`; the real source of truth is the sweep index

## Validation
- `.venv/bin/tab-foundry research sweep list-sweeps`
- `.venv/bin/tab-foundry research sweep inspect --sweep-id tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 --order 8`
- `.venv/bin/tab-foundry research scaling inspect --study tf_rd_009_muon_phase2_one_epoch_v1 --json`
- `.venv/bin/tab-foundry research sweep summarize --sweep-id tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 --json`
- `.venv/bin/pytest -q tests/research/test_navigation.py tests/benchmark/test_control_baseline.py tests/research/test_scaling_fit.py`
- `.venv/bin/pytest -q tests/research/test_navigation.py`
- `./scripts/dev verify paths reference/system_delta_sweeps/index.yaml reference/system_delta_sweeps/tf_rd_009_muon_training_dynamics_lmo_transfer_medium_v1 docs/development/roadmap.md reference/roadmap_evidence/tf_rd_009_scaling_law_measurement.md docs/workflows.md`
- `./scripts/dev verify paths src/tab_foundry/research/navigation.py tests/research/test_navigation.py`
